### PR TITLE
test: DB, adapter mock, and route tests

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+asyncio_mode = auto

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,40 @@
+from contextlib import asynccontextmanager
+from pathlib import Path
+
+import pytest
+import t01_llm_battle.db as db_module
+import t01_llm_battle.routers.runs as runs_module
+import t01_llm_battle.routers.sources as sources_module
+from httpx import AsyncClient, ASGITransport
+from t01_llm_battle.db import init_db, get_db
+from t01_llm_battle.server import create_app
+
+
+@pytest.fixture
+async def db_path(tmp_path):
+    path = str(tmp_path / "test.db")
+    await init_db(path)
+    return path
+
+
+@pytest.fixture
+async def client(db_path, monkeypatch):
+    """HTTP test client wired to an isolated SQLite database.
+
+    Replaces the get_db context manager in all router modules with a
+    version that always connects to the test database.
+    """
+    _db_path = db_path
+
+    @asynccontextmanager
+    async def _get_db_override(path=None):
+        async with get_db(_db_path) as db:
+            yield db
+
+    monkeypatch.setattr(db_module, "DB_PATH", Path(_db_path))
+    monkeypatch.setattr(runs_module, "get_db", _get_db_override)
+    monkeypatch.setattr(sources_module, "get_db", _get_db_override)
+
+    app = create_app(db_path=db_path)
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        yield c

--- a/tests/test_battles_router.py
+++ b/tests/test_battles_router.py
@@ -1,0 +1,85 @@
+"""Tests for battle-related DB operations and health check endpoint.
+
+Note: There is no dedicated /battles REST router in the current server;
+battles are created directly in the DB. These tests verify DB-level CRUD
+and the /healthz endpoint that confirms the server is up.
+"""
+import uuid
+from datetime import datetime, timezone
+
+import pytest
+from t01_llm_battle.db import get_db
+
+
+@pytest.mark.asyncio
+async def test_healthz(client):
+    resp = await client.get("/healthz")
+    assert resp.status_code == 200
+    assert resp.json() == {"status": "ok"}
+
+
+@pytest.mark.asyncio
+async def test_create_battle_in_db(db_path):
+    """Insert a battle row directly and verify it is retrievable."""
+    battle_id = str(uuid.uuid4())
+    now = datetime.now(timezone.utc).isoformat()
+    async with get_db(db_path) as db:
+        await db.execute(
+            "INSERT INTO battle (id, name, judge_provider, judge_model, judge_rubric, created_at) "
+            "VALUES (?, ?, ?, ?, ?, ?)",
+            (battle_id, "Test Battle", "openai", "gpt-4o", "", now),
+        )
+        await db.commit()
+
+    async with get_db(db_path) as db:
+        cursor = await db.execute("SELECT id, name FROM battle WHERE id = ?", (battle_id,))
+        row = await cursor.fetchone()
+
+    assert row is not None
+    assert row["id"] == battle_id
+    assert row["name"] == "Test Battle"
+
+
+@pytest.mark.asyncio
+async def test_list_battles_in_db(db_path):
+    """Insert two battles and verify both are returned."""
+    now = datetime.now(timezone.utc).isoformat()
+    async with get_db(db_path) as db:
+        for name in ("Alpha", "Beta"):
+            await db.execute(
+                "INSERT INTO battle (id, name, judge_provider, judge_model, judge_rubric, created_at) "
+                "VALUES (?, ?, ?, ?, ?, ?)",
+                (str(uuid.uuid4()), name, "openai", "gpt-4o", "", now),
+            )
+        await db.commit()
+
+    async with get_db(db_path) as db:
+        cursor = await db.execute("SELECT name FROM battle ORDER BY name")
+        names = [row[0] for row in await cursor.fetchall()]
+
+    assert "Alpha" in names
+    assert "Beta" in names
+
+
+@pytest.mark.asyncio
+async def test_delete_battle_in_db(db_path):
+    """Delete a battle row and verify it is gone."""
+    battle_id = str(uuid.uuid4())
+    now = datetime.now(timezone.utc).isoformat()
+    async with get_db(db_path) as db:
+        await db.execute(
+            "INSERT INTO battle (id, name, judge_provider, judge_model, judge_rubric, created_at) "
+            "VALUES (?, ?, ?, ?, ?, ?)",
+            (battle_id, "To Delete", "openai", "gpt-4o", "", now),
+        )
+        await db.commit()
+
+    async with get_db(db_path) as db:
+        await db.execute("DELETE FROM battle WHERE id = ?", (battle_id,))
+        await db.commit()
+
+    async with get_db(db_path) as db:
+        cursor = await db.execute("SELECT id FROM battle WHERE id = ?", (battle_id,))
+        row = await cursor.fetchone()
+
+    assert row is None

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -1,0 +1,14 @@
+import pytest
+from t01_llm_battle.db import init_db, get_db
+
+
+@pytest.mark.asyncio
+async def test_init_db_creates_tables(tmp_path):
+    db_path = str(tmp_path / "test.db")
+    await init_db(db_path)
+    async with get_db(db_path) as db:
+        cursor = await db.execute("SELECT name FROM sqlite_master WHERE type='table'")
+        tables = {row[0] for row in await cursor.fetchall()}
+    assert "battle" in tables
+    assert "fighter" in tables
+    assert "run" in tables

--- a/tests/test_openai_adapter.py
+++ b/tests/test_openai_adapter.py
@@ -1,0 +1,28 @@
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+from t01_llm_battle.providers.openai import OpenAIProvider
+from t01_llm_battle.providers.base import CompletionRequest
+
+
+@pytest.mark.asyncio
+async def test_complete_returns_result():
+    mock_response = {
+        "choices": [{"message": {"content": "Hello!"}}],
+        "usage": {"prompt_tokens": 10, "completion_tokens": 5},
+        "model": "gpt-4o",
+    }
+    provider = OpenAIProvider()
+    request = CompletionRequest(model="gpt-4o", system_prompt="", user_prompt="Hi")
+
+    mock_resp = MagicMock()
+    mock_resp.status_code = 200
+    mock_resp.json.return_value = mock_response
+
+    with patch("httpx.AsyncClient.post", new_callable=AsyncMock) as mock_post:
+        mock_post.return_value = mock_resp
+        result = await provider.complete(request)
+
+    assert result.content == "Hello!"
+    assert result.input_tokens == 10
+    assert result.output_tokens == 5
+    assert result.provider == "openai"

--- a/tests/test_runs_router.py
+++ b/tests/test_runs_router.py
@@ -1,0 +1,68 @@
+"""Tests for the /runs router."""
+import uuid
+from datetime import datetime, timezone
+from unittest.mock import patch
+
+import pytest
+from t01_llm_battle.db import get_db
+
+
+@pytest.mark.asyncio
+async def test_get_run_status_not_found(client):
+    """GET /runs/<nonexistent>/status should return 404."""
+    resp = await client.get(f"/runs/{uuid.uuid4()}/status")
+    assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_get_run_status_returns_data(client, db_path):
+    """Insert a battle + run directly, then poll status via the API."""
+    battle_id = str(uuid.uuid4())
+    run_id = str(uuid.uuid4())
+    now = datetime.now(timezone.utc).isoformat()
+
+    async with get_db(db_path) as db:
+        await db.execute(
+            "INSERT INTO battle (id, name, judge_provider, judge_model, judge_rubric, created_at) "
+            "VALUES (?, ?, ?, ?, ?, ?)",
+            (battle_id, "Status Battle", "openai", "gpt-4o", "", now),
+        )
+        await db.execute(
+            "INSERT INTO run (id, battle_id, status, started_at) VALUES (?, ?, ?, ?)",
+            (run_id, battle_id, "pending", now),
+        )
+        await db.commit()
+
+    resp = await client.get(f"/runs/{run_id}/status")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["run_id"] == run_id
+    assert data["status"] == "pending"
+    assert isinstance(data["fighter_results"], list)
+
+
+@pytest.mark.asyncio
+async def test_create_run_battle_not_found(client):
+    """POST /runs with a nonexistent battle_id should return 404."""
+    with patch("t01_llm_battle.engine.start_run_background"):
+        resp = await client.post("/runs", json={"battle_id": str(uuid.uuid4())})
+    assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_create_run_no_fighters(client, db_path):
+    """POST /runs for a battle with no fighters should return 422."""
+    battle_id = str(uuid.uuid4())
+    now = datetime.now(timezone.utc).isoformat()
+
+    async with get_db(db_path) as db:
+        await db.execute(
+            "INSERT INTO battle (id, name, judge_provider, judge_model, judge_rubric, created_at) "
+            "VALUES (?, ?, ?, ?, ?, ?)",
+            (battle_id, "Empty Battle", "openai", "gpt-4o", "", now),
+        )
+        await db.commit()
+
+    with patch("t01_llm_battle.engine.start_run_background"):
+        resp = await client.post("/runs", json={"battle_id": battle_id})
+    assert resp.status_code == 422


### PR DESCRIPTION
## Summary
- Adds `pytest.ini` with `asyncio_mode = auto` to support async tests
- Implements `tests/conftest.py` with `db_path` and `client` async fixtures backed by an isolated per-test SQLite database
- Adds four test modules covering DB init, OpenAI adapter (mocked httpx), battle DB CRUD, and runs router — 10 tests, all green

## Test plan
- [ ] `pip install -e ".[dev]"` then `python -m pytest tests/ -v` — all 10 pass

Closes #33

🤖 Generated with [Claude Code](https://claude.com/claude-code)