### PR TITLE
feat: source upload UI

### DIFF
--- a/t01_llm_battle/static/index.html
+++ b/t01_llm_battle/static/index.html
@@ -192,9 +192,69 @@
     </section>
 
     <!-- View: battle detail -->
-    <section x-show="route === 'battles/detail'">
-      <h1>Battle Detail <span class="badge" x-text="params.id ? params.id.slice(0,8) + '...' : ''"></span></h1>
-      <div class="placeholder">Sources, fighters, run button — implemented in #28</div>
+    <section x-show="route === 'battles/detail'"
+             x-data="battleDetail()"
+             x-init="$watch('$root.params.id', id => { if (id) load(id); }); if ($root.params.id) load($root.params.id);">
+
+      <div style="display:flex;align-items:center;gap:1rem;margin-bottom:1.5rem;">
+        <h1 style="margin:0;">
+          Battle Detail
+          <span class="badge" x-text="params.id ? params.id.slice(0,8) + '...' : ''"></span>
+        </h1>
+        <a href="#/battles" style="color:#888;font-size:0.9rem;text-decoration:none;">← Back to Battles</a>
+      </div>
+
+      <!-- Sources section -->
+      <div style="background:#fff;border:1px solid #e0e0e0;border-radius:8px;padding:1.5rem;margin-bottom:1.5rem;">
+        <h2 style="margin:0 0 1rem;display:flex;align-items:center;gap:0.5rem;">
+          Sources
+          <span class="badge" x-text="sources.length"></span>
+        </h2>
+
+        <!-- Upload area -->
+        <div style="margin-bottom:1.25rem;">
+          <label style="display:block;font-weight:600;font-size:0.9rem;margin-bottom:6px;">Upload files</label>
+          <p style="font-size:0.82rem;color:#666;margin:0 0 8px;">
+            Accepts <code>.txt</code>, <code>.md</code> (one source per file) and <code>.csv</code> (one source per row).
+            Multiple files supported for text/markdown.
+          </p>
+          <input type="file" accept=".txt,.md,.csv" multiple
+                 :disabled="uploading"
+                 @change="upload($event, $root.params.id)"
+                 style="display:block;font-size:0.9rem;">
+          <template x-if="uploading">
+            <p style="color:#7c6af7;font-size:0.9rem;margin:6px 0 0;">Uploading...</p>
+          </template>
+        </div>
+
+        <!-- Error message -->
+        <template x-if="error">
+          <p style="color:#c0392b;background:#fdf0f0;border:1px solid #f5c6c6;border-radius:6px;padding:10px 14px;margin:0 0 1rem;font-size:0.9rem;" x-text="error"></p>
+        </template>
+
+        <!-- Source list -->
+        <template x-if="sources.length === 0">
+          <p style="color:#888;font-size:0.9rem;margin:0;">No sources yet. Upload files above to add source items.</p>
+        </template>
+
+        <template x-if="sources.length > 0">
+          <ul style="list-style:none;padding:0;margin:0;display:flex;flex-direction:column;gap:0.5rem;">
+            <template x-for="s in sources" :key="s.id">
+              <li style="display:flex;align-items:center;justify-content:space-between;background:#f8f8fc;border:1px solid #e8e8f0;border-radius:6px;padding:8px 12px;">
+                <span style="font-size:0.9rem;color:#1a1a2e;" x-text="s.label"></span>
+                <button @click="remove($root.params.id, s.id)"
+                        style="background:none;border:1px solid #e0e0e0;border-radius:4px;padding:3px 10px;font-size:0.8rem;color:#c0392b;cursor:pointer;transition:background 0.15s;"
+                        onmouseover="this.style.background='#fdf0f0'" onmouseout="this.style.background='none'">
+                  Delete
+                </button>
+              </li>
+            </template>
+          </ul>
+        </template>
+      </div>
+
+      <!-- Remaining sections placeholder -->
+      <div class="placeholder">Fighters &amp; run button — implemented in #28</div>
     </section>
 
     <!-- View: live run -->
@@ -405,6 +465,74 @@
             await this.load();
           } catch(e) {
             this.saveErrors[provider] = e.message;
+          }
+        }
+      };
+    }
+
+    function battleDetail() {
+      return {
+        sources: [],
+        uploading: false,
+        error: null,
+
+        async load(battleId) {
+          if (!battleId) return;
+          this.error = null;
+          try {
+            const resp = await fetch(`/battles/${battleId}/sources`);
+            if (!resp.ok) throw new Error(await resp.text());
+            const data = await resp.json();
+            this.sources = data.sources || [];
+          } catch(e) {
+            this.error = e.message;
+          }
+        },
+
+        async upload(event, battleId) {
+          if (!battleId) return;
+          const files = Array.from(event.target.files || []);
+          if (!files.length) return;
+
+          this.uploading = true;
+          this.error = null;
+
+          for (const file of files) {
+            try {
+              const formData = new FormData();
+              formData.append('file', file);
+              const resp = await fetch(`/battles/${battleId}/sources`, {
+                method: 'POST',
+                body: formData,
+              });
+              if (!resp.ok) {
+                const msg = await resp.text();
+                throw new Error(`${file.name}: ${msg}`);
+              }
+              const data = await resp.json();
+              // server may return single or multiple sources (CSV)
+              const newItems = data.sources || (data.id ? [data] : []);
+              this.sources.push(...newItems);
+            } catch(e) {
+              this.error = e.message;
+            }
+          }
+
+          // reset file input
+          event.target.value = '';
+          this.uploading = false;
+        },
+
+        async remove(battleId, sourceId) {
+          this.error = null;
+          try {
+            const resp = await fetch(`/battles/${battleId}/sources/${sourceId}`, {
+              method: 'DELETE',
+            });
+            if (!resp.ok) throw new Error(await resp.text());
+            this.sources = this.sources.filter(s => s.id !== sourceId);
+          } catch(e) {
+            this.error = e.message;
           }
         }
       };


### PR DESCRIPTION
## Summary
- Replaces the battle detail placeholder with a real `battleDetail()` Alpine.js component
- Adds `sourceList` upload section: file input (.txt/.md/.csv, multiple select), upload progress, source list with delete buttons, and live source count badge
- Error messages shown on upload/delete failure

## Test plan
- [ ] Navigate to a battle detail view (`#/battles/<id>`)
- [ ] Upload a `.txt` or `.md` file — appears in list immediately
- [ ] Upload a `.csv` file — each data row appears as a separate source item
- [ ] Upload multiple `.txt`/`.md` files at once — all appear
- [ ] Click Delete on a source — removed from list, badge count updates
- [ ] Simulate a server error — error message is displayed
- [ ] All pytest tests pass: `python -m pytest tests/ -x -q`

Closes #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)