### PR TITLE
feat: markdown report generation via judge model

### DIFF
--- a/t01_llm_battle/db.py
+++ b/t01_llm_battle/db.py
@@ -47,11 +47,12 @@ CREATE TABLE IF NOT EXISTS fighter_step (
 );
 
 CREATE TABLE IF NOT EXISTS run (
-    id          TEXT PRIMARY KEY,
-    battle_id   TEXT NOT NULL REFERENCES battle(id),
-    status      TEXT NOT NULL DEFAULT 'pending',
-    started_at  TEXT NOT NULL,
-    finished_at TEXT
+    id               TEXT PRIMARY KEY,
+    battle_id        TEXT NOT NULL REFERENCES battle(id),
+    status           TEXT NOT NULL DEFAULT 'pending',
+    started_at       TEXT NOT NULL,
+    finished_at      TEXT,
+    report_markdown  TEXT
 );
 
 CREATE TABLE IF NOT EXISTS step_result (

--- a/t01_llm_battle/engine.py
+++ b/t01_llm_battle/engine.py
@@ -10,7 +10,7 @@ import uuid
 from datetime import datetime, timezone
 
 from .db import DB_PATH, get_db
-from .judge import score_response
+from .judge import score_response, generate_report
 from .providers.base import CompletionRequest, CompletionResult
 from .providers.registry import get_provider
 from . import rate_limiter
@@ -242,6 +242,10 @@ async def execute_run(run_id: str, db_path=DB_PATH) -> None:
             (run_status, finished_at, run_id),
         )
         await db.commit()
+
+    # Generate markdown report after all judging is complete
+    if judge_provider and judge_model:
+        await generate_report(run_id, judge_provider, judge_model, db_path)
 
 
 def start_run_background(run_id: str, db_path=DB_PATH) -> None:

--- a/t01_llm_battle/judge.py
+++ b/t01_llm_battle/judge.py
@@ -5,6 +5,7 @@ After a run completes, score each fighter_result using the battle's judge_provid
 import re
 from .providers.registry import get_provider
 from .providers.base import CompletionRequest
+from .db import get_db
 
 DEFAULT_JUDGE_PROMPT = """You are evaluating an AI assistant's response to a task.
 
@@ -58,3 +59,121 @@ async def score_response(
         return score, result.content
     except Exception as e:
         return None, f"Judge error: {e}"
+
+
+async def generate_report(
+    run_id: str,
+    judge_provider: str,
+    judge_model: str,
+    db_path: str,
+) -> str:
+    """Generate a markdown summary report for the run using the judge model.
+
+    Returns the markdown string (or an error message if generation fails).
+    The result is stored in run.report_markdown.
+    """
+    try:
+        # 1. Load all fighter_results with scores
+        async with get_db(db_path) as db:
+            cursor = await db.execute(
+                """
+                SELECT fr.fighter_id, fr.source_id, fr.final_output,
+                       fr.total_cost_usd, fr.total_latency_ms,
+                       fr.judge_score, fr.judge_reasoning,
+                       f.name AS fighter_name,
+                       bs.label AS source_label
+                FROM fighter_result fr
+                JOIN fighter f ON f.id = fr.fighter_id
+                JOIN battle_source bs ON bs.id = fr.source_id
+                WHERE fr.run_id = ? AND fr.judge_score IS NOT NULL
+                ORDER BY f.position, bs.position
+                """,
+                (run_id,),
+            )
+            rows = [dict(r) for r in await cursor.fetchall()]
+
+        if not rows:
+            return "Report generation failed: no judged results found."
+
+        # 2. Build per-fighter summary data
+        fighter_data: dict[str, dict] = {}
+        for r in rows:
+            fid = r["fighter_id"]
+            if fid not in fighter_data:
+                fighter_data[fid] = {
+                    "name": r["fighter_name"],
+                    "scores": [],
+                    "total_cost_usd": 0.0,
+                    "total_latency_ms": 0,
+                    "results": [],
+                }
+            fd = fighter_data[fid]
+            fd["scores"].append(r["judge_score"])
+            fd["total_cost_usd"] += r["total_cost_usd"] or 0.0
+            fd["total_latency_ms"] += r["total_latency_ms"] or 0
+            # Trim reasoning to a short snippet
+            reasoning_snippet = ""
+            if r["judge_reasoning"]:
+                snippet = r["judge_reasoning"].strip()
+                reasoning_snippet = snippet[:200] + "..." if len(snippet) > 200 else snippet
+            fd["results"].append({
+                "source_label": r["source_label"],
+                "score": r["judge_score"],
+                "reasoning_snippet": reasoning_snippet,
+            })
+
+        # 3. Build prompt summarising all results
+        summary_lines = []
+        for fid, fd in fighter_data.items():
+            avg_score = sum(fd["scores"]) / len(fd["scores"]) if fd["scores"] else 0.0
+            summary_lines.append(
+                f"Fighter: {fd['name']}\n"
+                f"  Average Score: {avg_score:.2f}/10\n"
+                f"  Total Cost: ${fd['total_cost_usd']:.4f}\n"
+                f"  Total Latency: {fd['total_latency_ms']}ms\n"
+                f"  Individual Results:"
+            )
+            for res in fd["results"]:
+                summary_lines.append(
+                    f"    - Source '{res['source_label']}': "
+                    f"Score {res['score']}/10 — {res['reasoning_snippet']}"
+                )
+
+        summary_text = "\n".join(summary_lines)
+
+        report_prompt = (
+            "You are writing a battle report comparing AI language models.\n\n"
+            "Here are the evaluation results:\n\n"
+            f"{summary_text}\n\n"
+            "Please write a comprehensive markdown report with the following sections:\n"
+            "1. ## Rankings — rank fighters from best to worst by average score\n"
+            "2. ## Per-Fighter Summary — for each fighter, summarise their strengths and weaknesses\n"
+            "3. ## Cost & Latency Comparison — compare total cost and latency across fighters\n"
+            "4. ## Notable Observations — any interesting patterns, surprises, or insights\n\n"
+            "Use proper markdown formatting with headers, tables where appropriate, and bullet points."
+        )
+
+        # 4. Call provider.complete
+        provider = get_provider(judge_provider)
+        result = await provider.complete(
+            CompletionRequest(
+                model=judge_model,
+                system_prompt="You are an expert technical writer producing clear, insightful battle reports.",
+                user_prompt=report_prompt,
+            )
+        )
+        markdown = result.content
+
+        # 5. Store in run.report_markdown
+        async with get_db(db_path) as db:
+            await db.execute(
+                "UPDATE run SET report_markdown = ? WHERE id = ?",
+                (markdown, run_id),
+            )
+            await db.commit()
+
+        # 6. Return markdown
+        return markdown
+
+    except Exception as e:
+        return f"Report generation failed: {e}"

--- a/t01_llm_battle/routers/runs.py
+++ b/t01_llm_battle/routers/runs.py
@@ -258,7 +258,7 @@ async def get_run_results(run_id: str):
 
     async with get_db() as db:
         cursor = await db.execute(
-            "SELECT id, battle_id, status FROM run WHERE id = ?",
+            "SELECT id, battle_id, status, report_markdown FROM run WHERE id = ?",
             (run_id,),
         )
         run_row = await cursor.fetchone()
@@ -362,5 +362,6 @@ async def get_run_results(run_id: str):
         "run_id": run_id,
         "battle_id": run_data["battle_id"],
         "status": run_data["status"],
+        "report_markdown": run_data.get("report_markdown"),
         "summary": summary,
     }


### PR DESCRIPTION
## Summary
- Adds `generate_report()` to `judge.py` — queries all judged `fighter_result` rows, builds a summary prompt, calls the judge model, and stores the result in `run.report_markdown`
- Calls `generate_report()` from `engine.py` after the run completes and all fighters are judged
- Exposes `report_markdown` in `GET /runs/{id}/results` response

## Test plan
- [ ] All 10 existing tests pass (`python -m pytest tests/ -x -q`)
- [ ] Import check passes (`python -c "import t01_llm_battle"`)
- [ ] Server starts (`from t01_llm_battle.server import create_app`)
- [ ] `generate_report` attribute exists on judge module
- [ ] After a completed run with judge config, `GET /runs/{id}/results` returns a non-null `report_markdown` field

Closes #23

🤖 Generated with [Claude Code](https://claude.com/claude-code)