### PR TITLE
chore: PyPI packaging + GitHub Actions CI/publish

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,9 @@ t01-llm-battle = "t01_llm_battle.cli:main"
 [tool.hatch.build.targets.wheel]
 packages = ["t01_llm_battle"]
 
+[tool.hatch.build.targets.wheel.force-include]
+"t01_llm_battle/static" = "t01_llm_battle/static"
+
 [project.optional-dependencies]
 dev = [
     "pytest>=8",


### PR DESCRIPTION
Closes #35

## Changes

- Updated `pyproject.toml` with `[tool.hatch.build.targets.wheel.force-include]` to explicitly include `t01_llm_battle/static` in the wheel
- Verified wheel builds cleanly with `python -m build --wheel` and static assets are present

## Note on Workflow Files

The t01buddy PAT lacks the `workflow` scope required to push `.github/workflows/` files. The following workflow files need to be added manually by the repo owner:

**`.github/workflows/ci.yml`** — runs pytest on push/PR:
\`\`\`yaml
name: CI
on: [push, pull_request]
jobs:
  test:
    runs-on: ubuntu-latest
    steps:
      - uses: actions/checkout@v4
      - uses: actions/setup-python@v5
        with:
          python-version: "3.11"
      - run: pip install -e ".[dev]"
      - run: pytest tests/ -v
\`\`\`

**`.github/workflows/publish.yml`** — publishes to PyPI on `v*` tag push:
\`\`\`yaml
name: Publish to PyPI
on:
  push:
    tags: ["v*"]
jobs:
  publish:
    runs-on: ubuntu-latest
    permissions:
      id-token: write
    steps:
      - uses: actions/checkout@v4
      - uses: actions/setup-python@v5
        with:
          python-version: "3.11"
      - run: pip install build
      - run: python -m build
      - uses: pypa/gh-action-pypi-publish@release/v1
\`\`\`