### PR TITLE
fix: add response_model=None to 204 DELETE routes

### DIFF
--- a/t01_llm_battle/routers/battles.py
+++ b/t01_llm_battle/routers/battles.py
@@ -104,7 +104,7 @@ async def get_battle(battle_id: str) -> BattleDetail:
     )
 
 
-@router.delete("/{battle_id}", status_code=204)
+@router.delete("/{battle_id}", status_code=204, response_model=None)
 async def delete_battle(battle_id: str) -> None:
     """Delete a battle and all related data via cascade."""
     async with get_db() as db:

--- a/t01_llm_battle/routers/fighters.py
+++ b/t01_llm_battle/routers/fighters.py
@@ -165,7 +165,7 @@ async def get_fighter(battle_id: str, fighter_id: str):
     return FighterWithSteps(**fighter.model_dump(), steps=steps)
 
 
-@router.delete("/{fighter_id}", status_code=204)
+@router.delete("/{fighter_id}", status_code=204, response_model=None)
 async def delete_fighter(battle_id: str, fighter_id: str):
     """Delete a fighter and all its steps."""
     async with get_db() as db:
@@ -210,7 +210,7 @@ async def add_step(battle_id: str, fighter_id: str, body: StepCreate):
     return _row_to_step_out(row)
 
 
-@router.delete("/{fighter_id}/steps/{step_id}", status_code=204)
+@router.delete("/{fighter_id}/steps/{step_id}", status_code=204, response_model=None)
 async def delete_step(battle_id: str, fighter_id: str, step_id: str):
     """Delete a step from a fighter."""
     async with get_db() as db:

--- a/t01_llm_battle/routers/sources.py
+++ b/t01_llm_battle/routers/sources.py
@@ -132,7 +132,7 @@ async def list_sources(battle_id: str):
     return {"sources": [{"id": r["id"], "label": r["label"], "position": r["position"]} for r in rows]}
 
 
-@router.delete("/{source_id}", status_code=204)
+@router.delete("/{source_id}", status_code=204, response_model=None)
 async def delete_source(battle_id: str, source_id: str):
     """Delete a single source item."""
     await _battle_exists(battle_id)


### PR DESCRIPTION
## Summary
- FastAPI 0.116 now infers `response_model` from `-> None` return annotations on DELETE routes
- This triggers a startup-time assertion: *Status code 204 must not have a response body*
- Added `response_model=None` explicitly to all four 204 DELETE routes (battles, fighters, steps, sources)

## Test plan
- [ ] Server starts without crashing (`t01-llm-battle --no-browser`)
- [ ] DELETE endpoints still return 204 with no body

🤖 Generated with [Claude Code](https://claude.com/claude-code)