### PR TITLE
fix: battle create navigates to wrong route (missing leading slash)

### DIFF
--- a/t01_llm_battle/static/index.html
+++ b/t01_llm_battle/static/index.html
@@ -900,7 +900,7 @@ Do not wrap the JSON in markdown fences.`;
             const data = await resp.json();
             // Destroy EasyMDE before navigating away to avoid ghost instances
             if (this._mde) { try { this._mde.toTextArea(); } catch(_) {} this._mde = null; }
-            window.location.hash = 'battles/' + data.id;
+            window.location.hash = '/battles/' + data.id;
           } catch(e) {
             this.error = e.message;
           } finally {


### PR DESCRIPTION
## Summary
- Fixes `window.location.hash` navigation after battle creation
- Hash was set to `battles/<id>` instead of `/battles/<id>`, causing router to show "Page not found"
- One-character fix: added leading `/` to the hash string

## Test plan
- [ ] Create a new battle and verify it navigates to the battle detail view
- [ ] Confirm no "Page not found" page appears after form submit

Closes #75

🤖 Generated with [Claude Code](https://claude.com/claude-code)