### PR TITLE
fix: JS error 'Cannot read properties of undefined (reading id)' on battles list

### DIFF
--- a/t01_llm_battle/routers/battles.py
+++ b/t01_llm_battle/routers/battles.py
@@ -78,7 +78,7 @@ async def list_battles() -> list[BattleSummary]:
         )
         rows = await cursor.fetchall()
 
-    return [BattleSummary(id=row["id"], name=row["name"], created_at=row["created_at"]) for row in rows]
+    return [BattleSummary(id=row["id"], name=row["name"], created_at=row["created_at"]) for row in rows if row["id"]]
 
 
 @router.get("/{battle_id}", response_model=BattleDetail)

--- a/t01_llm_battle/static/index.html
+++ b/t01_llm_battle/static/index.html
@@ -120,7 +120,7 @@
               <div>
                 <a :href="'#/battles/' + b.id" style="font-weight:600;color:#1a1a2e;text-decoration:none;font-size:1rem;" x-text="b.name"></a>
                 <div style="font-size:0.8rem;color:#888;margin-top:2px;">
-                  <span x-text="b.judge_provider"></span> / <span x-text="b.judge_model"></span>
+                  <span x-text="b.judge_provider || '—'"></span> / <span x-text="b.judge_model || '—'"></span>
                   &nbsp;·&nbsp; <span x-text="b.created_at ? new Date(b.created_at).toLocaleDateString() : ''"></span>
                 </div>
               </div>
@@ -788,7 +788,8 @@
           try {
             const resp = await fetch('/battles');
             if (!resp.ok) throw new Error(await resp.text());
-            this.battles = await resp.json();
+            const data = await resp.json();
+            this.battles = (Array.isArray(data) ? data : []).filter(b => b && b.id);
           } catch(e) {
             this.error = e.message;
           } finally {


### PR DESCRIPTION
## Summary
- Filters null/undefined entries from the battles list at both API level (`GET /battles`) and frontend before Alpine iterates `x-for`
- Shows `—` for missing `judge_provider`/`judge_model` fields (`BattleSummary` omits those, so they rendered as `undefined` in the UI)
- Prevents Alpine's `:key="b.id"` binding from crashing on null/undefined entries

## Test plan
- [ ] Open battles list page — no JS errors in console
- [ ] Battles with valid data render correctly
- [ ] Missing `judge_provider`/`judge_model` display as `—` instead of blank/undefined

Closes #76

🤖 Generated with [Claude Code](https://claude.com/claude-code)