### PR TITLE
fix: replace raise_for_status with graceful error handling in Google provider

### DIFF
--- a/t01_llm_battle/providers/google.py
+++ b/t01_llm_battle/providers/google.py
@@ -51,8 +51,15 @@ class GoogleProvider(BaseProvider):
 
         async with httpx.AsyncClient(timeout=120.0) as client:
             response = await client.post(url, json=payload)
-            response.raise_for_status()
-            data = response.json()
+
+        if response.status_code != 200:
+            try:
+                err = response.json().get("error", {}).get("message", response.text)
+            except Exception:
+                err = response.text
+            raise RuntimeError(f"Google API error {response.status_code}: {err}")
+
+        data = response.json()
 
         content = data["candidates"][0]["content"]["parts"][0]["text"]
         usage = data.get("usageMetadata", {})


### PR DESCRIPTION
## Summary

- Replaces `raise_for_status()` in `google.py` with explicit status code check and descriptive `RuntimeError`
- Matches the error handling pattern already used in openai.py, groq.py, openrouter.py, and ollama.py
- Other providers (anthropic, groq, openrouter, ollama) were already using graceful error handling — no changes needed there

## Test plan
- [ ] All 22 existing tests pass (`python -m pytest tests/ -x -q`)
- [ ] Google provider now raises `RuntimeError("Google API error <status>: <message>")` on non-200 responses instead of raw httpx exceptions

Closes #89

🤖 Generated with [Claude Code](https://claude.com/claude-code)