### PR TITLE
feat: redesign provider interface using Pydantic AI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ dependencies = [
     "uvicorn[standard]>=0.29",
     "aiosqlite>=0.20",
     "httpx>=0.27",
+    "pydantic-ai>=0.0.36",
     "typer>=0.12",
     "python-multipart>=0.0.9",
 ]

--- a/t01_llm_battle/engine.py
+++ b/t01_llm_battle/engine.py
@@ -11,7 +11,7 @@ from datetime import datetime, timezone
 
 from .db import DB_PATH, get_db, resolve_api_key, _PROVIDER_ENV_VARS
 from .judge import score_response, generate_report
-from .providers.base import CompletionRequest, CompletionResult
+from .providers.base import ProviderRequest, ProviderResult
 from .providers.registry import get_provider
 from . import rate_limiter
 
@@ -152,7 +152,7 @@ async def execute_run(run_id: str, db_path=DB_PATH) -> None:
                     temperature = config.pop("temperature", 0.7)
                     max_tokens = config.pop("max_tokens", 2048)
 
-                    request = CompletionRequest(
+                    request = ProviderRequest(
                         model=step["model_id"],
                         system_prompt=step["system_prompt"] or "",
                         user_prompt=step_input,
@@ -164,7 +164,7 @@ async def execute_run(run_id: str, db_path=DB_PATH) -> None:
                     # Inject DB key into env if env var not already set
                     injected_env_var = await _inject_api_key(step["provider"], db_path)
                     t0 = time.monotonic()
-                    result: CompletionResult = await provider.complete(request)
+                    result: ProviderResult = await provider.run(request)
                     latency_ms = int((time.monotonic() - t0) * 1000)
                     # Remove injected env var so it doesn't persist across steps
                     if injected_env_var:

--- a/t01_llm_battle/judge.py
+++ b/t01_llm_battle/judge.py
@@ -4,7 +4,7 @@ After a run completes, score each fighter_result using the battle's judge_provid
 """
 import re
 from .providers.registry import get_provider
-from .providers.base import CompletionRequest
+from .providers.base import ProviderRequest
 from .db import get_db
 
 DEFAULT_JUDGE_PROMPT = """You are evaluating an AI assistant's response to a task.
@@ -42,8 +42,8 @@ async def score_response(
             response=response_content,
             rubric=judge_rubric or "Quality, accuracy, and helpfulness.",
         )
-        result = await provider.complete(
-            CompletionRequest(
+        result = await provider.run(
+            ProviderRequest(
                 model=judge_model,
                 system_prompt="You are an objective evaluator. Always end with 'SCORE: <0-10>'.",
                 user_prompt=prompt,
@@ -153,10 +153,10 @@ async def generate_report(
             "Use proper markdown formatting with headers, tables where appropriate, and bullet points."
         )
 
-        # 4. Call provider.complete
+        # 4. Call provider.run
         provider = get_provider(judge_provider)
-        result = await provider.complete(
-            CompletionRequest(
+        result = await provider.run(
+            ProviderRequest(
                 model=judge_model,
                 system_prompt="You are an expert technical writer producing clear, insightful battle reports.",
                 user_prompt=report_prompt,

--- a/t01_llm_battle/providers/anthropic.py
+++ b/t01_llm_battle/providers/anthropic.py
@@ -1,8 +1,10 @@
 import os
 
-import httpx
+from pydantic_ai import Agent
+from pydantic_ai.models.anthropic import AnthropicModel
+from pydantic_ai.providers.anthropic import AnthropicProvider as PAIAnthropicProvider
 
-from .base import BaseProvider, CompletionRequest, CompletionResult
+from .base import BaseProvider, ProviderRequest, ProviderResult, ProviderType
 
 PRICING = {
     "claude-opus-4-6": (15.00, 75.00),
@@ -10,59 +12,45 @@ PRICING = {
     "claude-haiku-4-5-20251001": (0.80, 4.00),
 }
 
-API_URL = "https://api.anthropic.com/v1/messages"
-ANTHROPIC_VERSION = "2023-06-01"
-
 
 class AnthropicProvider(BaseProvider):
     name = "anthropic"
+    display_name = "Anthropic"
+    provider_type = ProviderType.LLM
 
     def models(self) -> list[str]:
         return ["claude-opus-4-6", "claude-sonnet-4-6", "claude-haiku-4-5-20251001"]
 
-    def cost(self, input_tokens: int, output_tokens: int, model: str) -> float:
+    def _calc_cost(self, input_tokens: int, output_tokens: int, model: str) -> float:
         if model not in PRICING:
             return 0.0
         input_rate, output_rate = PRICING[model]
         return (input_tokens * input_rate + output_tokens * output_rate) / 1_000_000
 
-    async def complete(self, request: CompletionRequest) -> CompletionResult:
+    async def run(self, request: ProviderRequest) -> ProviderResult:
         api_key = os.environ.get("ANTHROPIC_API_KEY", "")
         if not api_key:
             raise ValueError("ANTHROPIC_API_KEY environment variable is not set")
 
-        payload = {
-            "model": request.model,
-            "system": request.system_prompt,
-            "messages": [{"role": "user", "content": request.user_prompt}],
-            "max_tokens": request.max_tokens,
-            "temperature": request.temperature,
-        }
+        provider = PAIAnthropicProvider(api_key=api_key)
+        model = AnthropicModel(request.model, provider=provider)
+        agent = Agent(model)
 
-        headers = {
-            "x-api-key": api_key,
-            "anthropic-version": ANTHROPIC_VERSION,
-            "content-type": "application/json",
-        }
+        result = await agent.run(
+            request.user_prompt,
+            system_prompt=request.system_prompt or "",
+        )
 
-        async with httpx.AsyncClient() as client:
-            response = await client.post(API_URL, json=payload, headers=headers)
+        usage = result.usage()
+        input_tokens = usage.request_tokens or 0
+        output_tokens = usage.response_tokens or 0
+        cost_usd = self._calc_cost(input_tokens, output_tokens, request.model)
 
-        if response.status_code != 200:
-            data = response.json()
-            error_msg = data.get("error", {}).get("message", response.text)
-            raise RuntimeError(f"Anthropic API error {response.status_code}: {error_msg}")
-
-        data = response.json()
-        content = data["content"][0]["text"]
-        input_tokens = data["usage"]["input_tokens"]
-        output_tokens = data["usage"]["output_tokens"]
-        cost_usd = self.cost(input_tokens, output_tokens, request.model)
-
-        return CompletionResult(
-            content=content,
+        return ProviderResult(
+            content=result.data,
             input_tokens=input_tokens,
             output_tokens=output_tokens,
+            credits_used=None,
             cost_usd=cost_usd,
             model=request.model,
             provider="anthropic",

--- a/t01_llm_battle/providers/base.py
+++ b/t01_llm_battle/providers/base.py
@@ -1,42 +1,66 @@
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
+from enum import Enum
+
+
+class ProviderType(Enum):
+    LLM = "llm"    # Pydantic AI backed; token-based pricing
+    TOOL = "tool"   # plain httpx; credit-based pricing
 
 
 @dataclass
-class CompletionRequest:
-    model: str
-    system_prompt: str
+class TokenPricing:
+    input_per_million: float   # USD per 1M input tokens
+    output_per_million: float  # USD per 1M output tokens
+
+
+@dataclass
+class CreditPricing:
+    credits_per_call: float    # credits consumed per call
+    usd_per_credit: float      # USD per credit
+
+
+@dataclass
+class ProviderRequest:
+    model: str                 # model slug (LLM) or function name (TOOL)
+    system_prompt: str | None
     user_prompt: str
     temperature: float = 0.7
     max_tokens: int = 2048
+    extra: dict = field(default_factory=dict)
 
 
 @dataclass
-class CompletionResult:
+class ProviderResult:
     content: str
-    input_tokens: int
-    output_tokens: int
-    cost_usd: float
+    input_tokens: int | None   # None for TOOL providers
+    output_tokens: int | None  # None for TOOL providers
+    credits_used: float | None  # None for LLM providers
+    cost_usd: float | None
     model: str
     provider: str
     error: str | None = None
 
 
 class BaseProvider(ABC):
-    """Abstract base class for all LLM provider adapters."""
+    """Abstract base class for all provider adapters."""
 
-    name: str  # e.g. "openai", "anthropic"
+    name: str
+    display_name: str
+    provider_type: ProviderType
 
     @abstractmethod
-    async def complete(self, request: CompletionRequest) -> CompletionResult:
-        """Send a completion request and return the result."""
+    async def run(self, request: ProviderRequest) -> ProviderResult:
         ...
 
     @abstractmethod
     def models(self) -> list[str]:
-        """Return list of supported model IDs."""
         ...
 
-    def cost(self, input_tokens: int, output_tokens: int, model: str) -> float:
-        """Calculate cost in USD. Override per provider with real pricing."""
-        return 0.0
+    def cost(self, result: ProviderResult) -> float | None:
+        return result.cost_usd
+
+
+# Backward-compatible aliases for user plugins that may import old names
+CompletionRequest = ProviderRequest
+CompletionResult = ProviderResult

--- a/t01_llm_battle/providers/google.py
+++ b/t01_llm_battle/providers/google.py
@@ -1,15 +1,12 @@
-"""Google (Gemini) provider adapter — thin httpx client, no official SDK."""
+"""Google (Gemini) provider adapter — uses Pydantic AI."""
 
 import os
 
-import httpx
+from pydantic_ai import Agent
+from pydantic_ai.models.gemini import GeminiModel
+from pydantic_ai.providers.google_gla import GoogleGLAProvider
 
-from .base import BaseProvider, CompletionRequest, CompletionResult
-
-_ENDPOINT = (
-    "https://generativelanguage.googleapis.com/v1beta/models"
-    "/{model}:generateContent?key={api_key}"
-)
+from .base import BaseProvider, ProviderRequest, ProviderResult, ProviderType
 
 _PRICING: dict[str, tuple[float, float]] = {
     # (input $/1M tokens, output $/1M tokens)
@@ -21,56 +18,39 @@ _PRICING: dict[str, tuple[float, float]] = {
 
 class GoogleProvider(BaseProvider):
     name = "google"
+    display_name = "Google"
+    provider_type = ProviderType.LLM
 
     def models(self) -> list[str]:
         return ["gemini-2.0-flash", "gemini-1.5-pro", "gemini-1.5-flash"]
 
-    def cost(self, input_tokens: int, output_tokens: int, model: str) -> float:
+    def _calc_cost(self, input_tokens: int, output_tokens: int, model: str) -> float:
         if model not in _PRICING:
             return 0.0
         input_price, output_price = _PRICING[model]
         return (input_tokens * input_price + output_tokens * output_price) / 1_000_000
 
-    async def complete(self, request: CompletionRequest) -> CompletionResult:
+    async def run(self, request: ProviderRequest) -> ProviderResult:
         api_key = os.environ.get("GOOGLE_API_KEY", "")
-        url = _ENDPOINT.format(model=request.model, api_key=api_key)
+        provider = GoogleGLAProvider(api_key=api_key)
+        model = GeminiModel(request.model, provider=provider)
+        agent = Agent(model)
 
-        payload: dict = {
-            "contents": [
-                {"role": "user", "parts": [{"text": request.user_prompt}]}
-            ],
-            "generationConfig": {
-                "temperature": request.temperature,
-                "maxOutputTokens": request.max_tokens,
-            },
-        }
-        if request.system_prompt:
-            payload["system_instruction"] = {
-                "parts": [{"text": request.system_prompt}]
-            }
+        result = await agent.run(
+            request.user_prompt,
+            system_prompt=request.system_prompt or "",
+        )
 
-        async with httpx.AsyncClient(timeout=120.0) as client:
-            response = await client.post(url, json=payload)
+        usage = result.usage()
+        input_tokens = usage.request_tokens or 0
+        output_tokens = usage.response_tokens or 0
+        cost_usd = self._calc_cost(input_tokens, output_tokens, request.model)
 
-        if response.status_code != 200:
-            try:
-                err = response.json().get("error", {}).get("message", response.text)
-            except Exception:
-                err = response.text
-            raise RuntimeError(f"Google API error {response.status_code}: {err}")
-
-        data = response.json()
-
-        content = data["candidates"][0]["content"]["parts"][0]["text"]
-        usage = data.get("usageMetadata", {})
-        input_tokens = usage.get("promptTokenCount", 0)
-        output_tokens = usage.get("candidatesTokenCount", 0)
-        cost_usd = self.cost(input_tokens, output_tokens, request.model)
-
-        return CompletionResult(
-            content=content,
+        return ProviderResult(
+            content=result.data,
             input_tokens=input_tokens,
             output_tokens=output_tokens,
+            credits_used=None,
             cost_usd=cost_usd,
             model=request.model,
             provider=self.name,

--- a/t01_llm_battle/providers/groq.py
+++ b/t01_llm_battle/providers/groq.py
@@ -1,10 +1,10 @@
 import os
 
-import httpx
+from pydantic_ai import Agent
+from pydantic_ai.models.groq import GroqModel
+from pydantic_ai.providers.groq import GroqProvider as PAIGroqProvider
 
-from .base import BaseProvider, CompletionRequest, CompletionResult
-
-_API_URL = "https://api.groq.com/openai/v1/chat/completions"
+from .base import BaseProvider, ProviderRequest, ProviderResult, ProviderType
 
 _PRICING: dict[str, tuple[float, float]] = {
     # model: (input $/1M tokens, output $/1M tokens)
@@ -18,6 +18,8 @@ _DEFAULT_PRICING: tuple[float, float] = (0.10, 0.10)
 
 class GroqProvider(BaseProvider):
     name = "groq"
+    display_name = "Groq"
+    provider_type = ProviderType.LLM
 
     def models(self) -> list[str]:
         return [
@@ -27,53 +29,31 @@ class GroqProvider(BaseProvider):
             "gemma2-9b-it",
         ]
 
-    def cost(self, input_tokens: int, output_tokens: int, model: str) -> float:
+    def _calc_cost(self, input_tokens: int, output_tokens: int, model: str) -> float:
         input_rate, output_rate = _PRICING.get(model, _DEFAULT_PRICING)
         return (input_tokens * input_rate + output_tokens * output_rate) / 1_000_000
 
-    async def complete(self, request: CompletionRequest) -> CompletionResult:
+    async def run(self, request: ProviderRequest) -> ProviderResult:
         api_key = os.environ.get("GROQ_API_KEY", "")
+        provider = PAIGroqProvider(api_key=api_key)
+        model = GroqModel(request.model, provider=provider)
+        agent = Agent(model)
 
-        messages = []
-        if request.system_prompt:
-            messages.append({"role": "system", "content": request.system_prompt})
-        messages.append({"role": "user", "content": request.user_prompt})
+        result = await agent.run(
+            request.user_prompt,
+            system_prompt=request.system_prompt or "",
+        )
 
-        payload = {
-            "model": request.model,
-            "messages": messages,
-            "temperature": request.temperature,
-            "max_tokens": request.max_tokens,
-        }
+        usage = result.usage()
+        input_tokens = usage.request_tokens or 0
+        output_tokens = usage.response_tokens or 0
+        cost_usd = self._calc_cost(input_tokens, output_tokens, request.model)
 
-        async with httpx.AsyncClient(timeout=120.0) as client:
-            response = await client.post(
-                _API_URL,
-                headers={
-                    "Authorization": f"Bearer {api_key}",
-                    "Content-Type": "application/json",
-                },
-                json=payload,
-            )
-
-        if response.status_code != 200:
-            try:
-                err = response.json().get("error", {}).get("message", response.text)
-            except Exception:
-                err = response.text
-            raise RuntimeError(f"Groq API error {response.status_code}: {err}")
-
-        data = response.json()
-        content = data["choices"][0]["message"]["content"]
-        usage = data.get("usage", {})
-        input_tokens = usage.get("prompt_tokens", 0)
-        output_tokens = usage.get("completion_tokens", 0)
-        cost_usd = self.cost(input_tokens, output_tokens, request.model)
-
-        return CompletionResult(
-            content=content,
+        return ProviderResult(
+            content=result.data,
             input_tokens=input_tokens,
             output_tokens=output_tokens,
+            credits_used=None,
             cost_usd=cost_usd,
             model=request.model,
             provider="groq",

--- a/t01_llm_battle/providers/ollama.py
+++ b/t01_llm_battle/providers/ollama.py
@@ -1,12 +1,17 @@
 import httpx
+from pydantic_ai import Agent
+from pydantic_ai.models.openai import OpenAIChatModel
+from pydantic_ai.providers.openai import OpenAIProvider as PAIOpenAIProvider
 
-from .base import BaseProvider, CompletionRequest, CompletionResult
+from .base import BaseProvider, ProviderRequest, ProviderResult, ProviderType
 
 _DEFAULT_BASE_URL = "http://localhost:11434"
 
 
 class OllamaProvider(BaseProvider):
     name = "ollama"
+    display_name = "Ollama"
+    provider_type = ProviderType.LLM
 
     def __init__(self, base_url: str = _DEFAULT_BASE_URL) -> None:
         self.base_url = base_url.rstrip("/")
@@ -22,48 +27,28 @@ class OllamaProvider(BaseProvider):
         except Exception:
             return []
 
-    def cost(self, input_tokens: int, output_tokens: int, model: str) -> float:
-        """Ollama is local and free — always 0.0."""
-        return 0.0
+    async def run(self, request: ProviderRequest) -> ProviderResult:
+        provider = PAIOpenAIProvider(
+            base_url=f"{self.base_url}/v1",
+            api_key="ollama",  # Ollama doesn't need a real key
+        )
+        model = OpenAIChatModel(request.model, provider=provider)
+        agent = Agent(model)
 
-    async def complete(self, request: CompletionRequest) -> CompletionResult:
-        messages = []
-        if request.system_prompt:
-            messages.append({"role": "system", "content": request.system_prompt})
-        messages.append({"role": "user", "content": request.user_prompt})
+        result = await agent.run(
+            request.user_prompt,
+            system_prompt=request.system_prompt or "",
+        )
 
-        payload = {
-            "model": request.model,
-            "messages": messages,
-            "stream": False,
-            "options": {
-                "temperature": request.temperature,
-                "num_predict": request.max_tokens,
-            },
-        }
+        usage = result.usage()
+        input_tokens = usage.request_tokens or 0
+        output_tokens = usage.response_tokens or 0
 
-        async with httpx.AsyncClient(timeout=120.0) as client:
-            response = await client.post(
-                f"{self.base_url}/api/chat",
-                json=payload,
-            )
-
-        if response.status_code != 200:
-            try:
-                err = response.json().get("error", response.text)
-            except Exception:
-                err = response.text
-            raise RuntimeError(f"Ollama API error {response.status_code}: {err}")
-
-        data = response.json()
-        content = data["message"]["content"]
-        input_tokens = data.get("prompt_eval_count", 0)
-        output_tokens = data.get("eval_count", 0)
-
-        return CompletionResult(
-            content=content,
+        return ProviderResult(
+            content=result.data,
             input_tokens=input_tokens,
             output_tokens=output_tokens,
+            credits_used=None,
             cost_usd=0.0,
             model=request.model,
             provider="ollama",

--- a/t01_llm_battle/providers/openai.py
+++ b/t01_llm_battle/providers/openai.py
@@ -1,10 +1,10 @@
 import os
 
-import httpx
+from pydantic_ai import Agent
+from pydantic_ai.models.openai import OpenAIChatModel
+from pydantic_ai.providers.openai import OpenAIProvider as PAIOpenAIProvider
 
-from .base import BaseProvider, CompletionRequest, CompletionResult
-
-_API_URL = "https://api.openai.com/v1/chat/completions"
+from .base import BaseProvider, ProviderRequest, ProviderResult, ProviderType
 
 _PRICING: dict[str, tuple[float, float]] = {
     # model: (input $/1M tokens, output $/1M tokens)
@@ -17,59 +17,39 @@ _PRICING: dict[str, tuple[float, float]] = {
 
 class OpenAIProvider(BaseProvider):
     name = "openai"
+    display_name = "OpenAI"
+    provider_type = ProviderType.LLM
 
     def models(self) -> list[str]:
         return ["gpt-4o", "gpt-4o-mini", "gpt-4-turbo", "gpt-3.5-turbo"]
 
-    def cost(self, input_tokens: int, output_tokens: int, model: str) -> float:
+    def _calc_cost(self, input_tokens: int, output_tokens: int, model: str) -> float:
         if model not in _PRICING:
             return 0.0
         input_rate, output_rate = _PRICING[model]
         return (input_tokens * input_rate + output_tokens * output_rate) / 1_000_000
 
-    async def complete(self, request: CompletionRequest) -> CompletionResult:
+    async def run(self, request: ProviderRequest) -> ProviderResult:
         api_key = os.environ.get("OPENAI_API_KEY", "")
+        provider = PAIOpenAIProvider(api_key=api_key)
+        model = OpenAIChatModel(request.model, provider=provider)
+        agent = Agent(model)
 
-        messages = []
-        if request.system_prompt:
-            messages.append({"role": "system", "content": request.system_prompt})
-        messages.append({"role": "user", "content": request.user_prompt})
+        result = await agent.run(
+            request.user_prompt,
+            system_prompt=request.system_prompt or "",
+        )
 
-        payload = {
-            "model": request.model,
-            "messages": messages,
-            "temperature": request.temperature,
-            "max_tokens": request.max_tokens,
-        }
+        usage = result.usage()
+        input_tokens = usage.request_tokens or 0
+        output_tokens = usage.response_tokens or 0
+        cost_usd = self._calc_cost(input_tokens, output_tokens, request.model)
 
-        async with httpx.AsyncClient(timeout=120.0) as client:
-            response = await client.post(
-                _API_URL,
-                headers={
-                    "Authorization": f"Bearer {api_key}",
-                    "Content-Type": "application/json",
-                },
-                json=payload,
-            )
-
-        if response.status_code != 200:
-            try:
-                err = response.json().get("error", {}).get("message", response.text)
-            except Exception:
-                err = response.text
-            raise RuntimeError(f"OpenAI API error {response.status_code}: {err}")
-
-        data = response.json()
-        content = data["choices"][0]["message"]["content"]
-        usage = data.get("usage", {})
-        input_tokens = usage.get("prompt_tokens", 0)
-        output_tokens = usage.get("completion_tokens", 0)
-        cost_usd = self.cost(input_tokens, output_tokens, request.model)
-
-        return CompletionResult(
-            content=content,
+        return ProviderResult(
+            content=result.data,
             input_tokens=input_tokens,
             output_tokens=output_tokens,
+            credits_used=None,
             cost_usd=cost_usd,
             model=request.model,
             provider="openai",

--- a/t01_llm_battle/providers/openrouter.py
+++ b/t01_llm_battle/providers/openrouter.py
@@ -1,10 +1,10 @@
 import os
 
-import httpx
+from pydantic_ai import Agent
+from pydantic_ai.models.openai import OpenAIChatModel
+from pydantic_ai.providers.openai import OpenAIProvider as PAIOpenAIProvider
 
-from .base import BaseProvider, CompletionRequest, CompletionResult
-
-_API_URL = "https://openrouter.ai/api/v1/chat/completions"
+from .base import BaseProvider, ProviderRequest, ProviderResult, ProviderType
 
 _MODELS = [
     "openai/gpt-4o",
@@ -17,61 +17,36 @@ _MODELS = [
 
 class OpenRouterProvider(BaseProvider):
     name = "openrouter"
+    display_name = "OpenRouter"
+    provider_type = ProviderType.LLM
 
     def models(self) -> list[str]:
         return list(_MODELS)
 
-    def cost(self, input_tokens: int, output_tokens: int, model: str) -> float:
-        # OpenRouter pricing varies per model and is fetched dynamically in a real app.
-        # For v0.1, return 0.0 (unknown).
-        return 0.0
-
-    async def complete(self, request: CompletionRequest) -> CompletionResult:
+    async def run(self, request: ProviderRequest) -> ProviderResult:
         api_key = os.environ.get("OPENROUTER_API_KEY", "")
+        provider = PAIOpenAIProvider(
+            api_key=api_key,
+            base_url="https://openrouter.ai/api/v1",
+        )
+        model = OpenAIChatModel(request.model, provider=provider)
+        agent = Agent(model)
 
-        messages = []
-        if request.system_prompt:
-            messages.append({"role": "system", "content": request.system_prompt})
-        messages.append({"role": "user", "content": request.user_prompt})
+        result = await agent.run(
+            request.user_prompt,
+            system_prompt=request.system_prompt or "",
+        )
 
-        payload = {
-            "model": request.model,
-            "messages": messages,
-            "temperature": request.temperature,
-            "max_tokens": request.max_tokens,
-        }
+        usage = result.usage()
+        input_tokens = usage.request_tokens or 0
+        output_tokens = usage.response_tokens or 0
 
-        async with httpx.AsyncClient(timeout=120.0) as client:
-            response = await client.post(
-                _API_URL,
-                headers={
-                    "Authorization": f"Bearer {api_key}",
-                    "Content-Type": "application/json",
-                    "HTTP-Referer": "http://localhost:7700",
-                    "X-Title": "t01-llm-battle",
-                },
-                json=payload,
-            )
-
-        if response.status_code != 200:
-            try:
-                err = response.json().get("error", {}).get("message", response.text)
-            except Exception:
-                err = response.text
-            raise RuntimeError(f"OpenRouter API error {response.status_code}: {err}")
-
-        data = response.json()
-        content = data["choices"][0]["message"]["content"]
-        usage = data.get("usage", {})
-        input_tokens = usage.get("prompt_tokens", 0)
-        output_tokens = usage.get("completion_tokens", 0)
-        cost_usd = self.cost(input_tokens, output_tokens, request.model)
-
-        return CompletionResult(
-            content=content,
+        return ProviderResult(
+            content=result.data,
             input_tokens=input_tokens,
             output_tokens=output_tokens,
-            cost_usd=cost_usd,
+            credits_used=None,
+            cost_usd=0.0,
             model=request.model,
             provider="openrouter",
         )

--- a/tests/test_openai_adapter.py
+++ b/tests/test_openai_adapter.py
@@ -1,28 +1,33 @@
 import pytest
 from unittest.mock import AsyncMock, MagicMock, patch
 from t01_llm_battle.providers.openai import OpenAIProvider
-from t01_llm_battle.providers.base import CompletionRequest
+from t01_llm_battle.providers.base import ProviderRequest
 
 
 @pytest.mark.asyncio
-async def test_complete_returns_result():
-    mock_response = {
-        "choices": [{"message": {"content": "Hello!"}}],
-        "usage": {"prompt_tokens": 10, "completion_tokens": 5},
-        "model": "gpt-4o",
-    }
+async def test_run_returns_result():
     provider = OpenAIProvider()
-    request = CompletionRequest(model="gpt-4o", system_prompt="", user_prompt="Hi")
+    request = ProviderRequest(model="gpt-4o", system_prompt="", user_prompt="Hi")
 
-    mock_resp = MagicMock()
-    mock_resp.status_code = 200
-    mock_resp.json.return_value = mock_response
+    # Mock pydantic-ai Agent.run result
+    mock_usage = MagicMock()
+    mock_usage.request_tokens = 10
+    mock_usage.response_tokens = 5
 
-    with patch("httpx.AsyncClient.post", new_callable=AsyncMock) as mock_post:
-        mock_post.return_value = mock_resp
-        result = await provider.complete(request)
+    mock_result = MagicMock()
+    mock_result.data = "Hello!"
+    mock_result.usage.return_value = mock_usage
+
+    with patch("t01_llm_battle.providers.openai.Agent") as MockAgent:
+        mock_agent_instance = MagicMock()
+        mock_agent_instance.run = AsyncMock(return_value=mock_result)
+        MockAgent.return_value = mock_agent_instance
+
+        result = await provider.run(request)
 
     assert result.content == "Hello!"
     assert result.input_tokens == 10
     assert result.output_tokens == 5
     assert result.provider == "openai"
+    assert result.credits_used is None
+    assert result.cost_usd > 0  # gpt-4o has known pricing


### PR DESCRIPTION
## Summary
- Rewrote `BaseProvider` ABC with new `ProviderType` enum (LLM/TOOL), `TokenPricing`/`CreditPricing` dataclasses, and `ProviderRequest`/`ProviderResult` replacing `CompletionRequest`/`CompletionResult`
- Rewrote all 6 LLM providers (OpenAI, Anthropic, Google, Groq, OpenRouter, Ollama) to use `pydantic-ai` models instead of raw `httpx` calls
- Updated `engine.py` and `judge.py` to use new `provider.run()` interface instead of `provider.complete()`
- Added `pydantic-ai>=0.0.36` to `pyproject.toml` dependencies
- Backward-compatible aliases (`CompletionRequest`, `CompletionResult`) kept in `base.py` for user plugins

## Test plan
- [x] All 22 existing tests pass
- [x] Provider test updated to mock pydantic-ai Agent instead of httpx
- [ ] Manual smoke test with real API keys (OpenAI, Anthropic)
- [ ] Verify user plugin providers still load via registry

Closes #81

🤖 Generated with [Claude Code](https://claude.com/claude-code)