### PR TITLE
feat: add Serper, Tavily, Firecrawl tool providers

### DIFF
--- a/t01_llm_battle/providers/firecrawl.py
+++ b/t01_llm_battle/providers/firecrawl.py
@@ -1,0 +1,74 @@
+import os
+
+import httpx
+
+from .base import BaseProvider, CreditPricing, ProviderRequest, ProviderResult, ProviderType
+
+_PRICING = CreditPricing(credits_per_call=1.0, usd_per_credit=0.001)
+
+
+class FirecrawlProvider(BaseProvider):
+    name = "firecrawl"
+    display_name = "Firecrawl"
+    provider_type = ProviderType.TOOL
+
+    def models(self) -> list[str]:
+        return ["scrape", "crawl"]
+
+    async def run(self, request: ProviderRequest) -> ProviderResult:
+        api_key = os.environ.get("FIRECRAWL_API_KEY", "")
+        function = request.model  # "scrape" or "crawl"
+        headers = {"Authorization": f"Bearer {api_key}", "Content-Type": "application/json"}
+
+        async with httpx.AsyncClient() as client:
+            if function == "crawl":
+                response = await client.post(
+                    "https://api.firecrawl.dev/v1/crawl",
+                    json={"url": request.user_prompt},
+                    headers=headers,
+                    timeout=60.0,
+                )
+            else:
+                response = await client.post(
+                    "https://api.firecrawl.dev/v1/scrape",
+                    json={"url": request.user_prompt},
+                    headers=headers,
+                    timeout=30.0,
+                )
+            response.raise_for_status()
+            data = response.json()
+
+        content = _format_firecrawl_results(data, function)
+        cost_usd = _PRICING.credits_per_call * _PRICING.usd_per_credit
+
+        return ProviderResult(
+            content=content,
+            input_tokens=None,
+            output_tokens=None,
+            credits_used=_PRICING.credits_per_call,
+            cost_usd=cost_usd,
+            model=function,
+            provider="firecrawl",
+        )
+
+
+def _format_firecrawl_results(data: dict, function: str) -> str:
+    if function == "crawl":
+        pages = data.get("data", [])
+        lines = [f"Crawled {len(pages)} page(s):", ""]
+        for page in pages:
+            lines.append(f"**{page.get('metadata', {}).get('title', page.get('url', ''))}**")
+            lines.append(page.get("markdown", page.get("content", ""))[:500])
+            lines.append("")
+        return "\n".join(lines).strip()
+
+    # scrape
+    page = data.get("data", data)
+    markdown = page.get("markdown", page.get("content", ""))
+    title = page.get("metadata", {}).get("title", "")
+    lines = []
+    if title:
+        lines.append(f"**{title}**")
+        lines.append("")
+    lines.append(markdown)
+    return "\n".join(lines).strip()

--- a/t01_llm_battle/providers/registry.py
+++ b/t01_llm_battle/providers/registry.py
@@ -13,6 +13,9 @@ _BUILTIN_MODULES = [
     "t01_llm_battle.providers.groq",
     "t01_llm_battle.providers.openrouter",
     "t01_llm_battle.providers.ollama",
+    "t01_llm_battle.providers.serper",
+    "t01_llm_battle.providers.tavily",
+    "t01_llm_battle.providers.firecrawl",
 ]
 
 _USER_PLUGIN_DIR = Path.home() / ".t01-llm-battle" / "providers"

--- a/t01_llm_battle/providers/serper.py
+++ b/t01_llm_battle/providers/serper.py
@@ -1,0 +1,71 @@
+import os
+import json
+
+import httpx
+
+from .base import BaseProvider, CreditPricing, ProviderRequest, ProviderResult, ProviderType
+
+_PRICING = CreditPricing(credits_per_call=1.0, usd_per_credit=0.001)
+
+_ENDPOINTS = {
+    "search": "https://google.serper.dev/search",
+    "news": "https://google.serper.dev/news",
+}
+
+
+class SerperProvider(BaseProvider):
+    name = "serper"
+    display_name = "Serper.dev"
+    provider_type = ProviderType.TOOL
+
+    def models(self) -> list[str]:
+        return ["search", "news"]
+
+    async def run(self, request: ProviderRequest) -> ProviderResult:
+        api_key = os.environ.get("SERPER_API_KEY", "")
+        function = request.model  # "search" or "news"
+        endpoint = _ENDPOINTS.get(function, _ENDPOINTS["search"])
+
+        async with httpx.AsyncClient() as client:
+            response = await client.post(
+                endpoint,
+                json={"q": request.user_prompt},
+                headers={"X-API-KEY": api_key, "Content-Type": "application/json"},
+                timeout=30.0,
+            )
+            response.raise_for_status()
+            data = response.json()
+
+        content = _format_serper_results(data, function)
+        cost_usd = _PRICING.credits_per_call * _PRICING.usd_per_credit
+
+        return ProviderResult(
+            content=content,
+            input_tokens=None,
+            output_tokens=None,
+            credits_used=_PRICING.credits_per_call,
+            cost_usd=cost_usd,
+            model=function,
+            provider="serper",
+        )
+
+
+def _format_serper_results(data: dict, function: str) -> str:
+    lines = []
+    if function == "news":
+        for item in data.get("news", []):
+            lines.append(f"**{item.get('title', '')}**")
+            lines.append(item.get("snippet", ""))
+            lines.append(f"Source: {item.get('link', '')}")
+            lines.append("")
+    else:
+        for item in data.get("organic", []):
+            lines.append(f"**{item.get('title', '')}**")
+            lines.append(item.get("snippet", ""))
+            lines.append(f"URL: {item.get('link', '')}")
+            lines.append("")
+
+    if not lines:
+        lines.append(json.dumps(data, indent=2))
+
+    return "\n".join(lines).strip()

--- a/t01_llm_battle/providers/tavily.py
+++ b/t01_llm_battle/providers/tavily.py
@@ -1,0 +1,57 @@
+import os
+
+import httpx
+
+from .base import BaseProvider, CreditPricing, ProviderRequest, ProviderResult, ProviderType
+
+_PRICING = CreditPricing(credits_per_call=1.0, usd_per_credit=0.002)
+
+
+class TavilyProvider(BaseProvider):
+    name = "tavily"
+    display_name = "Tavily"
+    provider_type = ProviderType.TOOL
+
+    def models(self) -> list[str]:
+        return ["search"]
+
+    async def run(self, request: ProviderRequest) -> ProviderResult:
+        api_key = os.environ.get("TAVILY_API_KEY", "")
+
+        async with httpx.AsyncClient() as client:
+            response = await client.post(
+                "https://api.tavily.com/search",
+                json={"query": request.user_prompt, "api_key": api_key},
+                timeout=30.0,
+            )
+            response.raise_for_status()
+            data = response.json()
+
+        content = _format_tavily_results(data)
+        cost_usd = _PRICING.credits_per_call * _PRICING.usd_per_credit
+
+        return ProviderResult(
+            content=content,
+            input_tokens=None,
+            output_tokens=None,
+            credits_used=_PRICING.credits_per_call,
+            cost_usd=cost_usd,
+            model="search",
+            provider="tavily",
+        )
+
+
+def _format_tavily_results(data: dict) -> str:
+    lines = []
+    answer = data.get("answer")
+    if answer:
+        lines.append(f"**Answer**: {answer}")
+        lines.append("")
+
+    for item in data.get("results", []):
+        lines.append(f"**{item.get('title', '')}**")
+        lines.append(item.get("content", ""))
+        lines.append(f"URL: {item.get('url', '')}")
+        lines.append("")
+
+    return "\n".join(lines).strip()

--- a/t01_llm_battle/routers/keys.py
+++ b/t01_llm_battle/routers/keys.py
@@ -23,6 +23,9 @@ _ENV_VARS = {
     "google": "GOOGLE_API_KEY",
     "groq": "GROQ_API_KEY",
     "openrouter": "OPENROUTER_API_KEY",
+    "serper": "SERPER_API_KEY",
+    "tavily": "TAVILY_API_KEY",
+    "firecrawl": "FIRECRAWL_API_KEY",
 }
 
 


### PR DESCRIPTION
## Summary
- Adds three TOOL-type provider adapters: Serper.dev (search/news), Tavily (search), Firecrawl (scrape/crawl)
- All use credit-based pricing (`credits_used`, `cost_usd`; `input_tokens`/`output_tokens` are `None`)
- Registers all three in `registry.py` and adds their env var keys to `routers/keys.py`

## Test plan
- [ ] `python -m pytest tests/ -x -q` — all 22 tests pass
- [ ] Serper search/news functions callable via `ProviderRequest(model="search", ...)`
- [ ] Tavily search returns formatted results with answer + links
- [ ] Firecrawl scrape/crawl functions callable with a URL as `user_prompt`
- [ ] Key management UI lists SERPER_API_KEY, TAVILY_API_KEY, FIRECRAWL_API_KEY

Closes #82

🤖 Generated with [Claude Code](https://claude.com/claude-code)