### PR TITLE
fix: pass all provider_config keys through to providers (FR-7)

### DIFF
--- a/t01_llm_battle/engine.py
+++ b/t01_llm_battle/engine.py
@@ -151,6 +151,8 @@ async def execute_run(run_id: str, db_path=DB_PATH) -> None:
                     config = json.loads(step["provider_config"]) if step["provider_config"] else {}
                     temperature = config.pop("temperature", 0.7)
                     max_tokens = config.pop("max_tokens", 2048)
+                    # All remaining keys are passed through to the provider via extra
+                    extra = config
 
                     request = ProviderRequest(
                         model=step["model_id"],
@@ -158,6 +160,7 @@ async def execute_run(run_id: str, db_path=DB_PATH) -> None:
                         user_prompt=step_input,
                         temperature=temperature,
                         max_tokens=max_tokens,
+                        extra=extra,
                     )
 
                     await rate_limiter.acquire(step["provider"])

--- a/t01_llm_battle/providers/anthropic.py
+++ b/t01_llm_battle/providers/anthropic.py
@@ -36,9 +36,17 @@ class AnthropicProvider(BaseProvider):
         model = AnthropicModel(request.model, provider=provider)
         agent = Agent(model)
 
+        model_settings: dict = {
+            "temperature": request.temperature,
+            "max_tokens": request.max_tokens,
+        }
+        if "top_p" in request.extra:
+            model_settings["top_p"] = request.extra["top_p"]
+
         result = await agent.run(
             request.user_prompt,
             system_prompt=request.system_prompt or "",
+            model_settings=model_settings,
         )
 
         usage = result.usage()

--- a/t01_llm_battle/providers/google.py
+++ b/t01_llm_battle/providers/google.py
@@ -36,9 +36,17 @@ class GoogleProvider(BaseProvider):
         model = GeminiModel(request.model, provider=provider)
         agent = Agent(model)
 
+        model_settings: dict = {
+            "temperature": request.temperature,
+            "max_tokens": request.max_tokens,
+        }
+        if "top_p" in request.extra:
+            model_settings["top_p"] = request.extra["top_p"]
+
         result = await agent.run(
             request.user_prompt,
             system_prompt=request.system_prompt or "",
+            model_settings=model_settings,
         )
 
         usage = result.usage()

--- a/t01_llm_battle/providers/groq.py
+++ b/t01_llm_battle/providers/groq.py
@@ -39,9 +39,17 @@ class GroqProvider(BaseProvider):
         model = GroqModel(request.model, provider=provider)
         agent = Agent(model)
 
+        model_settings: dict = {
+            "temperature": request.temperature,
+            "max_tokens": request.max_tokens,
+        }
+        if "top_p" in request.extra:
+            model_settings["top_p"] = request.extra["top_p"]
+
         result = await agent.run(
             request.user_prompt,
             system_prompt=request.system_prompt or "",
+            model_settings=model_settings,
         )
 
         usage = result.usage()

--- a/t01_llm_battle/providers/ollama.py
+++ b/t01_llm_battle/providers/ollama.py
@@ -35,9 +35,17 @@ class OllamaProvider(BaseProvider):
         model = OpenAIChatModel(request.model, provider=provider)
         agent = Agent(model)
 
+        model_settings: dict = {
+            "temperature": request.temperature,
+            "max_tokens": request.max_tokens,
+        }
+        if "top_p" in request.extra:
+            model_settings["top_p"] = request.extra["top_p"]
+
         result = await agent.run(
             request.user_prompt,
             system_prompt=request.system_prompt or "",
+            model_settings=model_settings,
         )
 
         usage = result.usage()

--- a/t01_llm_battle/providers/openai.py
+++ b/t01_llm_battle/providers/openai.py
@@ -35,9 +35,18 @@ class OpenAIProvider(BaseProvider):
         model = OpenAIChatModel(request.model, provider=provider)
         agent = Agent(model)
 
+        # Build model_settings from known extra keys; unknown keys are ignored (forward-compat)
+        model_settings: dict = {
+            "temperature": request.temperature,
+            "max_tokens": request.max_tokens,
+        }
+        if "top_p" in request.extra:
+            model_settings["top_p"] = request.extra["top_p"]
+
         result = await agent.run(
             request.user_prompt,
             system_prompt=request.system_prompt or "",
+            model_settings=model_settings,
         )
 
         usage = result.usage()

--- a/t01_llm_battle/providers/openrouter.py
+++ b/t01_llm_battle/providers/openrouter.py
@@ -32,9 +32,17 @@ class OpenRouterProvider(BaseProvider):
         model = OpenAIChatModel(request.model, provider=provider)
         agent = Agent(model)
 
+        model_settings: dict = {
+            "temperature": request.temperature,
+            "max_tokens": request.max_tokens,
+        }
+        if "top_p" in request.extra:
+            model_settings["top_p"] = request.extra["top_p"]
+
         result = await agent.run(
             request.user_prompt,
             system_prompt=request.system_prompt or "",
+            model_settings=model_settings,
         )
 
         usage = result.usage()

--- a/tests/test_provider_config_passthrough.py
+++ b/tests/test_provider_config_passthrough.py
@@ -1,0 +1,134 @@
+"""Tests for FR-7: provider_config keys beyond temperature/max_tokens are passed through."""
+
+import json
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from t01_llm_battle.providers.openai import OpenAIProvider
+from t01_llm_battle.providers.base import ProviderRequest
+
+
+def _mock_agent_run(content="response"):
+    """Return a patcher context for Agent that yields a successful result."""
+    mock_usage = MagicMock()
+    mock_usage.request_tokens = 10
+    mock_usage.response_tokens = 5
+
+    mock_result = MagicMock()
+    mock_result.data = content
+    mock_result.usage.return_value = mock_usage
+    return mock_result
+
+
+@pytest.mark.asyncio
+async def test_openai_passes_top_p_in_model_settings():
+    """top_p from extra should appear in model_settings passed to agent.run."""
+    provider = OpenAIProvider()
+    request = ProviderRequest(
+        model="gpt-4o",
+        system_prompt="",
+        user_prompt="Hi",
+        temperature=0.5,
+        max_tokens=100,
+        extra={"top_p": 0.9},
+    )
+
+    mock_result = _mock_agent_run()
+
+    with patch("t01_llm_battle.providers.openai.Agent") as MockAgent:
+        mock_agent_instance = MagicMock()
+        mock_agent_instance.run = AsyncMock(return_value=mock_result)
+        MockAgent.return_value = mock_agent_instance
+
+        await provider.run(request)
+
+        call_kwargs = mock_agent_instance.run.call_args.kwargs
+        assert "model_settings" in call_kwargs
+        assert call_kwargs["model_settings"]["top_p"] == 0.9
+        assert call_kwargs["model_settings"]["temperature"] == 0.5
+        assert call_kwargs["model_settings"]["max_tokens"] == 100
+
+
+@pytest.mark.asyncio
+async def test_openai_unknown_extra_keys_are_ignored():
+    """Unknown extra keys should not raise errors (forward-compatible)."""
+    provider = OpenAIProvider()
+    request = ProviderRequest(
+        model="gpt-4o",
+        system_prompt="",
+        user_prompt="Hi",
+        extra={"some_future_key": "value", "another_unknown": 42},
+    )
+
+    mock_result = _mock_agent_run()
+
+    with patch("t01_llm_battle.providers.openai.Agent") as MockAgent:
+        mock_agent_instance = MagicMock()
+        mock_agent_instance.run = AsyncMock(return_value=mock_result)
+        MockAgent.return_value = mock_agent_instance
+
+        # Should not raise
+        result = await provider.run(request)
+
+    assert result.content == "response"
+
+
+@pytest.mark.asyncio
+async def test_openai_extra_empty_by_default():
+    """When extra is empty, model_settings should still have temperature and max_tokens."""
+    provider = OpenAIProvider()
+    request = ProviderRequest(
+        model="gpt-4o",
+        system_prompt="",
+        user_prompt="Hi",
+        temperature=0.3,
+        max_tokens=512,
+    )
+
+    mock_result = _mock_agent_run()
+
+    with patch("t01_llm_battle.providers.openai.Agent") as MockAgent:
+        mock_agent_instance = MagicMock()
+        mock_agent_instance.run = AsyncMock(return_value=mock_result)
+        MockAgent.return_value = mock_agent_instance
+
+        await provider.run(request)
+
+        call_kwargs = mock_agent_instance.run.call_args.kwargs
+        assert call_kwargs["model_settings"] == {"temperature": 0.3, "max_tokens": 512}
+
+
+def test_engine_builds_request_with_extra():
+    """engine.py should put non-temperature/max_tokens keys into request.extra."""
+    from t01_llm_battle.providers.base import ProviderRequest
+
+    # Simulate what engine.py does when parsing provider_config
+    provider_config = json.dumps({
+        "temperature": 0.8,
+        "max_tokens": 1024,
+        "top_p": 0.95,
+        "tools": ["web_search"],
+        "system_prompt_role": "developer",
+    })
+
+    config = json.loads(provider_config)
+    temperature = config.pop("temperature", 0.7)
+    max_tokens = config.pop("max_tokens", 2048)
+    extra = config  # all remaining keys
+
+    request = ProviderRequest(
+        model="gpt-4o",
+        system_prompt=None,
+        user_prompt="test",
+        temperature=temperature,
+        max_tokens=max_tokens,
+        extra=extra,
+    )
+
+    assert request.temperature == 0.8
+    assert request.max_tokens == 1024
+    assert request.extra["top_p"] == 0.95
+    assert request.extra["tools"] == ["web_search"]
+    assert request.extra["system_prompt_role"] == "developer"
+    assert "temperature" not in request.extra
+    assert "max_tokens" not in request.extra


### PR DESCRIPTION
## Summary

- In `engine.py`: after popping `temperature` and `max_tokens`, all remaining `provider_config` keys are put into `ProviderRequest.extra` and passed to providers
- In all 6 LLM providers (openai, anthropic, google, groq, openrouter, ollama): `model_settings` now includes `temperature`, `max_tokens`, and `top_p` (from `extra` when present); unknown keys in `extra` are silently ignored for forward-compatibility
- Added `tests/test_provider_config_passthrough.py` covering: `top_p` forwarding, unknown key tolerance, default model_settings shape, and the engine's config parsing logic

Closes #85

## Test plan
- [ ] `python -m pytest tests/ -x -q` — all tests pass
- [ ] Manually verify: create a step with `{"temperature": 0.5, "top_p": 0.9, "tools": ["web_search"]}` — `top_p` forwarded, `tools` in `extra` (no crash), `temperature`/`max_tokens` in model_settings

🤖 Generated with [Claude Code](https://claude.com/claude-code)