### PR TITLE
feat: parallel run execution across fighters x sources (FR-10)

### DIFF
--- a/t01_llm_battle/engine.py
+++ b/t01_llm_battle/engine.py
@@ -36,8 +36,175 @@ async def _inject_api_key(provider_name: str, db_path) -> str | None:
     return None
 
 
+async def _execute_pair(
+    run_id: str,
+    fighter: dict,
+    steps: list[dict],
+    source: dict,
+    judge_provider: str | None,
+    judge_model: str | None,
+    judge_rubric: str | None,
+    db_path,
+) -> bool:
+    """Execute one fighter x source pair. Returns True if successful (not errored)."""
+    import os
+
+    fighter_id = fighter["id"]
+    is_manual = fighter["is_manual"]
+    source_id = source["id"]
+    source_content = source["content"]
+
+    fr_id = str(uuid.uuid4())
+    fr_now = datetime.now(timezone.utc).isoformat()
+
+    if is_manual:
+        async with get_db(db_path) as db:
+            await db.execute(
+                "INSERT INTO fighter_result "
+                "(id, run_id, fighter_id, source_id, status, created_at) "
+                "VALUES (?, ?, ?, ?, ?, ?)",
+                (fr_id, run_id, fighter_id, source_id, "awaiting_input", fr_now),
+            )
+            await db.commit()
+        return True  # manual is not an error
+
+    # Mark fighter_result as running
+    async with get_db(db_path) as db:
+        await db.execute(
+            "INSERT INTO fighter_result "
+            "(id, run_id, fighter_id, source_id, status, created_at) "
+            "VALUES (?, ?, ?, ?, ?, ?)",
+            (fr_id, run_id, fighter_id, source_id, "running", fr_now),
+        )
+        await db.commit()
+
+    # Execute steps sequentially within this fighter
+    step_input = source_content
+    had_error = False
+    total_cost: float = 0.0
+    total_latency: int = 0
+    total_input_tokens: int = 0
+    total_output_tokens: int = 0
+    final_output: str | None = None
+
+    for step in steps:
+        step_id = step["id"]
+        sr_id = str(uuid.uuid4())
+        sr_now = datetime.now(timezone.utc).isoformat()
+
+        try:
+            provider = get_provider(step["provider"])
+
+            config = json.loads(step["provider_config"]) if step["provider_config"] else {}
+            temperature = config.pop("temperature", 0.7)
+            max_tokens = config.pop("max_tokens", 2048)
+            extra = config
+
+            request = ProviderRequest(
+                model=step["model_id"],
+                system_prompt=step["system_prompt"] or "",
+                user_prompt=step_input,
+                temperature=temperature,
+                max_tokens=max_tokens,
+                extra=extra,
+            )
+
+            await rate_limiter.acquire(step["provider"])
+            injected_env_var = await _inject_api_key(step["provider"], db_path)
+            t0 = time.monotonic()
+            result: ProviderResult = await provider.run(request)
+            latency_ms = int((time.monotonic() - t0) * 1000)
+            if injected_env_var:
+                os.environ.pop(injected_env_var, None)
+
+            async with get_db(db_path) as db:
+                await db.execute(
+                    "INSERT INTO step_result "
+                    "(id, run_id, fighter_id, step_id, source_id, "
+                    "input_text, output_text, input_tokens, output_tokens, "
+                    "latency_ms, cost_usd, error, created_at) "
+                    "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                    (
+                        sr_id, run_id, fighter_id, step_id, source_id,
+                        step_input, result.content, result.input_tokens,
+                        result.output_tokens, latency_ms, result.cost_usd,
+                        result.error, sr_now,
+                    ),
+                )
+                await db.commit()
+
+            if result.error:
+                had_error = True
+                break
+
+            total_cost += result.cost_usd or 0.0
+            total_latency += latency_ms
+            total_input_tokens += result.input_tokens or 0
+            total_output_tokens += result.output_tokens or 0
+
+            step_input = result.content
+            final_output = result.content
+
+        except Exception as exc:
+            async with get_db(db_path) as db:
+                await db.execute(
+                    "INSERT INTO step_result "
+                    "(id, run_id, fighter_id, step_id, source_id, "
+                    "input_text, output_text, input_tokens, output_tokens, "
+                    "latency_ms, cost_usd, error, created_at) "
+                    "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                    (
+                        sr_id, run_id, fighter_id, step_id, source_id,
+                        step_input, None, None, None, None, None,
+                        str(exc), sr_now,
+                    ),
+                )
+                await db.commit()
+            had_error = True
+            break
+
+    # Update fighter_result
+    fr_status = "error" if had_error else "complete"
+    async with get_db(db_path) as db:
+        await db.execute(
+            "UPDATE fighter_result SET "
+            "status = ?, final_output = ?, total_cost_usd = ?, "
+            "total_latency_ms = ?, total_input_tokens = ?, total_output_tokens = ? "
+            "WHERE id = ?",
+            (
+                fr_status, final_output, total_cost if total_cost else None,
+                total_latency if total_latency else None,
+                total_input_tokens if total_input_tokens else None,
+                total_output_tokens if total_output_tokens else None,
+                fr_id,
+            ),
+        )
+        await db.commit()
+
+    # Run judge scoring for completed results
+    if not had_error and final_output and judge_provider and judge_model:
+        injected_judge_env_var = await _inject_api_key(judge_provider, db_path)
+        judge_score, judge_reasoning = await score_response(
+            judge_provider=judge_provider,
+            judge_model=judge_model,
+            judge_rubric=judge_rubric or "",
+            source_content=source_content,
+            response_content=final_output,
+        )
+        if injected_judge_env_var:
+            os.environ.pop(injected_judge_env_var, None)
+        async with get_db(db_path) as db:
+            await db.execute(
+                "UPDATE fighter_result SET judge_score = ?, judge_reasoning = ? WHERE id = ?",
+                (judge_score, judge_reasoning, fr_id),
+            )
+            await db.commit()
+
+    return not had_error
+
+
 async def execute_run(run_id: str, db_path=DB_PATH) -> None:
-    """Execute a run: for each fighter x source pair, run all steps sequentially."""
+    """Execute a run: all fighter x source pairs in parallel; steps sequential within each pair."""
 
     now = datetime.now(timezone.utc).isoformat()
 
@@ -84,187 +251,37 @@ async def execute_run(run_id: str, db_path=DB_PATH) -> None:
         )
         sources = [dict(r) for r in await cursor.fetchall()]
 
-    all_errored = True
-
+    # Pre-load steps for each fighter
+    fighter_steps: dict[str, list[dict]] = {}
     for fighter in fighters:
-        fighter_id = fighter["id"]
-        is_manual = fighter["is_manual"]
-
-        # Load steps for this fighter (ordered by position)
         async with get_db(db_path) as db:
             cursor = await db.execute(
                 "SELECT id, position, system_prompt, provider, model_id, provider_config "
                 "FROM fighter_step WHERE fighter_id = ? ORDER BY position",
-                (fighter_id,),
+                (fighter["id"],),
             )
-            steps = [dict(r) for r in await cursor.fetchall()]
+            fighter_steps[fighter["id"]] = [dict(r) for r in await cursor.fetchall()]
 
-        for source in sources:
-            source_id = source["id"]
-            source_content = source["content"]
+    # Build all fighter x source tasks and run them in parallel
+    tasks = [
+        _execute_pair(
+            run_id=run_id,
+            fighter=fighter,
+            steps=fighter_steps[fighter["id"]],
+            source=source,
+            judge_provider=judge_provider,
+            judge_model=judge_model,
+            judge_rubric=judge_rubric,
+            db_path=db_path,
+        )
+        for fighter in fighters
+        for source in sources
+    ]
 
-            # Create fighter_result row
-            fr_id = str(uuid.uuid4())
-            fr_now = datetime.now(timezone.utc).isoformat()
+    results = await asyncio.gather(*tasks, return_exceptions=True)
 
-            if is_manual:
-                # Manual fighters enter awaiting_input status
-                async with get_db(db_path) as db:
-                    await db.execute(
-                        "INSERT INTO fighter_result "
-                        "(id, run_id, fighter_id, source_id, status, created_at) "
-                        "VALUES (?, ?, ?, ?, ?, ?)",
-                        (fr_id, run_id, fighter_id, source_id, "awaiting_input", fr_now),
-                    )
-                    await db.commit()
-                all_errored = False
-                continue
-
-            # Mark fighter_result as running
-            async with get_db(db_path) as db:
-                await db.execute(
-                    "INSERT INTO fighter_result "
-                    "(id, run_id, fighter_id, source_id, status, created_at) "
-                    "VALUES (?, ?, ?, ?, ?, ?)",
-                    (fr_id, run_id, fighter_id, source_id, "running", fr_now),
-                )
-                await db.commit()
-
-            # Execute steps sequentially
-            step_input = source_content
-            had_error = False
-            total_cost: float = 0.0
-            total_latency: int = 0
-            total_input_tokens: int = 0
-            total_output_tokens: int = 0
-            final_output: str | None = None
-
-            for step in steps:
-                step_id = step["id"]
-                sr_id = str(uuid.uuid4())
-                sr_now = datetime.now(timezone.utc).isoformat()
-
-                try:
-                    provider = get_provider(step["provider"])
-
-                    # Parse provider_config
-                    config = json.loads(step["provider_config"]) if step["provider_config"] else {}
-                    temperature = config.pop("temperature", 0.7)
-                    max_tokens = config.pop("max_tokens", 2048)
-                    # All remaining keys are passed through to the provider via extra
-                    extra = config
-
-                    request = ProviderRequest(
-                        model=step["model_id"],
-                        system_prompt=step["system_prompt"] or "",
-                        user_prompt=step_input,
-                        temperature=temperature,
-                        max_tokens=max_tokens,
-                        extra=extra,
-                    )
-
-                    await rate_limiter.acquire(step["provider"])
-                    # Inject DB key into env if env var not already set
-                    injected_env_var = await _inject_api_key(step["provider"], db_path)
-                    t0 = time.monotonic()
-                    result: ProviderResult = await provider.run(request)
-                    latency_ms = int((time.monotonic() - t0) * 1000)
-                    # Remove injected env var so it doesn't persist across steps
-                    if injected_env_var:
-                        import os
-                        os.environ.pop(injected_env_var, None)
-
-                    # Store step_result
-                    async with get_db(db_path) as db:
-                        await db.execute(
-                            "INSERT INTO step_result "
-                            "(id, run_id, fighter_id, step_id, source_id, "
-                            "input_text, output_text, input_tokens, output_tokens, "
-                            "latency_ms, cost_usd, error, created_at) "
-                            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
-                            (
-                                sr_id, run_id, fighter_id, step_id, source_id,
-                                step_input, result.content, result.input_tokens,
-                                result.output_tokens, latency_ms, result.cost_usd,
-                                result.error, sr_now,
-                            ),
-                        )
-                        await db.commit()
-
-                    # If the provider returned an error in the result
-                    if result.error:
-                        had_error = True
-                        break
-
-                    # Accumulate totals
-                    total_cost += result.cost_usd or 0.0
-                    total_latency += latency_ms
-                    total_input_tokens += result.input_tokens or 0
-                    total_output_tokens += result.output_tokens or 0
-
-                    # Next step input = this step's output
-                    step_input = result.content
-                    final_output = result.content
-
-                except Exception as exc:
-                    # Store error step_result
-                    async with get_db(db_path) as db:
-                        await db.execute(
-                            "INSERT INTO step_result "
-                            "(id, run_id, fighter_id, step_id, source_id, "
-                            "input_text, output_text, input_tokens, output_tokens, "
-                            "latency_ms, cost_usd, error, created_at) "
-                            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
-                            (
-                                sr_id, run_id, fighter_id, step_id, source_id,
-                                step_input, None, None, None, None, None,
-                                str(exc), sr_now,
-                            ),
-                        )
-                        await db.commit()
-                    had_error = True
-                    break
-
-            # Update fighter_result
-            fr_status = "error" if had_error else "complete"
-            async with get_db(db_path) as db:
-                await db.execute(
-                    "UPDATE fighter_result SET "
-                    "status = ?, final_output = ?, total_cost_usd = ?, "
-                    "total_latency_ms = ?, total_input_tokens = ?, total_output_tokens = ? "
-                    "WHERE id = ?",
-                    (
-                        fr_status, final_output, total_cost if total_cost else None,
-                        total_latency if total_latency else None,
-                        total_input_tokens if total_input_tokens else None,
-                        total_output_tokens if total_output_tokens else None,
-                        fr_id,
-                    ),
-                )
-                await db.commit()
-
-            if not had_error:
-                all_errored = False
-
-            # Run judge scoring for completed results with a final output
-            if not had_error and final_output and judge_provider and judge_model:
-                injected_judge_env_var = await _inject_api_key(judge_provider, db_path)
-                judge_score, judge_reasoning = await score_response(
-                    judge_provider=judge_provider,
-                    judge_model=judge_model,
-                    judge_rubric=judge_rubric or "",
-                    source_content=source_content,
-                    response_content=final_output,
-                )
-                if injected_judge_env_var:
-                    import os
-                    os.environ.pop(injected_judge_env_var, None)
-                async with get_db(db_path) as db:
-                    await db.execute(
-                        "UPDATE fighter_result SET judge_score = ?, judge_reasoning = ? WHERE id = ?",
-                        (judge_score, judge_reasoning, fr_id),
-                    )
-                    await db.commit()
+    # all_errored if every result was False or an exception
+    all_errored = all(r is not True for r in results)
 
     # Mark run as complete (or error if ALL fighter_results errored)
     finished_at = datetime.now(timezone.utc).isoformat()
@@ -278,10 +295,10 @@ async def execute_run(run_id: str, db_path=DB_PATH) -> None:
 
     # Generate markdown report after all judging is complete
     if judge_provider and judge_model:
+        import os
         injected_report_env_var = await _inject_api_key(judge_provider, db_path)
         await generate_report(run_id, judge_provider, judge_model, db_path)
         if injected_report_env_var:
-            import os
             os.environ.pop(injected_report_env_var, None)
 
 


### PR DESCRIPTION
## Summary

- Extracted `_execute_pair` coroutine that handles one fighter × source pair (sequential steps within)
- Replaced nested `for fighter / for source` loops in `execute_run` with `asyncio.gather(*tasks)` to run all pairs in parallel
- Pre-loads all fighter steps before launching tasks; `all_errored` logic updated to work with gathered results

## Test plan

- [ ] Existing import check passes (`python -c "import t01_llm_battle.engine"`)
- [ ] Manual smoke test: start a battle with 2+ fighters and 2+ sources, confirm results arrive concurrently
- [ ] Error in one pair should not block others; run status reflects overall outcome

Closes #87

🤖 Generated with [Claude Code](https://claude.com/claude-code)