### PR TITLE
fix: CLI default port 7700 → 7878 (FR-1)

### DIFF
--- a/t01_llm_battle/cli.py
+++ b/t01_llm_battle/cli.py
@@ -6,7 +6,7 @@ app = typer.Typer(help="LLM Battle Arena — compare LLMs side by side.")
 
 @app.command()
 def serve(
-    port: int = typer.Option(7700, help="Port to listen on"),
+    port: int = typer.Option(7878, help="Port to listen on"),
     no_browser: bool = typer.Option(False, "--no-browser", help="Don't open browser"),
 ) -> None:
     """Start the LLM Battle server."""


### PR DESCRIPTION
## Summary

- Changes default port in `cli.py` from `7700` to `7878` as specified in PRD FR-1
- Single-line fix; no other behavior changes

Closes #102

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>