### PR TITLE
fix: add env var mappings for tool providers (serper, tavily, firecrawl)

### DIFF
--- a/t01_llm_battle/db.py
+++ b/t01_llm_battle/db.py
@@ -125,6 +125,9 @@ _PROVIDER_ENV_VARS: dict[str, str] = {
     "google": "GOOGLE_API_KEY",
     "groq": "GROQ_API_KEY",
     "openrouter": "OPENROUTER_API_KEY",
+    "serper": "SERPER_API_KEY",
+    "tavily": "TAVILY_API_KEY",
+    "firecrawl": "FIRECRAWL_API_KEY",
 }
 
 


### PR DESCRIPTION
## Summary

- Adds `serper`, `tavily`, `firecrawl` to `_PROVIDER_ENV_VARS` in `db.py`
- Fixes `resolve_api_key` silently ignoring `SERPER_API_KEY`, `TAVILY_API_KEY`, `FIRECRAWL_API_KEY` env vars
- No schema or API changes

Closes #104

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>