### PR TITLE
feat: provider management API — enable/disable, config editing, uninstall

### DIFF
--- a/t01_llm_battle/db.py
+++ b/t01_llm_battle/db.py
@@ -94,6 +94,13 @@ CREATE TABLE IF NOT EXISTS api_key (
     key_value   TEXT NOT NULL,
     updated_at  TEXT NOT NULL
 );
+
+CREATE TABLE IF NOT EXISTS provider_config (
+    provider    TEXT PRIMARY KEY,
+    enabled     INTEGER NOT NULL DEFAULT 1,
+    server_url  TEXT,
+    updated_at  TEXT NOT NULL
+);
 """
 
 

--- a/t01_llm_battle/routers/fighters.py
+++ b/t01_llm_battle/routers/fighters.py
@@ -19,9 +19,14 @@ from typing import Any
 from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel
 
-from ..db import get_db
+from ..db import get_db, DB_PATH
 from ..providers.registry import list_providers, get_provider
 from ..providers.base import ProviderType, TokenPricing, CreditPricing
+
+_SYSTEM_PROVIDERS = {
+    "openai", "anthropic", "google", "groq",
+    "openrouter", "ollama", "serper", "tavily", "firecrawl",
+}
 
 router = APIRouter(prefix="/battles/{battle_id}/fighters", tags=["fighters"])
 
@@ -246,6 +251,9 @@ class ProviderInfo(BaseModel):
     provider_type: str  # "llm" or "tool"
     models: list[ProviderModelInfo]
     native_tools: list[str]  # only for LLM providers; empty list for tool providers
+    enabled: bool = True
+    is_system: bool = True
+    config: dict = {}
 
 
 def _build_provider_info(name: str) -> ProviderInfo | None:
@@ -299,11 +307,27 @@ def _build_provider_info(name: str) -> ProviderInfo | None:
 
 @providers_router.get("", response_model=list[ProviderInfo])
 async def list_provider_info() -> list[ProviderInfo]:
-    """Return all registered providers with type, models/functions, and pricing."""
+    """Return all registered providers with type, models/functions, pricing, enabled state, and config."""
     names = list_providers()
+
+    # Fetch all provider_config rows in one query
+    provider_configs: dict[str, dict] = {}
+    async with get_db(DB_PATH) as db:
+        cur = await db.execute("SELECT provider, enabled, server_url FROM provider_config")
+        rows = await cur.fetchall()
+        for row in rows:
+            provider_configs[row["provider"]] = {
+                "enabled": bool(row["enabled"]),
+                "server_url": row["server_url"],
+            }
+
     result = []
     for name in names:
         info = _build_provider_info(name)
         if info:
+            cfg = provider_configs.get(name, {"enabled": True, "server_url": None})
+            info.enabled = cfg["enabled"]
+            info.is_system = name in _SYSTEM_PROVIDERS
+            info.config = {"server_url": cfg["server_url"]} if cfg["server_url"] else {}
             result.append(info)
     return result

--- a/t01_llm_battle/routers/providers.py
+++ b/t01_llm_battle/routers/providers.py
@@ -1,0 +1,100 @@
+"""
+Provider management API.
+
+PATCH  /providers/{name}        — toggle enabled/disabled
+PUT    /providers/{name}/config — update server_url or other config
+DELETE /providers/{name}        — uninstall non-system provider (403 for system)
+"""
+from datetime import datetime, timezone
+
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel
+
+from ..db import get_db
+from ..providers.registry import list_providers, get_provider
+
+router = APIRouter(prefix="/providers", tags=["providers"])
+
+# Built-in (system) providers — cannot be uninstalled
+_SYSTEM_PROVIDERS = {
+    "openai", "anthropic", "google", "groq",
+    "openrouter", "ollama", "serper", "tavily", "firecrawl",
+}
+
+# Providers that support a configurable server_url
+_SERVER_URL_PROVIDERS = {"ollama"}
+
+
+class ProviderPatch(BaseModel):
+    enabled: bool
+
+
+class ProviderConfigUpdate(BaseModel):
+    server_url: str | None = None
+
+
+async def _get_provider_config(db, name: str) -> dict:
+    cur = await db.execute(
+        "SELECT enabled, server_url FROM provider_config WHERE provider = ?", (name,)
+    )
+    row = await cur.fetchone()
+    if row:
+        return {"enabled": bool(row["enabled"]), "server_url": row["server_url"]}
+    return {"enabled": True, "server_url": None}
+
+
+@router.patch("/{name}")
+async def toggle_provider(name: str, body: ProviderPatch):
+    """Enable or disable a provider."""
+    if name not in list_providers():
+        raise HTTPException(status_code=404, detail=f"Unknown provider: {name}")
+
+    now = datetime.now(timezone.utc).isoformat()
+    async with get_db() as db:
+        await db.execute(
+            """INSERT INTO provider_config (provider, enabled, updated_at)
+               VALUES (?, ?, ?)
+               ON CONFLICT(provider) DO UPDATE SET enabled = excluded.enabled, updated_at = excluded.updated_at""",
+            (name, int(body.enabled), now),
+        )
+        await db.commit()
+    return {"provider": name, "enabled": body.enabled}
+
+
+@router.put("/{name}/config")
+async def update_provider_config(name: str, body: ProviderConfigUpdate):
+    """Update provider-specific config (e.g. server_url for Ollama)."""
+    if name not in list_providers():
+        raise HTTPException(status_code=404, detail=f"Unknown provider: {name}")
+
+    now = datetime.now(timezone.utc).isoformat()
+    async with get_db() as db:
+        existing = await _get_provider_config(db, name)
+        server_url = body.server_url if body.server_url is not None else existing["server_url"]
+        await db.execute(
+            """INSERT INTO provider_config (provider, enabled, server_url, updated_at)
+               VALUES (?, ?, ?, ?)
+               ON CONFLICT(provider) DO UPDATE SET server_url = excluded.server_url, updated_at = excluded.updated_at""",
+            (name, int(existing["enabled"]), server_url, now),
+        )
+        await db.commit()
+    return {"provider": name, "server_url": server_url}
+
+
+@router.delete("/{name}", status_code=204, response_model=None)
+async def uninstall_provider(name: str):
+    """Uninstall a non-system provider. Returns 403 for system providers."""
+    if name in _SYSTEM_PROVIDERS:
+        raise HTTPException(status_code=403, detail=f"Cannot uninstall system provider: {name}")
+    if name not in list_providers():
+        raise HTTPException(status_code=404, detail=f"Unknown provider: {name}")
+    # For user-installed providers, just mark as disabled (no registry mutation at runtime)
+    now = datetime.now(timezone.utc).isoformat()
+    async with get_db() as db:
+        await db.execute(
+            """INSERT INTO provider_config (provider, enabled, updated_at)
+               VALUES (?, 0, ?)
+               ON CONFLICT(provider) DO UPDATE SET enabled = 0, updated_at = excluded.updated_at""",
+            (name, now),
+        )
+        await db.commit()

--- a/t01_llm_battle/server.py
+++ b/t01_llm_battle/server.py
@@ -10,6 +10,7 @@ from .routers.keys import router as keys_router
 from .routers.runs import router as runs_router
 from .routers.sources import router as sources_router
 from .routers.fighters import router as fighters_router, providers_router
+from .routers.providers import router as provider_mgmt_router
 
 
 @asynccontextmanager
@@ -27,6 +28,7 @@ def create_app(db_path=DB_PATH) -> FastAPI:
     app.include_router(sources_router)
     app.include_router(fighters_router)
     app.include_router(providers_router)
+    app.include_router(provider_mgmt_router)
 
     # Health check
     @app.get("/healthz")

--- a/tests/test_providers_router.py
+++ b/tests/test_providers_router.py
@@ -1,0 +1,120 @@
+"""Tests for provider management API: PATCH/PUT/DELETE /providers/{name}."""
+import pytest
+from httpx import AsyncClient, ASGITransport
+from contextlib import asynccontextmanager
+from pathlib import Path
+
+import t01_llm_battle.db as db_module
+import t01_llm_battle.routers.runs as runs_module
+import t01_llm_battle.routers.sources as sources_module
+import t01_llm_battle.routers.providers as providers_module
+import t01_llm_battle.routers.fighters as fighters_module
+from t01_llm_battle.db import init_db, get_db
+from t01_llm_battle.server import create_app
+
+
+@pytest.fixture
+async def db_path(tmp_path):
+    path = str(tmp_path / "test.db")
+    await init_db(path)
+    return path
+
+
+@pytest.fixture
+async def client(db_path, monkeypatch):
+    _db_path = db_path
+
+    @asynccontextmanager
+    async def _get_db_override(path=None):
+        async with get_db(_db_path) as db:
+            yield db
+
+    monkeypatch.setattr(db_module, "DB_PATH", Path(_db_path))
+    monkeypatch.setattr(runs_module, "get_db", _get_db_override)
+    monkeypatch.setattr(sources_module, "get_db", _get_db_override)
+    monkeypatch.setattr(providers_module, "get_db", _get_db_override)
+    monkeypatch.setattr(fighters_module, "DB_PATH", Path(_db_path))
+
+    app = create_app(db_path=db_path)
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        yield c
+
+
+@pytest.mark.asyncio
+async def test_patch_provider_disable(client):
+    """PATCH /providers/openai disables the provider."""
+    r = await client.patch("/providers/openai", json={"enabled": False})
+    assert r.status_code == 200
+    data = r.json()
+    assert data["provider"] == "openai"
+    assert data["enabled"] is False
+
+
+@pytest.mark.asyncio
+async def test_patch_provider_enable(client):
+    """PATCH /providers/openai can re-enable after disabling."""
+    await client.patch("/providers/openai", json={"enabled": False})
+    r = await client.patch("/providers/openai", json={"enabled": True})
+    assert r.status_code == 200
+    assert r.json()["enabled"] is True
+
+
+@pytest.mark.asyncio
+async def test_patch_unknown_provider_404(client):
+    """PATCH /providers/unknown returns 404."""
+    r = await client.patch("/providers/does-not-exist", json={"enabled": False})
+    assert r.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_put_provider_config_server_url(client):
+    """PUT /providers/ollama/config sets server_url."""
+    r = await client.put("/providers/ollama/config", json={"server_url": "http://localhost:11434"})
+    assert r.status_code == 200
+    assert r.json()["server_url"] == "http://localhost:11434"
+
+
+@pytest.mark.asyncio
+async def test_put_provider_config_unknown_404(client):
+    """PUT /providers/unknown/config returns 404."""
+    r = await client.put("/providers/unknown/config", json={"server_url": "http://x"})
+    assert r.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_delete_system_provider_403(client):
+    """DELETE /providers/openai returns 403 — system provider."""
+    r = await client.delete("/providers/openai")
+    assert r.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_delete_unknown_provider_404(client):
+    """DELETE /providers/unknown returns 404."""
+    r = await client.delete("/providers/does-not-exist")
+    assert r.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_get_providers_includes_enabled_and_is_system(client):
+    """GET /providers returns enabled and is_system fields."""
+    r = await client.get("/providers")
+    assert r.status_code == 200
+    providers = r.json()
+    assert len(providers) > 0
+    openai = next((p for p in providers if p["name"] == "openai"), None)
+    assert openai is not None
+    assert "enabled" in openai
+    assert "is_system" in openai
+    assert "config" in openai
+    assert openai["is_system"] is True
+    assert openai["enabled"] is True  # default
+
+
+@pytest.mark.asyncio
+async def test_get_providers_reflects_disabled_state(client):
+    """GET /providers reflects disabled state after PATCH."""
+    await client.patch("/providers/openai", json={"enabled": False})
+    r = await client.get("/providers")
+    openai = next(p for p in r.json() if p["name"] == "openai")
+    assert openai["enabled"] is False


### PR DESCRIPTION
## Summary

- Adds `provider_config` table to SQLite schema (`enabled`, `server_url`, `updated_at`)
- Adds `PATCH /providers/{name}` to toggle enabled/disabled state, persisted in DB
- Adds `PUT /providers/{name}/config` to update provider-specific config (e.g. `server_url` for Ollama)
- Adds `DELETE /providers/{name}` — returns 403 for system providers, 404 for unknown
- Extends `GET /providers` to include `enabled`, `is_system`, and `config` fields
- 9 new pytest tests covering all acceptance criteria

Closes #108

## Test plan
- [x] `pytest tests/test_providers_router.py` — all 9 pass
- [x] `pytest tests/` — all 53 pass
- [x] `PATCH /providers/openai` with `{"enabled": false}` → 200
- [x] `DELETE /providers/openai` → 403 (system provider)
- [x] `DELETE /providers/unknown` → 404
- [x] `PUT /providers/ollama/config` with `{"server_url": "http://localhost:11434"}` → 200
- [x] `GET /providers` includes `enabled`, `is_system`, `config` fields