### PR TITLE
feat: sidebar + Gold-on-Ink dark theme layout (FR-20)

### DIFF
--- a/t01_llm_battle/static/index.html
+++ b/t01_llm_battle/static/index.html
@@ -3,882 +3,1056 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>LLM Battle Arena</title>
+  <title>T01 LLM Battle</title>
   <link rel="stylesheet" href="/vendor/easymde.min.css">
   <style>
     *, *::before, *::after { box-sizing: border-box; }
 
-    body {
+    :root {
+      --ink:       #0d0f13;
+      --card:      #14181f;
+      --border:    #1e2430;
+      --gold:      #F0B90B;
+      --gold-dim:  #c49a09;
+      --high:      #E7ECF3;
+      --mid:       #8A93A3;
+      --low:       #3d4657;
+      --danger:    #e05252;
+      --success:   #27ae60;
+    }
+
+    html, body {
       margin: 0;
+      height: 100%;
       font-family: system-ui, -apple-system, sans-serif;
       font-size: 15px;
-      color: #1a1a1a;
-      background: #f5f5f5;
+      color: var(--high);
+      background: var(--ink);
     }
 
-    nav {
-      background: #1a1a2e;
-      color: #fff;
-      padding: 0 1.5rem;
+    .app-shell {
       display: flex;
-      align-items: center;
-      gap: 2rem;
-      height: 52px;
+      height: 100vh;
+      overflow: hidden;
     }
 
-    nav .brand {
+    /* ── Sidebar ──────────────────────────────────── */
+    .sidebar {
+      width: 260px;
+      min-width: 260px;
+      background: var(--card);
+      border-right: 1px solid var(--border);
+      display: flex;
+      flex-direction: column;
+      overflow: hidden;
+    }
+
+    .sidebar-brand {
+      padding: 1.1rem 1rem 0.9rem;
+      font-size: 1rem;
       font-weight: 700;
-      font-size: 1.05rem;
       letter-spacing: -0.01em;
-      color: #fff;
-      text-decoration: none;
+      color: var(--gold);
+      border-bottom: 1px solid var(--border);
+      flex-shrink: 0;
     }
 
-    nav a {
-      color: #c8c8e8;
-      text-decoration: none;
-      font-size: 0.9rem;
-      padding: 4px 0;
-      border-bottom: 2px solid transparent;
-      transition: color 0.15s, border-color 0.15s;
+    .sidebar-battles {
+      flex: 1;
+      overflow-y: auto;
+      padding: 0.6rem 0.5rem;
     }
 
-    nav a:hover { color: #fff; }
-    nav a.active { color: #fff; border-bottom-color: #7c6af7; }
-
-    main {
-      max-width: 960px;
-      margin: 0 auto;
-      padding: 2rem 1.5rem;
-    }
-
-    h1 { font-size: 1.5rem; margin: 0 0 1.25rem; }
-    h2 { font-size: 1.15rem; margin: 0 0 1rem; }
-
-    .placeholder {
-      background: #e8e8f0;
-      border-radius: 8px;
-      height: 180px;
+    .sidebar-section-header {
       display: flex;
       align-items: center;
-      justify-content: center;
-      color: #888;
+      justify-content: space-between;
+      padding: 0 0.5rem;
+      margin-bottom: 0.4rem;
+    }
+
+    .sidebar-section-title {
+      font-size: 0.7rem;
+      font-weight: 700;
+      text-transform: uppercase;
+      letter-spacing: 0.07em;
+      color: var(--low);
+    }
+
+    .btn-sidebar-new {
+      background: none;
+      border: 1px solid var(--border);
+      color: var(--mid);
+      font-size: 0.75rem;
+      font-weight: 600;
+      padding: 2px 8px;
+      border-radius: 4px;
+      cursor: pointer;
+      transition: border-color 0.12s, color 0.12s;
+    }
+    .btn-sidebar-new:hover { border-color: var(--gold); color: var(--gold); }
+
+    .battle-item {
+      display: flex;
+      align-items: center;
+      padding: 6px 8px;
+      border-radius: 6px;
+      cursor: pointer;
+      gap: 0.4rem;
+      transition: background 0.1s;
+    }
+    .battle-item:hover { background: var(--border); }
+    .battle-item.active { background: rgba(240,185,11,0.1); }
+
+    .battle-item-name {
+      flex: 1;
+      font-size: 0.86rem;
+      color: var(--high);
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+    .battle-item.active .battle-item-name { color: var(--gold); font-weight: 600; }
+
+    .btn-delete-battle {
+      background: none;
+      border: none;
+      color: var(--low);
+      font-size: 1rem;
+      line-height: 1;
+      cursor: pointer;
+      padding: 1px 4px;
+      border-radius: 3px;
+      flex-shrink: 0;
+      opacity: 0;
+      transition: opacity 0.1s, color 0.1s;
+    }
+    .battle-item:hover .btn-delete-battle { opacity: 1; }
+    .btn-delete-battle:hover { color: var(--danger); }
+
+    .sidebar-footer {
+      border-top: 1px solid var(--border);
+      padding: 0.6rem 0.5rem;
+      flex-shrink: 0;
+    }
+    .sidebar-footer a {
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
+      padding: 6px 8px;
+      border-radius: 6px;
+      color: var(--mid);
+      text-decoration: none;
+      font-size: 0.86rem;
+      transition: background 0.1s, color 0.1s;
+    }
+    .sidebar-footer a:hover { background: var(--border); color: var(--high); }
+    .sidebar-footer a.active { color: var(--gold); }
+
+    /* ── Main content ─────────────────────────────── */
+    .main-content {
+      flex: 1;
+      overflow-y: auto;
+      padding: 2rem 2.5rem;
+      background: var(--ink);
+    }
+
+    h1 { font-size: 1.35rem; margin: 0 0 1.25rem; color: var(--high); font-weight: 700; letter-spacing: -0.01em; }
+    h2 { font-size: 1.05rem; margin: 0 0 0.9rem; color: var(--high); font-weight: 600; }
+    h3 { font-size: 0.95rem; margin: 0 0 0.75rem; color: var(--high); font-weight: 600; }
+
+    label {
+      display: block;
+      font-weight: 600;
+      font-size: 0.83rem;
+      margin-bottom: 4px;
+      color: var(--mid);
+    }
+
+    input[type="text"], input[type="password"], select, textarea {
+      width: 100%;
+      background: rgba(0,0,0,0.3);
+      border: 1px solid var(--border);
+      color: var(--high);
+      border-radius: 6px;
+      padding: 8px 10px;
       font-size: 0.9rem;
-      border: 2px dashed #ccc;
-      margin-top: 1rem;
+      font-family: inherit;
+      transition: border-color 0.15s;
+    }
+    input:focus, select:focus, textarea:focus {
+      outline: none;
+      border-color: var(--gold);
+    }
+    select option { background: var(--card); }
+    input[type="file"] { background: none; border: none; padding: 0; color: var(--mid); font-size: 0.86rem; }
+
+    .card {
+      background: var(--card);
+      border: 1px solid var(--border);
+      border-radius: 8px;
+      padding: 1.25rem 1.5rem;
+      margin-bottom: 1.25rem;
     }
 
     .badge {
       display: inline-block;
-      background: #7c6af7;
-      color: #fff;
+      background: var(--gold);
+      color: #0d0f13;
       border-radius: 4px;
-      padding: 2px 8px;
-      font-size: 0.75rem;
-      margin-left: 0.5rem;
+      padding: 1px 7px;
+      font-size: 0.72rem;
+      font-weight: 700;
       vertical-align: middle;
+      margin-left: 0.4rem;
     }
+    .badge-muted {
+      display: inline-block;
+      background: var(--border);
+      color: var(--mid);
+      border-radius: 4px;
+      padding: 1px 7px;
+      font-size: 0.72rem;
+      font-weight: 600;
+      vertical-align: middle;
+      margin-left: 0.4rem;
+    }
+
+    .btn-primary {
+      background: var(--gold);
+      color: #0d0f13;
+      border: none;
+      padding: 8px 18px;
+      border-radius: 6px;
+      font-size: 0.88rem;
+      font-weight: 700;
+      cursor: pointer;
+      transition: background 0.15s;
+    }
+    .btn-primary:hover:not(:disabled) { background: var(--gold-dim); }
+    .btn-primary:disabled { opacity: 0.5; cursor: not-allowed; }
+
+    .btn-secondary {
+      background: none;
+      border: 1px solid var(--border);
+      color: var(--mid);
+      padding: 7px 14px;
+      border-radius: 6px;
+      font-size: 0.86rem;
+      cursor: pointer;
+      transition: border-color 0.15s, color 0.15s;
+    }
+    .btn-secondary:hover { border-color: var(--mid); color: var(--high); }
+
+    .btn-danger-sm {
+      background: none;
+      border: 1px solid rgba(224,82,82,0.35);
+      color: var(--danger);
+      padding: 3px 10px;
+      border-radius: 4px;
+      font-size: 0.8rem;
+      cursor: pointer;
+      transition: background 0.12s;
+    }
+    .btn-danger-sm:hover { background: rgba(224,82,82,0.1); }
+
+    .error-box {
+      background: rgba(224,82,82,0.08);
+      border: 1px solid rgba(224,82,82,0.3);
+      color: var(--danger);
+      border-radius: 6px;
+      padding: 9px 14px;
+      font-size: 0.86rem;
+      margin-bottom: 1rem;
+    }
+
+    .placeholder {
+      background: rgba(255,255,255,0.02);
+      border: 2px dashed var(--border);
+      border-radius: 8px;
+      height: 110px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      color: var(--mid);
+      font-size: 0.88rem;
+    }
+
+    .text-muted { color: var(--mid); }
+    .text-danger { color: var(--danger); }
+    .text-gold   { color: var(--gold); }
+
+    .form-grid-2 { display: grid; grid-template-columns: 1fr 1fr; gap: 1rem; }
+
+    .source-item {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      background: rgba(255,255,255,0.03);
+      border: 1px solid var(--border);
+      border-radius: 6px;
+      padding: 7px 12px;
+      margin-bottom: 6px;
+      font-size: 0.86rem;
+    }
+
+    .step-row {
+      background: rgba(255,255,255,0.02);
+      border: 1px solid var(--border);
+      border-radius: 5px;
+      padding: 5px 10px;
+      font-size: 0.82rem;
+      display: flex;
+      gap: 0.75rem;
+      align-items: center;
+      margin-bottom: 3px;
+    }
+
+    /* Tables */
+    .data-table { width: 100%; border-collapse: collapse; background: var(--card); border: 1px solid var(--border); border-radius: 8px; overflow: hidden; font-size: 0.86rem; }
+    .data-table th { padding: 10px 14px; text-align: left; font-size: 0.8rem; color: var(--mid); border-bottom: 1px solid var(--border); font-weight: 600; background: rgba(255,255,255,0.02); }
+    .data-table td { padding: 10px 14px; border-bottom: 1px solid var(--border); }
+    .data-table tr:last-child td { border-bottom: none; }
+
+    code { background: var(--border); color: var(--gold); padding: 2px 6px; border-radius: 3px; font-size: 0.83em; }
+
+    /* EasyMDE dark overrides */
+    .EasyMDEContainer .CodeMirror { background: rgba(0,0,0,0.3) !important; color: var(--high) !important; border-color: var(--border) !important; }
+    .editor-toolbar { background: var(--card) !important; border-color: var(--border) !important; }
+    .editor-toolbar a { color: var(--mid) !important; }
+    .editor-toolbar a:hover, .editor-toolbar a.active { color: var(--gold) !important; background: var(--border) !important; }
+    .editor-preview { background: var(--ink) !important; color: var(--high) !important; }
+
+    ::-webkit-scrollbar { width: 5px; height: 5px; }
+    ::-webkit-scrollbar-track { background: transparent; }
+    ::-webkit-scrollbar-thumb { background: var(--border); border-radius: 3px; }
   </style>
 </head>
 <body x-data="app()" x-init="init()">
 
-  <nav>
-    <a href="#/battles" class="brand">LLM Battle Arena</a>
-    <a href="#/battles"
-       :class="{ active: route === 'battles' || route === 'battles/new' || route === 'battles/detail' }">
-      Battles
-    </a>
-    <a href="#/keys"
-       :class="{ active: route === 'keys' }">
-      API Keys
-    </a>
-  </nav>
+  <div class="app-shell">
 
-  <main>
+    <!-- ── Sidebar ─────────────────────────────────── -->
+    <aside class="sidebar"
+           x-data="sidebarData()"
+           x-init="load()"
+           @battle-created.window="load()"
+           @battle-deleted.window="load()">
 
-    <!-- View: battles list -->
-    <section x-show="route === 'battles'" x-data="battlesList()" x-init="load()">
-      <div style="display:flex; align-items:center; justify-content:space-between; margin-bottom:1.25rem;">
-        <h1 style="margin:0;">Battles</h1>
-        <a href="#/battles/new" style="background:#7c6af7;color:#fff;padding:8px 16px;border-radius:6px;text-decoration:none;font-size:0.9rem;font-weight:600;">+ New Battle</a>
+      <div class="sidebar-brand">T01 LLM Battle</div>
+
+      <div class="sidebar-battles">
+        <div class="sidebar-section-header">
+          <span class="sidebar-section-title">Battles</span>
+          <button class="btn-sidebar-new" @click="$root.navigate('/battles/new')">+ New</button>
+        </div>
+
+        <template x-if="loading">
+          <p class="text-muted" style="font-size:0.82rem;padding:4px 8px;">Loading...</p>
+        </template>
+
+        <template x-if="!loading && battles.length === 0">
+          <p class="text-muted" style="font-size:0.82rem;padding:4px 8px;">No battles yet.</p>
+        </template>
+
+        <template x-for="b in battles" :key="b.id">
+          <div class="battle-item"
+               :class="{ active: $root.params.id === b.id }"
+               @click="$root.navigate('/battles/' + b.id)">
+            <span class="battle-item-name" x-text="b.name"></span>
+            <button class="btn-delete-battle" title="Delete"
+                    @click.stop="deleteBattle(b.id, $root)">×</button>
+          </div>
+        </template>
       </div>
 
-      <template x-if="loading">
-        <p style="color:#888;">Loading...</p>
-      </template>
+      <div class="sidebar-footer">
+        <a href="#/keys" :class="{ active: $root.route === 'keys' }">
+          <span>🔑</span> API Keys
+        </a>
+      </div>
+    </aside>
 
-      <template x-if="!loading && battles.length === 0">
-        <div class="placeholder">
-          No battles yet. <a href="#/battles/new" style="color:#7c6af7;">Create your first battle</a> to get started.
+    <!-- ── Main content ────────────────────────────── -->
+    <main class="main-content">
+
+      <!-- Empty state when no battle selected -->
+      <section x-show="route === 'battles'" style="height:70%;display:flex;align-items:center;justify-content:center;">
+        <div style="text-align:center;">
+          <p class="text-muted" style="font-size:1rem;margin-bottom:1rem;">Select a battle from the sidebar or create a new one.</p>
+          <button class="btn-primary" @click="navigate('/battles/new')">+ New Battle</button>
         </div>
-      </template>
+      </section>
 
-      <template x-if="!loading && battles.length > 0">
-        <ul style="list-style:none;padding:0;margin:0;display:flex;flex-direction:column;gap:0.75rem;">
-          <template x-for="b in battles" :key="b.id">
-            <li style="background:#fff;border:1px solid #e0e0e0;border-radius:8px;padding:1rem 1.25rem;display:flex;align-items:center;justify-content:space-between;">
-              <div>
-                <a :href="'#/battles/' + b.id" style="font-weight:600;color:#1a1a2e;text-decoration:none;font-size:1rem;" x-text="b.name"></a>
-                <div style="font-size:0.8rem;color:#888;margin-top:2px;">
-                  <span x-text="b.judge_provider || '—'"></span> / <span x-text="b.judge_model || '—'"></span>
-                  &nbsp;·&nbsp; <span x-text="b.created_at ? new Date(b.created_at).toLocaleDateString() : ''"></span>
+      <!-- ── New battle form ─────────────────────── -->
+      <section x-show="route === 'battles/new'" x-data="battleForm()" x-init="init()">
+        <h1>New Battle</h1>
+
+        <form @submit.prevent="submit()" style="max-width:560px;display:flex;flex-direction:column;gap:1.1rem;">
+
+          <div>
+            <label for="bf-name">Battle Name <span class="text-danger">*</span></label>
+            <input id="bf-name" type="text" x-model="name" required placeholder="e.g. Summarisation quality test">
+          </div>
+
+          <div class="form-grid-2">
+            <div>
+              <label for="bf-provider">Judge Provider</label>
+              <select id="bf-provider" x-model="judge_provider" @change="onProviderChange()">
+                <template x-if="providers.length === 0">
+                  <option value="">Loading…</option>
+                </template>
+                <template x-for="p in providers" :key="p">
+                  <option :value="p" x-text="p"></option>
+                </template>
+              </select>
+            </div>
+            <div>
+              <label for="bf-model">Judge Model</label>
+              <input id="bf-model" type="text" x-model="judge_model"
+                :placeholder="modelPlaceholder()"
+                :list="'bf-model-suggestions-' + judge_provider">
+              <datalist id="bf-model-suggestions-openai">
+                <option value="gpt-4o"></option><option value="gpt-4o-mini"></option><option value="gpt-4-turbo"></option>
+              </datalist>
+              <datalist id="bf-model-suggestions-anthropic">
+                <option value="claude-opus-4-5"></option><option value="claude-sonnet-4-5"></option><option value="claude-haiku-3-5"></option>
+              </datalist>
+              <datalist id="bf-model-suggestions-google">
+                <option value="gemini-2.0-flash"></option><option value="gemini-1.5-pro"></option>
+              </datalist>
+              <datalist id="bf-model-suggestions-groq">
+                <option value="llama-3.3-70b-versatile"></option>
+              </datalist>
+              <datalist id="bf-model-suggestions-openrouter">
+                <option value="openai/gpt-4o"></option><option value="anthropic/claude-opus-4-5"></option>
+              </datalist>
+              <datalist id="bf-model-suggestions-ollama">
+                <option value="llama3.2"></option><option value="mistral"></option>
+              </datalist>
+            </div>
+          </div>
+
+          <div>
+            <label for="bf-rubric">Judge Rubric
+              <span style="font-weight:400;color:var(--low);">(optional — edit or replace the default)</span>
+            </label>
+            <textarea id="bf-rubric" x-ref="rubricTextarea" style="display:none;" x-model="judge_rubric"></textarea>
+          </div>
+
+          <template x-if="error">
+            <div class="error-box" x-text="error"></div>
+          </template>
+
+          <div style="display:flex;align-items:center;gap:1rem;">
+            <button type="submit" class="btn-primary" :disabled="loading">
+              <span x-text="loading ? 'Creating...' : 'Create Battle'"></span>
+            </button>
+            <a href="#/battles" class="text-muted" style="text-decoration:none;font-size:0.88rem;">Cancel</a>
+          </div>
+
+        </form>
+      </section>
+
+      <!-- ── Battle detail ───────────────────────── -->
+      <section x-show="route === 'battles/detail'"
+               x-data="battleDetail()"
+               x-init="$watch('$root.params.id', id => { if (id) load(id); }); if ($root.params.id) load($root.params.id);">
+
+        <div style="display:flex;align-items:center;gap:0.75rem;margin-bottom:1.5rem;">
+          <h1 style="margin:0;">Battle Detail</h1>
+          <span class="badge-muted" x-text="params.id ? params.id.slice(0,8) + '...' : ''"></span>
+        </div>
+
+        <!-- Sources card -->
+        <div class="card">
+          <h2 style="display:flex;align-items:center;">
+            Sources <span class="badge" x-text="sources.length"></span>
+          </h2>
+
+          <div style="margin-bottom:1rem;">
+            <label>Upload files</label>
+            <p class="text-muted" style="margin:0 0 6px;font-size:0.8rem;">
+              Accepts <code>.txt</code>, <code>.md</code> (one source per file) and <code>.csv</code> (one source per row).
+            </p>
+            <input type="file" accept=".txt,.md,.csv" multiple
+                   :disabled="uploading"
+                   @change="upload($event, $root.params.id)">
+            <template x-if="uploading">
+              <p class="text-gold" style="font-size:0.86rem;margin:4px 0 0;">Uploading...</p>
+            </template>
+          </div>
+
+          <template x-if="error">
+            <div class="error-box" x-text="error"></div>
+          </template>
+
+          <template x-if="sources.length === 0">
+            <p class="text-muted" style="font-size:0.86rem;margin:0;">No sources yet. Upload files above to add source items.</p>
+          </template>
+
+          <template x-if="sources.length > 0">
+            <div>
+              <template x-for="s in sources" :key="s.id">
+                <div class="source-item">
+                  <span x-text="s.label"></span>
+                  <button class="btn-danger-sm" @click="remove($root.params.id, s.id)">Delete</button>
+                </div>
+              </template>
+            </div>
+          </template>
+        </div>
+
+        <!-- Fighters card -->
+        <div class="card" x-data="fighterList()" x-init="load($root.params.id)">
+          <div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:1rem;">
+            <h2 style="margin:0;">Fighters</h2>
+            <button class="btn-primary" @click="showAddFighter = !showAddFighter" style="padding:6px 14px;font-size:0.83rem;">
+              + Add Fighter
+            </button>
+          </div>
+
+          <!-- Add fighter form -->
+          <template x-if="showAddFighter">
+            <form @submit.prevent="addFighter($root.params.id)"
+              style="background:rgba(0,0,0,0.25);border:1px solid var(--border);border-radius:8px;padding:1rem;margin-bottom:1rem;display:flex;flex-direction:column;gap:0.75rem;">
+              <h3>New Fighter</h3>
+              <div style="display:flex;gap:1rem;align-items:flex-end;">
+                <div style="flex:1;">
+                  <label>Fighter Name <span class="text-danger">*</span></label>
+                  <input type="text" x-model="newFighter.name" required placeholder="e.g. GPT-4o pipeline">
+                </div>
+                <div style="display:flex;align-items:center;gap:6px;padding-bottom:2px;">
+                  <input type="checkbox" id="f-manual" x-model="newFighter.is_manual" style="width:16px;height:16px;cursor:pointer;">
+                  <label for="f-manual" style="margin:0;cursor:pointer;">Manual</label>
                 </div>
               </div>
-              <a :href="'#/battles/' + b.id" style="color:#7c6af7;font-size:0.85rem;text-decoration:none;">View →</a>
-            </li>
-          </template>
-        </ul>
-      </template>
-
-      <template x-if="error">
-        <p style="color:#c0392b;" x-text="error"></p>
-      </template>
-    </section>
-
-    <!-- View: new battle -->
-    <section x-show="route === 'battles/new'" x-data="battleForm()" x-init="init()">
-      <div style="display:flex;align-items:center;gap:1rem;margin-bottom:1.5rem;">
-        <h1 style="margin:0;">New Battle</h1>
-        <a href="#/battles" style="color:#888;font-size:0.9rem;text-decoration:none;">← Cancel</a>
-      </div>
-
-      <form @submit.prevent="submit()" style="max-width:600px;display:flex;flex-direction:column;gap:1.25rem;">
-
-        <div>
-          <label style="display:block;font-weight:600;font-size:0.9rem;margin-bottom:4px;" for="bf-name">Battle Name <span style="color:#c0392b;">*</span></label>
-          <input id="bf-name" type="text" x-model="name" required placeholder="e.g. Summarisation quality test"
-            style="width:100%;padding:8px 10px;border:1px solid #ccc;border-radius:6px;font-size:0.95rem;">
-        </div>
-
-        <div style="display:grid;grid-template-columns:1fr 1fr;gap:1rem;">
-          <div>
-            <label style="display:block;font-weight:600;font-size:0.9rem;margin-bottom:4px;" for="bf-provider">Judge Provider</label>
-            <select id="bf-provider" x-model="judge_provider" @change="onProviderChange()"
-              style="width:100%;padding:8px 10px;border:1px solid #ccc;border-radius:6px;font-size:0.95rem;background:#fff;">
-              <template x-if="providers.length === 0">
-                <option value="">Loading…</option>
+              <template x-if="addFighterError">
+                <p class="text-danger" style="margin:0;font-size:0.84rem;" x-text="addFighterError"></p>
               </template>
-              <template x-for="p in providers" :key="p">
-                <option :value="p" x-text="p"></option>
-              </template>
-            </select>
-          </div>
-          <div>
-            <label style="display:block;font-weight:600;font-size:0.9rem;margin-bottom:4px;" for="bf-model">Judge Model</label>
-            <input id="bf-model" type="text" x-model="judge_model"
-              :placeholder="modelPlaceholder()"
-              :list="'bf-model-suggestions-' + judge_provider"
-              style="width:100%;padding:8px 10px;border:1px solid #ccc;border-radius:6px;font-size:0.95rem;">
-            <!-- datalist for suggestions per provider -->
-            <datalist id="bf-model-suggestions-openai">
-              <option value="gpt-4o"></option>
-              <option value="gpt-4o-mini"></option>
-              <option value="gpt-4-turbo"></option>
-              <option value="o1-mini"></option>
-            </datalist>
-            <datalist id="bf-model-suggestions-anthropic">
-              <option value="claude-opus-4-5"></option>
-              <option value="claude-sonnet-4-5"></option>
-              <option value="claude-haiku-3-5"></option>
-            </datalist>
-            <datalist id="bf-model-suggestions-google">
-              <option value="gemini-2.0-flash"></option>
-              <option value="gemini-1.5-pro"></option>
-              <option value="gemini-1.5-flash"></option>
-            </datalist>
-            <datalist id="bf-model-suggestions-groq">
-              <option value="llama-3.3-70b-versatile"></option>
-              <option value="mixtral-8x7b-32768"></option>
-            </datalist>
-            <datalist id="bf-model-suggestions-openrouter">
-              <option value="openai/gpt-4o"></option>
-              <option value="anthropic/claude-opus-4-5"></option>
-            </datalist>
-            <datalist id="bf-model-suggestions-ollama">
-              <option value="llama3.2"></option>
-              <option value="mistral"></option>
-              <option value="phi4"></option>
-            </datalist>
-          </div>
-        </div>
-
-        <div>
-          <label style="display:block;font-weight:600;font-size:0.9rem;margin-bottom:6px;" for="bf-rubric">
-            Judge Rubric
-            <span style="color:#888;font-weight:400;">(optional — edit or replace the default)</span>
-          </label>
-          <textarea id="bf-rubric" x-ref="rubricTextarea"
-            style="display:none;"
-            x-model="judge_rubric"></textarea>
-          <!-- EasyMDE is mounted here; actual value synced via x-model above -->
-        </div>
-
-        <template x-if="error">
-          <p style="color:#c0392b;background:#fdf0f0;border:1px solid #f5c6c6;border-radius:6px;padding:10px 14px;margin:0;font-size:0.9rem;" x-text="error"></p>
-        </template>
-
-        <div style="display:flex;align-items:center;gap:1rem;">
-          <button type="submit" :disabled="loading"
-            style="background:#7c6af7;color:#fff;border:none;padding:10px 22px;border-radius:6px;font-size:0.95rem;font-weight:600;cursor:pointer;opacity:1;"
-            :style="loading ? 'opacity:0.6;cursor:not-allowed;' : ''">
-            <span x-text="loading ? 'Creating...' : 'Create Battle'"></span>
-          </button>
-          <a href="#/battles" style="color:#888;font-size:0.9rem;text-decoration:none;">Cancel</a>
-        </div>
-
-      </form>
-    </section>
-
-    <!-- View: battle detail -->
-    <section x-show="route === 'battles/detail'"
-             x-data="battleDetail()"
-             x-init="$watch('$root.params.id', id => { if (id) load(id); }); if ($root.params.id) load($root.params.id);">
-
-      <div style="display:flex;align-items:center;gap:1rem;margin-bottom:1.5rem;">
-        <h1 style="margin:0;">
-          Battle Detail
-          <span class="badge" x-text="params.id ? params.id.slice(0,8) + '...' : ''"></span>
-        </h1>
-        <a href="#/battles" style="color:#888;font-size:0.9rem;text-decoration:none;">← Back to Battles</a>
-      </div>
-
-      <!-- Sources section -->
-      <div style="background:#fff;border:1px solid #e0e0e0;border-radius:8px;padding:1.5rem;margin-bottom:1.5rem;">
-        <h2 style="margin:0 0 1rem;display:flex;align-items:center;gap:0.5rem;">
-          Sources
-          <span class="badge" x-text="sources.length"></span>
-        </h2>
-
-        <!-- Upload area -->
-        <div style="margin-bottom:1.25rem;">
-          <label style="display:block;font-weight:600;font-size:0.9rem;margin-bottom:6px;">Upload files</label>
-          <p style="font-size:0.82rem;color:#666;margin:0 0 8px;">
-            Accepts <code>.txt</code>, <code>.md</code> (one source per file) and <code>.csv</code> (one source per row).
-            Multiple files supported for text/markdown.
-          </p>
-          <input type="file" accept=".txt,.md,.csv" multiple
-                 :disabled="uploading"
-                 @change="upload($event, $root.params.id)"
-                 style="display:block;font-size:0.9rem;">
-          <template x-if="uploading">
-            <p style="color:#7c6af7;font-size:0.9rem;margin:6px 0 0;">Uploading...</p>
-          </template>
-        </div>
-
-        <!-- Error message -->
-        <template x-if="error">
-          <p style="color:#c0392b;background:#fdf0f0;border:1px solid #f5c6c6;border-radius:6px;padding:10px 14px;margin:0 0 1rem;font-size:0.9rem;" x-text="error"></p>
-        </template>
-
-        <!-- Source list -->
-        <template x-if="sources.length === 0">
-          <p style="color:#888;font-size:0.9rem;margin:0;">No sources yet. Upload files above to add source items.</p>
-        </template>
-
-        <template x-if="sources.length > 0">
-          <ul style="list-style:none;padding:0;margin:0;display:flex;flex-direction:column;gap:0.5rem;">
-            <template x-for="s in sources" :key="s.id">
-              <li style="display:flex;align-items:center;justify-content:space-between;background:#f8f8fc;border:1px solid #e8e8f0;border-radius:6px;padding:8px 12px;">
-                <span style="font-size:0.9rem;color:#1a1a2e;" x-text="s.label"></span>
-                <button @click="remove($root.params.id, s.id)"
-                        style="background:none;border:1px solid #e0e0e0;border-radius:4px;padding:3px 10px;font-size:0.8rem;color:#c0392b;cursor:pointer;transition:background 0.15s;"
-                        onmouseover="this.style.background='#fdf0f0'" onmouseout="this.style.background='none'">
-                  Delete
+              <div style="display:flex;gap:0.75rem;">
+                <button type="submit" class="btn-primary" :disabled="addingFighter" style="padding:6px 14px;font-size:0.84rem;">
+                  <span x-text="addingFighter ? 'Adding...' : 'Add Fighter'"></span>
                 </button>
-              </li>
-            </template>
-          </ul>
-        </template>
-      </div>
-
-      <!-- Fighters section -->
-      <div x-data="fighterList()" x-init="load($root.params.id)">
-        <div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:1rem;">
-          <h2 style="margin:0;">Fighters</h2>
-          <button @click="showAddFighter = !showAddFighter"
-            style="background:#7c6af7;color:#fff;border:none;padding:7px 14px;border-radius:6px;font-size:0.85rem;font-weight:600;cursor:pointer;">
-            + Add Fighter
-          </button>
-        </div>
-
-        <!-- Add fighter form -->
-        <template x-if="showAddFighter">
-          <form @submit.prevent="addFighter($root.params.id)"
-            style="background:#fff;border:1px solid #e0e0e0;border-radius:8px;padding:1rem 1.25rem;margin-bottom:1rem;display:flex;flex-direction:column;gap:0.75rem;">
-            <h3 style="margin:0;font-size:1rem;">New Fighter</h3>
-            <div style="display:flex;gap:1rem;align-items:flex-end;">
-              <div style="flex:1;">
-                <label style="display:block;font-weight:600;font-size:0.85rem;margin-bottom:4px;">Fighter Name <span style="color:#c0392b;">*</span></label>
-                <input type="text" x-model="newFighter.name" required placeholder="e.g. GPT-4o pipeline"
-                  style="width:100%;padding:7px 10px;border:1px solid #ccc;border-radius:6px;font-size:0.9rem;">
+                <button type="button" class="btn-secondary" @click="showAddFighter = false">Cancel</button>
               </div>
-              <div style="display:flex;align-items:center;gap:6px;padding-bottom:2px;">
-                <input type="checkbox" id="f-manual" x-model="newFighter.is_manual" style="width:16px;height:16px;cursor:pointer;">
-                <label for="f-manual" style="font-size:0.9rem;cursor:pointer;">Manual</label>
-              </div>
-            </div>
-            <template x-if="addFighterError">
-              <p style="color:#c0392b;margin:0;font-size:0.85rem;" x-text="addFighterError"></p>
-            </template>
-            <div style="display:flex;gap:0.75rem;">
-              <button type="submit" :disabled="addingFighter"
-                style="background:#7c6af7;color:#fff;border:none;padding:7px 16px;border-radius:6px;font-size:0.85rem;font-weight:600;cursor:pointer;"
-                :style="addingFighter ? 'opacity:0.6;cursor:not-allowed;' : ''">
-                <span x-text="addingFighter ? 'Adding...' : 'Add Fighter'"></span>
-              </button>
-              <button type="button" @click="showAddFighter = false"
-                style="background:none;border:1px solid #ccc;padding:7px 14px;border-radius:6px;font-size:0.85rem;cursor:pointer;">
-                Cancel
-              </button>
-            </div>
-          </form>
-        </template>
+            </form>
+          </template>
 
-        <!-- Loading fighters -->
-        <template x-if="loadingFighters">
-          <p style="color:#888;font-size:0.9rem;">Loading fighters...</p>
-        </template>
+          <template x-if="loadingFighters">
+            <p class="text-muted" style="font-size:0.86rem;">Loading fighters...</p>
+          </template>
 
-        <!-- Empty state -->
-        <template x-if="!loadingFighters && fighters.length === 0">
-          <div class="placeholder" style="height:120px;">No fighters yet. Add your first fighter above.</div>
-        </template>
+          <template x-if="!loadingFighters && fighters.length === 0">
+            <div class="placeholder">No fighters yet. Add your first fighter above.</div>
+          </template>
 
-        <!-- Fighter cards -->
-        <template x-if="!loadingFighters && fighters.length > 0">
-          <div style="display:flex;flex-direction:column;gap:1rem;">
-            <template x-for="fighter in fighters" :key="fighter.id">
-              <div style="background:#fff;border:1px solid #e0e0e0;border-radius:8px;padding:1rem 1.25rem;">
-                <div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:0.75rem;">
-                  <div style="display:flex;align-items:center;gap:0.5rem;">
-                    <span style="font-weight:600;font-size:0.95rem;" x-text="fighter.name"></span>
-                    <span x-show="fighter.is_manual" class="badge" style="background:#888;">manual</span>
+          <template x-if="!loadingFighters && fighters.length > 0">
+            <div style="display:flex;flex-direction:column;gap:0.75rem;">
+              <template x-for="fighter in fighters" :key="fighter.id">
+                <div style="background:rgba(0,0,0,0.2);border:1px solid var(--border);border-radius:8px;padding:1rem;">
+                  <div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:0.6rem;">
+                    <div>
+                      <span style="font-weight:600;font-size:0.9rem;" x-text="fighter.name"></span>
+                      <span x-show="fighter.is_manual" class="badge-muted">manual</span>
+                    </div>
+                    <button x-show="!fighter.is_manual"
+                      @click="toggleAddStep(fighter.id)"
+                      style="background:rgba(240,185,11,0.1);color:var(--gold);border:1px solid rgba(240,185,11,0.25);padding:4px 12px;border-radius:5px;font-size:0.8rem;font-weight:600;cursor:pointer;">
+                      + Add Step
+                    </button>
                   </div>
-                  <button x-show="!fighter.is_manual"
-                    @click="toggleAddStep(fighter.id)"
-                    style="background:#f0eeff;color:#7c6af7;border:1px solid #c8bffa;padding:5px 12px;border-radius:6px;font-size:0.82rem;font-weight:600;cursor:pointer;">
-                    + Add Step
-                  </button>
-                </div>
 
-                <!-- Steps list -->
-                <template x-if="fighter.steps && fighter.steps.length > 0">
-                  <ul style="list-style:none;padding:0;margin:0 0 0.75rem;display:flex;flex-direction:column;gap:4px;">
-                    <template x-for="(step, idx) in fighter.steps" :key="step.id">
-                      <li style="background:#f8f8fb;border:1px solid #ececf4;border-radius:6px;padding:6px 10px;font-size:0.85rem;display:flex;gap:0.75rem;align-items:center;">
-                        <span style="color:#888;font-weight:600;" x-text="'Step ' + (idx + 1)"></span>
-                        <span style="color:#555;" x-text="step.provider"></span>
-                        <span style="color:#333;font-weight:500;" x-text="step.model_id"></span>
-                        <span x-show="step.system_prompt" style="color:#888;font-style:italic;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;max-width:220px;" x-text="step.system_prompt"></span>
-                      </li>
-                    </template>
-                  </ul>
-                </template>
+                  <template x-if="fighter.steps && fighter.steps.length > 0">
+                    <div style="margin-bottom:0.5rem;">
+                      <template x-for="(step, idx) in fighter.steps" :key="step.id">
+                        <div class="step-row">
+                          <span style="color:var(--low);font-weight:600;" x-text="'Step ' + (idx + 1)"></span>
+                          <span class="text-muted" x-text="step.provider"></span>
+                          <span style="color:var(--high);font-weight:500;" x-text="step.model_id"></span>
+                          <span x-show="step.system_prompt" style="color:var(--low);font-style:italic;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;max-width:200px;" x-text="step.system_prompt"></span>
+                        </div>
+                      </template>
+                    </div>
+                  </template>
 
-                <template x-if="!fighter.steps || fighter.steps.length === 0">
-                  <p x-show="!fighter.is_manual" style="font-size:0.85rem;color:#aaa;margin:0 0 0.5rem;">No steps yet.</p>
-                </template>
+                  <template x-if="!fighter.steps || fighter.steps.length === 0">
+                    <p x-show="!fighter.is_manual" class="text-muted" style="margin:0 0 0.4rem;font-size:0.82rem;">No steps yet.</p>
+                  </template>
 
-                <!-- Add step form (inline) -->
-                <template x-if="activeStepFighterId === fighter.id">
-                  <form @submit.prevent="addStep($root.params.id, fighter.id)"
-                    style="background:#f8f8fb;border:1px solid #ddd;border-radius:6px;padding:0.75rem;margin-top:0.5rem;display:flex;flex-direction:column;gap:0.65rem;">
-                    <h4 style="margin:0;font-size:0.9rem;">New Step</h4>
-                    <!-- System prompt: only for LLM providers -->
-                    <template x-if="stepProviderType() === 'llm'">
-                      <div>
-                        <label style="display:block;font-size:0.82rem;font-weight:600;margin-bottom:3px;">System Prompt <span style="font-weight:400;color:#888;">(optional)</span></label>
-                        <textarea x-model="newStep.system_prompt" rows="3"
-                          placeholder="You are a helpful assistant..."
-                          style="width:100%;padding:7px 10px;border:1px solid #ccc;border-radius:6px;font-size:0.85rem;resize:vertical;font-family:inherit;"></textarea>
-                      </div>
-                    </template>
-                    <div style="display:grid;grid-template-columns:1fr 1fr;gap:0.75rem;">
-                      <div>
-                        <label style="display:block;font-size:0.82rem;font-weight:600;margin-bottom:3px;">Provider <span style="color:#c0392b;">*</span></label>
-                        <select x-model="newStep.provider" @change="onStepProviderChange()" required
-                          style="width:100%;padding:7px 10px;border:1px solid #ccc;border-radius:6px;font-size:0.85rem;background:#fff;">
-                          <!-- LLM group -->
-                          <template x-if="providerInfoList.filter(p => p.provider_type === 'llm').length > 0">
-                            <optgroup label="LLM Providers">
-                              <template x-for="p in providerInfoList.filter(pi => pi.provider_type === 'llm')" :key="p.name">
-                                <option :value="p.name" x-text="p.display_name"></option>
-                              </template>
-                            </optgroup>
-                          </template>
-                          <!-- Tool group -->
-                          <template x-if="providerInfoList.filter(p => p.provider_type === 'tool').length > 0">
-                            <optgroup label="Tool Providers">
-                              <template x-for="p in providerInfoList.filter(pi => pi.provider_type === 'tool')" :key="p.name">
-                                <option :value="p.name" x-text="p.display_name"></option>
-                              </template>
-                            </optgroup>
-                          </template>
-                          <!-- Fallback if providerInfoList empty -->
-                          <template x-if="providerInfoList.length === 0">
-                            <template x-for="p in providers" :key="p">
-                              <option :value="p" x-text="p"></option>
-                            </template>
-                          </template>
-                        </select>
-                      </div>
-                      <!-- Model dropdown for LLM providers -->
+                  <!-- Add step inline form -->
+                  <template x-if="activeStepFighterId === fighter.id">
+                    <form @submit.prevent="addStep($root.params.id, fighter.id)"
+                      style="background:rgba(0,0,0,0.3);border:1px solid var(--border);border-radius:6px;padding:0.75rem;margin-top:0.5rem;display:flex;flex-direction:column;gap:0.6rem;">
+                      <h4 style="margin:0;font-size:0.88rem;">New Step</h4>
+
                       <template x-if="stepProviderType() === 'llm'">
                         <div>
-                          <label style="display:block;font-size:0.82rem;font-weight:600;margin-bottom:3px;">Model <span style="color:#c0392b;">*</span></label>
-                          <select x-model="newStep.model_id" required
-                            style="width:100%;padding:7px 10px;border:1px solid #ccc;border-radius:6px;font-size:0.85rem;background:#fff;">
-                            <template x-for="m in stepProviderModels()" :key="m.id">
-                              <option :value="m.id" :title="m.pricing_label" x-text="m.id + ' — ' + m.pricing_label"></option>
-                            </template>
-                            <option value="">Custom…</option>
-                          </select>
-                          <template x-if="newStep.model_id === ''">
-                            <input type="text" x-model="newStep.model_id_custom" placeholder="Enter custom model ID"
-                              style="width:100%;margin-top:4px;padding:6px 10px;border:1px solid #ccc;border-radius:6px;font-size:0.85rem;">
-                          </template>
+                          <label>System Prompt <span style="font-weight:400;color:var(--low);">(optional)</span></label>
+                          <textarea x-model="newStep.system_prompt" rows="2"
+                            placeholder="You are a helpful assistant..."
+                            style="resize:vertical;font-family:inherit;font-size:0.84rem;"></textarea>
                         </div>
                       </template>
-                      <!-- Function dropdown for tool providers -->
-                      <template x-if="stepProviderType() === 'tool'">
+
+                      <div class="form-grid-2">
                         <div>
-                          <label style="display:block;font-size:0.82rem;font-weight:600;margin-bottom:3px;">Function <span style="color:#c0392b;">*</span></label>
-                          <select x-model="newStep.model_id" required
-                            style="width:100%;padding:7px 10px;border:1px solid #ccc;border-radius:6px;font-size:0.85rem;background:#fff;">
-                            <template x-for="m in stepProviderModels()" :key="m.id">
-                              <option :value="m.id" :title="m.pricing_label" x-text="m.id + ' — ' + m.pricing_label"></option>
+                          <label>Provider <span class="text-danger">*</span></label>
+                          <select x-model="newStep.provider" @change="onStepProviderChange()" required>
+                            <template x-if="providerInfoList.filter(p => p.provider_type === 'llm').length > 0">
+                              <optgroup label="LLM Providers">
+                                <template x-for="p in providerInfoList.filter(pi => pi.provider_type === 'llm')" :key="p.name">
+                                  <option :value="p.name" x-text="p.display_name"></option>
+                                </template>
+                              </optgroup>
+                            </template>
+                            <template x-if="providerInfoList.filter(p => p.provider_type === 'tool').length > 0">
+                              <optgroup label="Tool Providers">
+                                <template x-for="p in providerInfoList.filter(pi => pi.provider_type === 'tool')" :key="p.name">
+                                  <option :value="p.name" x-text="p.display_name"></option>
+                                </template>
+                              </optgroup>
+                            </template>
+                            <template x-if="providerInfoList.length === 0">
+                              <template x-for="p in providers" :key="p">
+                                <option :value="p" x-text="p"></option>
+                              </template>
                             </template>
                           </select>
                         </div>
-                      </template>
-                      <!-- Fallback text input if no providerInfoList -->
-                      <template x-if="stepProviderType() === null">
-                        <div>
-                          <label style="display:block;font-size:0.82rem;font-weight:600;margin-bottom:3px;">Model <span style="color:#c0392b;">*</span></label>
-                          <input type="text" x-model="newStep.model_id" required placeholder="e.g. gpt-4o"
-                            style="width:100%;padding:7px 10px;border:1px solid #ccc;border-radius:6px;font-size:0.85rem;">
-                        </div>
-                      </template>
-                    </div>
-                    <!-- Pricing hint -->
-                    <template x-if="stepPricingHint()">
-                      <p style="margin:0;font-size:0.78rem;color:#7c6af7;background:#f0eeff;border:1px solid #d8d0fa;border-radius:4px;padding:4px 8px;" x-text="stepPricingHint()"></p>
-                    </template>
-                    <!-- Native tools multi-select (LLM providers only) -->
-                    <template x-if="stepNativeTools().length > 0">
-                      <div>
-                        <label style="display:block;font-size:0.82rem;font-weight:600;margin-bottom:3px;">Tools <span style="font-weight:400;color:#888;">(optional model-native tools)</span></label>
-                        <div style="display:flex;flex-wrap:wrap;gap:6px;">
-                          <template x-for="tool in stepNativeTools()" :key="tool">
-                            <label style="display:flex;align-items:center;gap:4px;font-size:0.82rem;cursor:pointer;">
-                              <input type="checkbox" :value="tool" x-model="newStep.selected_tools">
-                              <span x-text="tool"></span>
-                            </label>
-                          </template>
-                        </div>
+                        <template x-if="stepProviderType() === 'llm'">
+                          <div>
+                            <label>Model <span class="text-danger">*</span></label>
+                            <select x-model="newStep.model_id" required>
+                              <template x-for="m in stepProviderModels()" :key="m.id">
+                                <option :value="m.id" :title="m.pricing_label" x-text="m.id + ' — ' + m.pricing_label"></option>
+                              </template>
+                              <option value="">Custom…</option>
+                            </select>
+                            <template x-if="newStep.model_id === ''">
+                              <input type="text" x-model="newStep.model_id_custom" placeholder="Enter custom model ID" style="margin-top:4px;">
+                            </template>
+                          </div>
+                        </template>
+                        <template x-if="stepProviderType() === 'tool'">
+                          <div>
+                            <label>Function <span class="text-danger">*</span></label>
+                            <select x-model="newStep.model_id" required>
+                              <template x-for="m in stepProviderModels()" :key="m.id">
+                                <option :value="m.id" :title="m.pricing_label" x-text="m.id + ' — ' + m.pricing_label"></option>
+                              </template>
+                            </select>
+                          </div>
+                        </template>
+                        <template x-if="stepProviderType() === null">
+                          <div>
+                            <label>Model <span class="text-danger">*</span></label>
+                            <input type="text" x-model="newStep.model_id" required placeholder="e.g. gpt-4o">
+                          </div>
+                        </template>
                       </div>
+
+                      <template x-if="stepPricingHint()">
+                        <p style="margin:0;font-size:0.76rem;color:var(--gold);background:rgba(240,185,11,0.07);border:1px solid rgba(240,185,11,0.2);border-radius:4px;padding:4px 8px;" x-text="stepPricingHint()"></p>
+                      </template>
+
+                      <template x-if="stepNativeTools().length > 0">
+                        <div>
+                          <label>Tools <span style="font-weight:400;color:var(--low);">(optional)</span></label>
+                          <div style="display:flex;flex-wrap:wrap;gap:6px;">
+                            <template x-for="tool in stepNativeTools()" :key="tool">
+                              <label style="display:flex;align-items:center;gap:4px;font-size:0.82rem;cursor:pointer;margin:0;">
+                                <input type="checkbox" :value="tool" x-model="newStep.selected_tools">
+                                <span x-text="tool"></span>
+                              </label>
+                            </template>
+                          </div>
+                        </div>
+                      </template>
+
+                      <div>
+                        <label>Provider Config <span style="font-weight:400;color:var(--low);">(JSON, optional)</span></label>
+                        <textarea x-model="newStep.provider_config" rows="2" placeholder="{}" style="resize:vertical;font-family:monospace;font-size:0.82rem;"></textarea>
+                      </div>
+
+                      <template x-if="addStepError">
+                        <p class="text-danger" style="margin:0;font-size:0.82rem;" x-text="addStepError"></p>
+                      </template>
+
+                      <div style="display:flex;gap:0.75rem;">
+                        <button type="submit" class="btn-primary" :disabled="addingStep" style="padding:6px 14px;font-size:0.82rem;">
+                          <span x-text="addingStep ? 'Adding...' : 'Add Step'"></span>
+                        </button>
+                        <button type="button" class="btn-secondary" @click="activeStepFighterId = null">Cancel</button>
+                      </div>
+                    </form>
+                  </template>
+                </div>
+              </template>
+            </div>
+          </template>
+
+          <template x-if="fightersError">
+            <p class="text-danger" style="font-size:0.86rem;" x-text="fightersError"></p>
+          </template>
+        </div>
+
+        <!-- Run Battle -->
+        <div style="display:flex;align-items:center;gap:1rem;"
+             @fighters-updated.window="fighterCount = $event.detail.count">
+          <button @click="runBattle()" class="btn-primary"
+            :disabled="running || sources.length === 0 || fighterCount === 0"
+            style="padding:10px 24px;font-size:0.92rem;">
+            <span x-text="running ? 'Starting...' : 'Run Battle'"></span>
+          </button>
+          <template x-if="sources.length === 0 || fighterCount === 0">
+            <span class="text-muted" style="font-size:0.84rem;"
+              x-text="sources.length === 0 && fighterCount === 0 ? 'Add at least 1 source and 1 fighter to run.' : sources.length === 0 ? 'Add at least 1 source to run.' : 'Add at least 1 fighter to run.'">
+            </span>
+          </template>
+          <template x-if="runError">
+            <p class="text-danger" style="margin:0;font-size:0.88rem;" x-text="runError"></p>
+          </template>
+        </div>
+      </section>
+
+      <!-- ── Live run view ───────────────────────── -->
+      <section x-show="route === 'runs/detail'" x-data="runView()"
+               x-init="$watch('$root.params.id', id => { if (id && $root.route === 'runs/detail') init(id); }); if ($root.params.id && $root.route === 'runs/detail') init($root.params.id);">
+
+        <div style="display:flex;align-items:center;gap:0.75rem;margin-bottom:1.25rem;">
+          <h1 style="margin:0;">Live Run</h1>
+          <template x-if="run">
+            <span class="badge-muted" x-text="runId ? runId.slice(0,8) + '...' : ''"></span>
+          </template>
+        </div>
+
+        <template x-if="error">
+          <p class="text-danger" x-text="error"></p>
+        </template>
+
+        <template x-if="!run && !error">
+          <p class="text-muted">Loading run status...</p>
+        </template>
+
+        <template x-if="run">
+          <div>
+            <div style="display:flex;align-items:center;gap:1rem;margin-bottom:1.5rem;">
+              <span class="text-muted" style="font-size:0.88rem;">Status:</span>
+              <span x-text="run.status"
+                :style="run.status === 'complete' ? 'color:var(--success);font-weight:600;' : run.status === 'error' ? 'color:var(--danger);font-weight:600;' : 'color:var(--gold);font-weight:600;'"></span>
+              <template x-if="run.status === 'complete'">
+                <a :href="'#/results/' + runId"
+                   style="background:var(--success);color:#fff;padding:5px 14px;border-radius:6px;font-size:0.84rem;font-weight:600;text-decoration:none;">
+                  View Results →
+                </a>
+              </template>
+            </div>
+
+            <template x-if="sources().length > 0 && fighters().length > 0">
+              <div style="overflow-x:auto;">
+                <table class="data-table">
+                  <thead>
+                    <tr>
+                      <th style="min-width:140px;">Source</th>
+                      <template x-for="fighter in fighters()" :key="fighter.fighter_id">
+                        <th style="min-width:180px;" x-text="fighter.fighter_name"></th>
+                      </template>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <template x-for="source in sources()" :key="source.source_id">
+                      <tr>
+                        <td style="font-size:0.82rem;color:var(--mid);vertical-align:top;max-width:160px;word-break:break-word;" x-text="source.source_label"></td>
+                        <template x-for="fighter in fighters()" :key="fighter.fighter_id">
+                          <td style="vertical-align:top;">
+                            <template x-if="getCellResult(fighter.fighter_id, source.source_id)">
+                              <div x-data="{ cell: getCellResult(fighter.fighter_id, source.source_id), submitContent: '', submitting: false, submitError: null }">
+                                <div style="display:flex;flex-wrap:wrap;gap:4px;margin-bottom:6px;">
+                                  <template x-for="(step, idx) in (cell.steps || [])" :key="idx">
+                                    <span
+                                      :title="step.status === 'error' ? (step.error || 'Error') : ''"
+                                      :style="step.status === 'complete'
+                                        ? 'background:rgba(39,174,96,0.15);color:#27ae60;border:1px solid rgba(39,174,96,0.3);border-radius:4px;padding:2px 7px;font-size:0.74rem;'
+                                        : step.status === 'error'
+                                          ? 'background:rgba(224,82,82,0.15);color:var(--danger);border:1px solid rgba(224,82,82,0.3);border-radius:4px;padding:2px 7px;font-size:0.74rem;cursor:help;'
+                                          : 'background:var(--border);color:var(--mid);border:1px solid var(--border);border-radius:4px;padding:2px 7px;font-size:0.74rem;'">
+                                      <span x-text="step.status === 'complete' ? '✓ ' + (step.label || ('step ' + (idx+1))) : step.status === 'error' ? '✗ ' + (step.label || ('step ' + (idx+1))) : (step.label || ('step ' + (idx+1)))"></span>
+                                    </span>
+                                  </template>
+                                  <template x-if="!cell.steps || cell.steps.length === 0">
+                                    <span :style="cell.status === 'complete'
+                                      ? 'background:rgba(39,174,96,0.15);color:#27ae60;border:1px solid rgba(39,174,96,0.3);border-radius:4px;padding:2px 7px;font-size:0.74rem;'
+                                      : cell.status === 'error'
+                                        ? 'background:rgba(224,82,82,0.15);color:var(--danger);border:1px solid rgba(224,82,82,0.3);border-radius:4px;padding:2px 7px;font-size:0.74rem;'
+                                        : cell.status === 'running'
+                                          ? 'background:rgba(240,185,11,0.1);color:var(--gold);border:1px solid rgba(240,185,11,0.25);border-radius:4px;padding:2px 7px;font-size:0.74rem;'
+                                          : cell.status === 'awaiting_input'
+                                            ? 'background:rgba(240,185,11,0.1);color:var(--gold);border:1px solid rgba(240,185,11,0.25);border-radius:4px;padding:2px 7px;font-size:0.74rem;'
+                                            : 'background:var(--border);color:var(--mid);border:1px solid var(--border);border-radius:4px;padding:2px 7px;font-size:0.74rem;'">
+                                      <span x-text="cell.status === 'complete' ? '✓ done' : cell.status === 'error' ? '✗ error' : cell.status === 'running' ? '⟳ running' : cell.status === 'awaiting_input' ? '⌛ awaiting input' : '· pending'"></span>
+                                    </span>
+                                  </template>
+                                </div>
+                                <template x-if="cell.status === 'awaiting_input'">
+                                  <div style="margin-top:6px;">
+                                    <textarea x-model="submitContent" rows="3" placeholder="Enter result..."
+                                      style="font-size:0.84rem;resize:vertical;"></textarea>
+                                    <template x-if="submitError">
+                                      <p class="text-danger" style="font-size:0.8rem;margin:2px 0;" x-text="submitError"></p>
+                                    </template>
+                                    <button @click="async () => {
+                                        submitting = true; submitError = null;
+                                        try {
+                                          const r = await fetch('/runs/' + runId + '/steps/' + cell.fighter_result_id + '/submit', {
+                                            method: 'POST',
+                                            headers: {'Content-Type': 'application/json'},
+                                            body: JSON.stringify({ content: submitContent })
+                                          });
+                                          if (!r.ok) throw new Error(await r.text());
+                                        } catch(e) { submitError = e.message; }
+                                        finally { submitting = false; }
+                                      }"
+                                      :disabled="submitting || !submitContent.trim()"
+                                      class="btn-primary" style="margin-top:4px;padding:5px 14px;font-size:0.84rem;"
+                                      :style="(submitting || !submitContent.trim()) ? 'opacity:0.5;cursor:not-allowed;' : ''">
+                                      <span x-text="submitting ? 'Submitting...' : 'Submit'"></span>
+                                    </button>
+                                  </div>
+                                </template>
+                              </div>
+                            </template>
+                            <template x-if="!getCellResult(fighter.fighter_id, source.source_id)">
+                              <span style="background:var(--border);color:var(--mid);border-radius:4px;padding:2px 7px;font-size:0.74rem;">· pending</span>
+                            </template>
+                          </td>
+                        </template>
+                      </tr>
                     </template>
-                    <div>
-                      <label style="display:block;font-size:0.82rem;font-weight:600;margin-bottom:3px;">Provider Config <span style="font-weight:400;color:#888;">(JSON, optional)</span></label>
-                      <textarea x-model="newStep.provider_config" rows="2"
-                        placeholder="{}"
-                        style="width:100%;padding:7px 10px;border:1px solid #ccc;border-radius:6px;font-size:0.85rem;resize:vertical;font-family:monospace;"></textarea>
-                    </div>
-                    <template x-if="addStepError">
-                      <p style="color:#c0392b;margin:0;font-size:0.82rem;" x-text="addStepError"></p>
-                    </template>
-                    <div style="display:flex;gap:0.75rem;">
-                      <button type="submit" :disabled="addingStep"
-                        style="background:#7c6af7;color:#fff;border:none;padding:6px 14px;border-radius:6px;font-size:0.83rem;font-weight:600;cursor:pointer;"
-                        :style="addingStep ? 'opacity:0.6;cursor:not-allowed;' : ''">
-                        <span x-text="addingStep ? 'Adding...' : 'Add Step'"></span>
-                      </button>
-                      <button type="button" @click="activeStepFighterId = null"
-                        style="background:none;border:1px solid #ccc;padding:6px 12px;border-radius:6px;font-size:0.83rem;cursor:pointer;">
-                        Cancel
-                      </button>
-                    </div>
-                  </form>
-                </template>
+                  </tbody>
+                </table>
               </div>
             </template>
           </div>
         </template>
+      </section>
 
-        <template x-if="fightersError">
-          <p style="color:#c0392b;font-size:0.9rem;" x-text="fightersError"></p>
-        </template>
-      </div>
+      <!-- ── Results view ────────────────────────── -->
+      <section x-show="route === 'results/detail'" x-data="resultsView()"
+               x-init="$watch('$root.route', r => { if (r === 'results/detail' && $root.params.id) load($root.params.id); }); if (route === 'results/detail' && params.id) load(params.id);">
 
-      <!-- Run Battle button -->
-      <div style="margin-top:1.5rem;display:flex;align-items:center;gap:1rem;"
-           @fighters-updated.window="fighterCount = $event.detail.count">
-        <button @click="runBattle()"
-          :disabled="running || sources.length === 0 || fighterCount === 0"
-          style="background:#7c6af7;color:#fff;border:none;padding:10px 24px;border-radius:6px;font-size:0.95rem;font-weight:600;cursor:pointer;"
-          :style="(running || sources.length === 0 || fighterCount === 0) ? 'opacity:0.5;cursor:not-allowed;' : ''">
-          <span x-text="running ? 'Starting...' : 'Run Battle'"></span>
-        </button>
-        <template x-if="sources.length === 0 || fighterCount === 0">
-          <span style="font-size:0.85rem;color:#888;"
-            x-text="sources.length === 0 && fighterCount === 0 ? 'Add at least 1 source and 1 fighter to run.' : sources.length === 0 ? 'Add at least 1 source to run.' : 'Add at least 1 fighter to run.'">
-          </span>
-        </template>
-        <template x-if="runError">
-          <p style="color:#c0392b;margin:0;font-size:0.9rem;" x-text="runError"></p>
-        </template>
-      </div>
-    </section>
-
-    <!-- View: live run -->
-    <section x-show="route === 'runs/detail'" x-data="runView()" x-init="$watch('$root.params.id', id => { if (id && $root.route === 'runs/detail') init(id); }); if ($root.params.id && $root.route === 'runs/detail') init($root.params.id);">
-      <div style="display:flex;align-items:center;gap:1rem;margin-bottom:1.25rem;">
-        <h1 style="margin:0;">Live Run</h1>
-        <template x-if="run">
-          <span class="badge" x-text="runId ? runId.slice(0,8) + '...' : ''"></span>
-        </template>
-      </div>
-
-      <template x-if="error">
-        <p style="color:#c0392b;" x-text="error"></p>
-      </template>
-
-      <template x-if="!run && !error">
-        <p style="color:#888;">Loading run status...</p>
-      </template>
-
-      <template x-if="run">
-        <div>
-          <!-- Status bar -->
-          <div style="display:flex;align-items:center;gap:1rem;margin-bottom:1.5rem;">
-            <span style="font-size:0.9rem;color:#555;">Status:</span>
-            <span x-text="run.status"
-              :style="run.status === 'complete' ? 'color:#27ae60;font-weight:600;' : run.status === 'error' ? 'color:#c0392b;font-weight:600;' : 'color:#7c6af7;font-weight:600;'"></span>
-            <template x-if="run.status === 'complete'">
-              <a :href="'#/results/' + runId" style="background:#27ae60;color:#fff;padding:6px 14px;border-radius:6px;font-size:0.85rem;font-weight:600;text-decoration:none;">View Results →</a>
-            </template>
+        <div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:1.25rem;">
+          <div style="display:flex;align-items:center;gap:0.75rem;">
+            <h1 style="margin:0;">Results</h1>
+            <span class="badge-muted" x-text="runId ? runId.slice(0,8) + '...' : ''"></span>
           </div>
+          <div style="display:flex;gap:0.75rem;align-items:center;">
+            <button @click="downloadMarkdown()" x-show="results"
+              class="btn-secondary" style="color:var(--gold);border-color:rgba(240,185,11,0.3);">
+              Download Markdown
+            </button>
+            <a href="#/battles" class="text-muted" style="text-decoration:none;font-size:0.86rem;">← Back</a>
+          </div>
+        </div>
 
-          <!-- Progress grid -->
-          <template x-if="sources().length > 0 && fighters().length > 0">
-            <div style="overflow-x:auto;">
-              <table style="width:100%;border-collapse:collapse;background:#fff;border:1px solid #e0e0e0;border-radius:8px;overflow:hidden;">
+        <template x-if="loading">
+          <p class="text-muted">Loading results...</p>
+        </template>
+        <template x-if="error">
+          <div class="error-box" x-text="error"></div>
+        </template>
+
+        <template x-if="results">
+          <div>
+            <h2>Fighter Summary</h2>
+            <div style="overflow-x:auto;margin-bottom:2rem;">
+              <table class="data-table">
                 <thead>
-                  <tr style="background:#f5f5f5;">
-                    <th style="padding:10px 14px;text-align:left;font-size:0.85rem;color:#555;border-bottom:1px solid #e0e0e0;min-width:140px;">Source</th>
-                    <template x-for="fighter in fighters()" :key="fighter.fighter_id">
-                      <th style="padding:10px 14px;text-align:left;font-size:0.85rem;color:#555;border-bottom:1px solid #e0e0e0;min-width:180px;" x-text="fighter.fighter_name"></th>
-                    </template>
+                  <tr>
+                    <th>Fighter</th>
+                    <th style="text-align:right;">Avg Score</th>
+                    <th style="text-align:right;">Total Cost USD</th>
+                    <th style="text-align:right;">Token Cost</th>
+                    <th style="text-align:right;">Credit Cost</th>
+                    <th style="text-align:right;">Steps</th>
+                    <th style="text-align:right;">Items</th>
                   </tr>
                 </thead>
                 <tbody>
-                  <template x-for="source in sources()" :key="source.source_id">
-                    <tr style="border-bottom:1px solid #f0f0f0;">
-                      <td style="padding:10px 14px;font-size:0.85rem;color:#555;vertical-align:top;max-width:160px;word-break:break-word;" x-text="source.source_label"></td>
-                      <template x-for="fighter in fighters()" :key="fighter.fighter_id">
-                        <td style="padding:10px 14px;vertical-align:top;">
-                          <template x-if="getCellResult(fighter.fighter_id, source.source_id)">
-                            <div x-data="{ cell: getCellResult(fighter.fighter_id, source.source_id), submitContent: '', submitting: false, submitError: null }">
-                              <!-- Step chips -->
-                              <div style="display:flex;flex-wrap:wrap;gap:4px;margin-bottom:6px;">
-                                <template x-for="(step, idx) in (cell.steps || [])" :key="idx">
-                                  <span
-                                    :title="step.status === 'error' ? (step.error || 'Error') : ''"
-                                    :style="step.status === 'complete'
-                                      ? 'background:#d4edda;color:#155724;border:1px solid #c3e6cb;border-radius:4px;padding:2px 7px;font-size:0.75rem;'
-                                      : step.status === 'error'
-                                        ? 'background:#f8d7da;color:#721c24;border:1px solid #f5c6cb;border-radius:4px;padding:2px 7px;font-size:0.75rem;cursor:help;'
-                                        : 'background:#e2e3e5;color:#383d41;border:1px solid #d6d8db;border-radius:4px;padding:2px 7px;font-size:0.75rem;'">
-                                    <span x-text="step.status === 'complete' ? '✓ ' + (step.label || ('step ' + (idx+1))) : step.status === 'error' ? '✗ ' + (step.label || ('step ' + (idx+1))) : (step.label || ('step ' + (idx+1)))"></span>
-                                  </span>
-                                </template>
-                                <!-- Overall cell status chip when no steps yet -->
-                                <template x-if="!cell.steps || cell.steps.length === 0">
-                                  <span :style="cell.status === 'complete'
-                                    ? 'background:#d4edda;color:#155724;border:1px solid #c3e6cb;border-radius:4px;padding:2px 7px;font-size:0.75rem;'
-                                    : cell.status === 'error'
-                                      ? 'background:#f8d7da;color:#721c24;border:1px solid #f5c6cb;border-radius:4px;padding:2px 7px;font-size:0.75rem;'
-                                      : cell.status === 'running'
-                                        ? 'background:#cce5ff;color:#004085;border:1px solid #b8daff;border-radius:4px;padding:2px 7px;font-size:0.75rem;'
-                                        : cell.status === 'awaiting_input'
-                                          ? 'background:#fff3cd;color:#856404;border:1px solid #ffeeba;border-radius:4px;padding:2px 7px;font-size:0.75rem;'
-                                          : 'background:#e2e3e5;color:#383d41;border:1px solid #d6d8db;border-radius:4px;padding:2px 7px;font-size:0.75rem;'">
-                                    <span x-text="cell.status === 'complete' ? '✓ done' : cell.status === 'error' ? '✗ error' : cell.status === 'running' ? '⟳ running' : cell.status === 'awaiting_input' ? '⌛ awaiting input' : '· pending'"></span>
-                                  </span>
-                                </template>
-                              </div>
-                              <!-- Manual input area for awaiting_input -->
-                              <template x-if="cell.status === 'awaiting_input'">
-                                <div style="margin-top:6px;">
-                                  <textarea x-model="submitContent" rows="3"
-                                    placeholder="Enter result..."
-                                    style="width:100%;padding:6px 8px;border:1px solid #ccc;border-radius:4px;font-size:0.85rem;font-family:inherit;resize:vertical;"></textarea>
-                                  <template x-if="submitError">
-                                    <p style="color:#c0392b;font-size:0.8rem;margin:2px 0;" x-text="submitError"></p>
-                                  </template>
-                                  <button @click="async () => {
-                                      submitting = true; submitError = null;
-                                      try {
-                                        const r = await fetch('/runs/' + runId + '/steps/' + cell.fighter_result_id + '/submit', {
-                                          method: 'POST',
-                                          headers: {'Content-Type': 'application/json'},
-                                          body: JSON.stringify({ content: submitContent })
-                                        });
-                                        if (!r.ok) throw new Error(await r.text());
-                                      } catch(e) { submitError = e.message; }
-                                      finally { submitting = false; }
-                                    }"
-                                    :disabled="submitting || !submitContent.trim()"
-                                    style="margin-top:4px;background:#7c6af7;color:#fff;border:none;padding:5px 14px;border-radius:4px;font-size:0.85rem;cursor:pointer;"
-                                    :style="(submitting || !submitContent.trim()) ? 'opacity:0.6;cursor:not-allowed;' : ''">
-                                    <span x-text="submitting ? 'Submitting...' : 'Submit'"></span>
-                                  </button>
-                                </div>
-                              </template>
-                            </div>
-                          </template>
-                          <template x-if="!getCellResult(fighter.fighter_id, source.source_id)">
-                            <span style="background:#e2e3e5;color:#383d41;border:1px solid #d6d8db;border-radius:4px;padding:2px 7px;font-size:0.75rem;">· pending</span>
-                          </template>
-                        </td>
-                      </template>
+                  <template x-for="(f, idx) in fighterSummary()" :key="f.fighter_name">
+                    <tr>
+                      <td style="font-weight:600;" x-text="f.fighter_name"></td>
+                      <td style="text-align:right;">
+                        <span :style="scoreColor(f.avg_score)" x-text="f.avg_score.toFixed(2)"></span>
+                      </td>
+                      <td style="text-align:right;font-family:monospace;font-size:0.83rem;" x-text="'$' + f.total_cost.toFixed(4)"></td>
+                      <td style="text-align:right;font-family:monospace;font-size:0.83rem;color:var(--mid);" x-text="f.token_cost > 0 ? '$' + f.token_cost.toFixed(4) : '—'"></td>
+                      <td style="text-align:right;font-family:monospace;font-size:0.83rem;color:var(--gold);" x-text="f.credit_cost > 0 ? '$' + f.credit_cost.toFixed(4) : '—'"></td>
+                      <td style="text-align:right;" x-text="f.total_steps"></td>
+                      <td style="text-align:right;" x-text="f.item_count"></td>
                     </tr>
                   </template>
                 </tbody>
               </table>
             </div>
-          </template>
-        </div>
-      </template>
-    </section>
 
-    <!-- View: results -->
-    <section x-show="route === 'results/detail'" x-data="resultsView()" x-init="$watch('$root.route', r => { if (r === 'results/detail' && $root.params.id) load($root.params.id); }); if (route === 'results/detail' && params.id) load(params.id);">
-
-      <div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:1.25rem;">
-        <div style="display:flex;align-items:center;gap:1rem;">
-          <h1 style="margin:0;">Results</h1>
-          <span class="badge" x-text="runId ? runId.slice(0,8) + '...' : ''"></span>
-        </div>
-        <div style="display:flex;gap:0.75rem;">
-          <button @click="downloadMarkdown()"
-            x-show="results"
-            style="background:#fff;color:#7c6af7;border:1px solid #7c6af7;padding:8px 16px;border-radius:6px;font-size:0.85rem;font-weight:600;cursor:pointer;">
-            Download as Markdown
-          </button>
-          <a href="#/battles" style="color:#888;font-size:0.9rem;text-decoration:none;padding:8px 0;">← Back</a>
-        </div>
-      </div>
-
-      <template x-if="loading">
-        <p style="color:#888;">Loading results...</p>
-      </template>
-
-      <template x-if="error">
-        <p style="color:#c0392b;background:#fdf0f0;border:1px solid #f5c6c6;border-radius:6px;padding:10px 14px;margin:0;font-size:0.9rem;" x-text="error"></p>
-      </template>
-
-      <template x-if="results">
-        <div>
-
-          <!-- Summary Table -->
-          <h2>Fighter Summary</h2>
-          <div style="overflow-x:auto;margin-bottom:2rem;">
-            <table style="width:100%;border-collapse:collapse;background:#fff;border:1px solid #e0e0e0;border-radius:8px;overflow:hidden;">
-              <thead>
-                <tr style="background:#f0f0f8;font-size:0.85rem;text-align:left;">
-                  <th style="padding:10px 14px;font-weight:600;">Fighter</th>
-                  <th style="padding:10px 14px;font-weight:600;text-align:right;">Avg Score</th>
-                  <th style="padding:10px 14px;font-weight:600;text-align:right;">Total Cost USD</th>
-                  <th style="padding:10px 14px;font-weight:600;text-align:right;">Token Cost</th>
-                  <th style="padding:10px 14px;font-weight:600;text-align:right;">Credit Cost</th>
-                  <th style="padding:10px 14px;font-weight:600;text-align:right;">Steps</th>
-                  <th style="padding:10px 14px;font-weight:600;text-align:right;">Items</th>
-                </tr>
-              </thead>
-              <tbody>
-                <template x-for="(f, idx) in fighterSummary()" :key="f.fighter_name">
-                  <tr :style="idx % 2 === 0 ? 'background:#fff;' : 'background:#fafafa;'">
-                    <td style="padding:10px 14px;font-weight:600;" x-text="f.fighter_name"></td>
-                    <td style="padding:10px 14px;text-align:right;">
-                      <span :style="scoreColor(f.avg_score)" x-text="f.avg_score.toFixed(2)"></span>
-                    </td>
-                    <td style="padding:10px 14px;text-align:right;font-family:monospace;font-size:0.85rem;" x-text="'$' + f.total_cost.toFixed(4)"></td>
-                    <td style="padding:10px 14px;text-align:right;font-family:monospace;font-size:0.85rem;color:#555;" x-text="f.token_cost > 0 ? '$' + f.token_cost.toFixed(4) : '—'"></td>
-                    <td style="padding:10px 14px;text-align:right;font-family:monospace;font-size:0.85rem;color:#7c6af7;" x-text="f.credit_cost > 0 ? '$' + f.credit_cost.toFixed(4) : '—'"></td>
-                    <td style="padding:10px 14px;text-align:right;" x-text="f.total_steps"></td>
-                    <td style="padding:10px 14px;text-align:right;" x-text="f.item_count"></td>
-                  </tr>
-                </template>
-              </tbody>
-            </table>
-          </div>
-
-          <!-- Per-Source Breakdown -->
-          <h2>Per-Source Breakdown</h2>
-          <template x-for="source in sourceGroups()" :key="source.label">
-            <div style="background:#fff;border:1px solid #e0e0e0;border-radius:8px;margin-bottom:1.25rem;overflow:hidden;">
-              <div style="background:#f0f0f8;padding:10px 14px;font-weight:600;font-size:0.9rem;border-bottom:1px solid #e0e0e0;">
-                <span x-text="source.label"></span>
+            <h2>Per-Source Breakdown</h2>
+            <template x-for="source in sourceGroups()" :key="source.label">
+              <div class="card" style="padding:0;overflow:hidden;margin-bottom:1rem;">
+                <div style="padding:9px 14px;font-weight:600;font-size:0.88rem;border-bottom:1px solid var(--border);background:rgba(255,255,255,0.02);">
+                  <span x-text="source.label"></span>
+                </div>
+                <div :style="'display:grid;grid-template-columns:repeat(' + source.fighters.length + ', 1fr);gap:0;'">
+                  <template x-for="(fighter, fi) in source.fighters" :key="fighter.fighter_name">
+                    <div :style="fi > 0 ? 'border-left:1px solid var(--border);' : ''">
+                      <div style="padding:8px 14px;border-bottom:1px solid var(--border);display:flex;align-items:center;justify-content:space-between;">
+                        <span style="font-weight:600;font-size:0.84rem;" x-text="fighter.fighter_name"></span>
+                        <span :style="'font-size:0.8rem;font-weight:700;padding:2px 8px;border-radius:4px;' + scoreColor(fighter.score)" x-text="fighter.score !== null ? fighter.score.toFixed(1) : 'N/A'"></span>
+                      </div>
+                      <div style="padding:10px 14px;">
+                        <div @click="toggleExpand(source.label + '::' + fighter.fighter_name)"
+                          style="cursor:pointer;display:flex;align-items:center;gap:6px;font-size:0.8rem;color:var(--gold);margin-bottom:6px;user-select:none;">
+                          <span x-text="expanded[source.label + '::' + fighter.fighter_name] ? '▼ Hide output' : '▶ Show output'"></span>
+                        </div>
+                        <template x-if="expanded[source.label + '::' + fighter.fighter_name]">
+                          <pre style="background:rgba(0,0,0,0.3);border:1px solid var(--border);border-radius:4px;padding:10px;font-size:0.78rem;white-space:pre-wrap;word-break:break-word;margin:0;max-height:300px;overflow-y:auto;color:var(--high);" x-text="fighter.final_output || '(no output)'"></pre>
+                        </template>
+                        <div style="font-size:0.76rem;color:var(--mid);margin-top:6px;">
+                          <span x-text="fighter.step_count + ' step(s)'"></span>
+                          &nbsp;·&nbsp;
+                          <span style="font-family:monospace;" x-text="'$' + (fighter.total_cost_usd || 0).toFixed(4) + ' total'"></span>
+                          <template x-if="fighter.total_input_tokens || fighter.total_output_tokens">
+                            <span>&nbsp;·&nbsp;<span x-text="(fighter.total_input_tokens || 0) + ' in / ' + (fighter.total_output_tokens || 0) + ' out tokens'"></span></span>
+                          </template>
+                          <template x-if="(!fighter.total_input_tokens && !fighter.total_output_tokens) && fighter.total_cost_usd">
+                            <span>&nbsp;·&nbsp;<span style="color:var(--gold);">credit-based</span></span>
+                          </template>
+                        </div>
+                      </div>
+                    </div>
+                  </template>
+                </div>
               </div>
-              <div :style="'display:grid;grid-template-columns:repeat(' + source.fighters.length + ', 1fr);gap:0;'">
-                <template x-for="(fighter, fi) in source.fighters" :key="fighter.fighter_name">
-                  <div :style="fi > 0 ? 'border-left:1px solid #e0e0e0;' : ''">
-                    <!-- Fighter header in source -->
-                    <div style="padding:8px 14px;border-bottom:1px solid #e8e8f0;display:flex;align-items:center;justify-content:space-between;">
-                      <span style="font-weight:600;font-size:0.85rem;" x-text="fighter.fighter_name"></span>
-                      <span :style="'font-size:0.8rem;font-weight:700;padding:2px 8px;border-radius:4px;' + scoreColor(fighter.score)" x-text="fighter.score !== null ? fighter.score.toFixed(1) : 'N/A'"></span>
-                    </div>
-                    <!-- Output preview + expand -->
-                    <div style="padding:10px 14px;">
-                      <div
-                        @click="toggleExpand(source.label + '::' + fighter.fighter_name)"
-                        style="cursor:pointer;display:flex;align-items:center;gap:6px;font-size:0.8rem;color:#7c6af7;margin-bottom:6px;user-select:none;">
-                        <span x-text="expanded[source.label + '::' + fighter.fighter_name] ? '▼ Hide output' : '▶ Show output'"></span>
-                      </div>
-                      <template x-if="expanded[source.label + '::' + fighter.fighter_name]">
-                        <pre style="background:#f8f8fc;border:1px solid #e0e0e0;border-radius:4px;padding:10px;font-size:0.8rem;white-space:pre-wrap;word-break:break-word;margin:0;max-height:320px;overflow-y:auto;" x-text="fighter.final_output || '(no output)'"></pre>
-                      </template>
-                      <div style="font-size:0.78rem;color:#888;margin-top:6px;">
-                        <span x-text="fighter.step_count + ' step(s)'"></span>
-                        &nbsp;·&nbsp;
-                        <span style="font-family:monospace;" x-text="'$' + (fighter.total_cost_usd || 0).toFixed(4) + ' total'"></span>
-                        <template x-if="fighter.total_input_tokens || fighter.total_output_tokens">
-                          <span>
-                            &nbsp;·&nbsp;
-                            <span x-text="(fighter.total_input_tokens || 0) + ' in / ' + (fighter.total_output_tokens || 0) + ' out tokens'"></span>
-                          </span>
-                        </template>
-                        <!-- Credit cost indicator for tool steps (no tokens) -->
-                        <template x-if="(!fighter.total_input_tokens && !fighter.total_output_tokens) && fighter.total_cost_usd">
-                          <span>&nbsp;·&nbsp;<span style="color:#7c6af7;">credit-based</span></span>
-                        </template>
-                      </div>
-                    </div>
+            </template>
+
+            <template x-if="results.report_markdown">
+              <div>
+                <h2>Judge Report</h2>
+                <div class="card" style="line-height:1.7;" x-html="renderMarkdown(results.report_markdown)"></div>
+              </div>
+            </template>
+          </div>
+        </template>
+      </section>
+
+      <!-- ── API Keys ────────────────────────────── -->
+      <section x-show="route === 'keys'" x-data="keysList()" x-init="load()">
+        <h1>API Keys</h1>
+        <p class="text-muted" style="margin-top:-0.75rem;margin-bottom:1.5rem;font-size:0.88rem;">
+          Keys stored in the database are used when no environment variable is set. Environment variables always take precedence.
+        </p>
+
+        <template x-if="loading">
+          <p class="text-muted">Loading...</p>
+        </template>
+        <template x-if="error && !loading">
+          <div class="error-box" x-text="error"></div>
+        </template>
+
+        <template x-if="!loading">
+          <div style="display:flex;flex-direction:column;gap:0.75rem;max-width:600px;">
+            <template x-for="k in keys" :key="k.provider">
+              <div class="card" style="padding:1rem 1.25rem;">
+                <div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:0.6rem;">
+                  <div style="display:flex;align-items:center;gap:0.5rem;">
+                    <span style="font-weight:600;font-size:0.95rem;text-transform:capitalize;" x-text="k.provider"></span>
+                    <template x-if="k.source === 'env'">
+                      <span style="display:inline-block;background:rgba(39,174,96,0.15);color:var(--success);border:1px solid rgba(39,174,96,0.3);border-radius:4px;padding:1px 7px;font-size:0.72rem;font-weight:600;">env var set</span>
+                    </template>
+                    <template x-if="k.source === 'db'">
+                      <span style="display:inline-block;background:rgba(240,185,11,0.1);color:var(--gold);border:1px solid rgba(240,185,11,0.25);border-radius:4px;padding:1px 7px;font-size:0.72rem;font-weight:600;">saved in DB</span>
+                    </template>
+                  </div>
+                  <div style="display:flex;align-items:center;gap:0.5rem;">
+                    <template x-if="k.source === 'db'">
+                      <span class="text-muted" style="font-size:0.84rem;font-family:monospace;" x-text="k.masked_key"></span>
+                    </template>
+                    <template x-if="k.source === 'db'">
+                      <button @click="remove(k.provider)" class="btn-danger-sm">Remove</button>
+                    </template>
+                  </div>
+                </div>
+
+                <template x-if="saved[k.provider]">
+                  <p style="color:var(--success);font-size:0.84rem;margin:0 0 0.5rem;">Key saved successfully.</p>
+                </template>
+                <template x-if="saveErrors[k.provider]">
+                  <p class="text-danger" style="font-size:0.84rem;margin:0 0 0.5rem;" x-text="saveErrors[k.provider]"></p>
+                </template>
+
+                <template x-if="k.source !== 'env'">
+                  <div style="display:flex;gap:0.5rem;align-items:center;">
+                    <input type="password"
+                      :placeholder="k.source === 'db' ? 'Replace saved key…' : 'Paste API key…'"
+                      x-model="inputs[k.provider]"
+                      style="font-family:monospace;">
+                    <button @click="save(k.provider)" class="btn-primary" style="white-space:nowrap;padding:8px 16px;">
+                      Save
+                    </button>
                   </div>
                 </template>
               </div>
-            </div>
-          </template>
+            </template>
+          </div>
+        </template>
+      </section>
 
-          <!-- Judge Report -->
-          <template x-if="results.report_markdown">
-            <div>
-              <h2>Judge Report</h2>
-              <div style="background:#fff;border:1px solid #e0e0e0;border-radius:8px;padding:1.25rem 1.5rem;margin-bottom:2rem;line-height:1.7;" x-html="renderMarkdown(results.report_markdown)"></div>
-            </div>
-          </template>
+      <!-- ── 404 ────────────────────────────────── -->
+      <section x-show="route === 'not-found'">
+        <h1>Page not found</h1>
+        <p class="text-muted">No route matches <code x-text="window.location.hash"></code>.
+          <a href="#/battles" style="color:var(--gold);text-decoration:none;">Go home</a>.
+        </p>
+      </section>
 
-        </div>
-      </template>
-
-    </section>
-
-    <!-- View: API key management -->
-    <section x-show="route === 'keys'" x-data="keysList()" x-init="load()">
-      <h1>API Keys</h1>
-      <p style="color:#555;font-size:0.9rem;margin-top:-0.5rem;margin-bottom:1.5rem;">
-        Keys stored in the database are used when no environment variable is set.
-        Environment variables always take precedence.
-      </p>
-
-      <template x-if="loading">
-        <p style="color:#888;">Loading...</p>
-      </template>
-
-      <template x-if="error && !loading">
-        <p style="color:#c0392b;background:#fdf0f0;border:1px solid #f5c6c6;border-radius:6px;padding:10px 14px;font-size:0.9rem;" x-text="error"></p>
-      </template>
-
-      <template x-if="!loading">
-        <ul style="list-style:none;padding:0;margin:0;display:flex;flex-direction:column;gap:0.75rem;">
-          <template x-for="k in keys" :key="k.provider">
-            <li style="background:#fff;border:1px solid #e0e0e0;border-radius:8px;padding:1rem 1.25rem;">
-              <div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:0.6rem;">
-                <div style="display:flex;align-items:center;gap:0.5rem;">
-                  <span style="font-weight:600;font-size:1rem;text-transform:capitalize;" x-text="k.provider"></span>
-                  <template x-if="k.source === 'env'">
-                    <span style="display:inline-block;background:#27ae60;color:#fff;border-radius:4px;padding:2px 8px;font-size:0.75rem;">env var set</span>
-                  </template>
-                  <template x-if="k.source === 'db'">
-                    <span style="display:inline-block;background:#7c6af7;color:#fff;border-radius:4px;padding:2px 8px;font-size:0.75rem;">saved in DB</span>
-                  </template>
-                </div>
-                <div style="display:flex;align-items:center;gap:0.5rem;">
-                  <template x-if="k.source === 'db'">
-                    <span style="font-size:0.85rem;color:#888;font-family:monospace;" x-text="k.masked_key"></span>
-                  </template>
-                  <template x-if="k.source === 'db'">
-                    <button
-                      @click="remove(k.provider)"
-                      style="background:#fdf0f0;color:#c0392b;border:1px solid #f5c6c6;padding:4px 12px;border-radius:5px;font-size:0.8rem;cursor:pointer;">
-                      Remove
-                    </button>
-                  </template>
-                </div>
-              </div>
-
-              <template x-if="saved[k.provider]">
-                <p style="color:#27ae60;font-size:0.85rem;margin:0 0 0.5rem;">Key saved successfully.</p>
-              </template>
-              <template x-if="saveErrors[k.provider]">
-                <p style="color:#c0392b;font-size:0.85rem;margin:0 0 0.5rem;" x-text="saveErrors[k.provider]"></p>
-              </template>
-
-              <template x-if="k.source !== 'env'">
-                <div style="display:flex;gap:0.5rem;align-items:center;">
-                  <input
-                    type="password"
-                    :placeholder="k.source === 'db' ? 'Replace saved key…' : 'Paste API key…'"
-                    x-model="inputs[k.provider]"
-                    style="flex:1;padding:7px 10px;border:1px solid #ccc;border-radius:6px;font-size:0.9rem;font-family:monospace;">
-                  <button
-                    @click="save(k.provider)"
-                    style="background:#7c6af7;color:#fff;border:none;padding:7px 16px;border-radius:6px;font-size:0.9rem;font-weight:600;cursor:pointer;">
-                    Save
-                  </button>
-                </div>
-              </template>
-            </li>
-          </template>
-        </ul>
-      </template>
-    </section>
-
-    <!-- View: 404 fallback -->
-    <section x-show="route === 'not-found'">
-      <h1>Page not found</h1>
-      <p>No route matches <code x-text="window.location.hash"></code>. <a href="#/battles">Go home</a>.</p>
-    </section>
-
-  </main>
+    </main>
+  </div>
 
   <script src="/vendor/alpine.min.js" defer></script>
   <script src="/vendor/marked.min.js"></script>
   <script src="/vendor/easymde.min.js"></script>
   <script>
-    function battlesList() {
+    // ── Sidebar data ─────────────────────────────────────────
+    function sidebarData() {
       return {
         battles: [],
         loading: false,
-        error: null,
+
         async load() {
           this.loading = true;
-          this.error = null;
           try {
             const resp = await fetch('/battles');
             if (!resp.ok) throw new Error(await resp.text());
             const data = await resp.json();
-            this.battles = (Array.isArray(data) ? data : []).filter(b => b && b.id);
-          } catch(e) {
-            this.error = e.message;
-          } finally {
-            this.loading = false;
-          }
+            this.battles = (Array.isArray(data) ? data : [])
+              .filter(b => b && b.id)
+              .sort((a, b) => (b.created_at > a.created_at ? 1 : -1));
+          } catch(_) {}
+          finally { this.loading = false; }
+        },
+
+        async deleteBattle(id, root) {
+          if (!confirm('Delete this battle?')) return;
+          try {
+            await fetch('/battles/' + id, { method: 'DELETE' });
+            if (root.params.id === id) root.navigate('/battles');
+            window.dispatchEvent(new CustomEvent('battle-deleted'));
+          } catch(_) {}
         }
       };
     }
 
+    // ── Shared constants ─────────────────────────────────────
     const DEFAULT_RUBRIC = `Score the following LLM output on a scale from 0 to 10.
 
 **Criteria:**
@@ -903,19 +1077,14 @@ Do not wrap the JSON in markdown fences.`;
       ollama: 'llama3.2',
     };
 
+    // ── Battle form ──────────────────────────────────────────
     function battleForm() {
       return {
-        name: '',
-        judge_provider: 'openai',
-        judge_model: 'gpt-4o',
-        judge_rubric: DEFAULT_RUBRIC,
-        loading: false,
-        error: null,
-        providers: [],
-        _mde: null,
+        name: '', judge_provider: 'openai', judge_model: 'gpt-4o',
+        judge_rubric: DEFAULT_RUBRIC, loading: false, error: null,
+        providers: [], _mde: null,
 
         async init() {
-          // Load available providers from GET /keys
           try {
             const resp = await fetch('/keys');
             if (resp.ok) {
@@ -927,64 +1096,39 @@ Do not wrap the JSON in markdown fences.`;
               }
             }
           } catch(_) {}
-          // Fallback to default providers list if keys endpoint unavailable
           if (this.providers.length === 0) {
             this.providers = ['openai', 'anthropic', 'google', 'groq', 'openrouter', 'ollama'];
           }
-
-          // Mount EasyMDE on the rubric textarea
           await this.$nextTick();
           const ta = this.$refs.rubricTextarea;
           if (ta && typeof EasyMDE !== 'undefined') {
             this._mde = new EasyMDE({
-              element: ta,
-              initialValue: this.judge_rubric,
-              spellChecker: false,
+              element: ta, initialValue: this.judge_rubric, spellChecker: false,
               autosave: { enabled: false },
               toolbar: ['bold', 'italic', '|', 'unordered-list', 'ordered-list', '|', 'preview'],
-              minHeight: '180px',
-              placeholder: 'Describe how the judge should score outputs (0-10)…',
+              minHeight: '180px', placeholder: 'Describe how the judge should score outputs (0-10)…',
             });
-            this._mde.codemirror.on('change', () => {
-              this.judge_rubric = this._mde.value();
-            });
+            this._mde.codemirror.on('change', () => { this.judge_rubric = this._mde.value(); });
           }
         },
 
-        onProviderChange() {
-          this.judge_model = DEFAULT_MODELS[this.judge_provider] || '';
-        },
-
-        modelPlaceholder() {
-          return DEFAULT_MODELS[this.judge_provider]
-            ? `e.g. ${DEFAULT_MODELS[this.judge_provider]}`
-            : 'e.g. my-custom-model';
-        },
+        onProviderChange() { this.judge_model = DEFAULT_MODELS[this.judge_provider] || ''; },
+        modelPlaceholder() { return DEFAULT_MODELS[this.judge_provider] ? `e.g. ${DEFAULT_MODELS[this.judge_provider]}` : 'e.g. my-custom-model'; },
 
         async submit() {
-          // Sync EasyMDE value before submitting
           if (this._mde) this.judge_rubric = this._mde.value();
-          if (!this.name.trim()) {
-            this.error = 'Battle name is required.';
-            return;
-          }
-          this.loading = true;
-          this.error = null;
+          if (!this.name.trim()) { this.error = 'Battle name is required.'; return; }
+          this.loading = true; this.error = null;
           try {
             const resp = await fetch('/battles', {
               method: 'POST',
               headers: {'Content-Type': 'application/json'},
-              body: JSON.stringify({
-                name: this.name,
-                judge_provider: this.judge_provider,
-                judge_model: this.judge_model,
-                judge_rubric: this.judge_rubric,
-              })
+              body: JSON.stringify({ name: this.name, judge_provider: this.judge_provider, judge_model: this.judge_model, judge_rubric: this.judge_rubric })
             });
             if (!resp.ok) throw new Error(await resp.text());
             const data = await resp.json();
-            // Destroy EasyMDE before navigating away to avoid ghost instances
             if (this._mde) { try { this._mde.toTextArea(); } catch(_) {} this._mde = null; }
+            window.dispatchEvent(new CustomEvent('battle-created'));
             window.location.hash = '/battles/' + data.id;
           } catch(e) {
             this.error = e.message;
@@ -995,97 +1139,26 @@ Do not wrap the JSON in markdown fences.`;
       };
     }
 
-    function keysList() {
-      return {
-        keys: [],
-        loading: false,
-        error: null,
-        inputs: {},
-        saved: {},
-        saveErrors: {},
-
-        async load() {
-          this.loading = true;
-          this.error = null;
-          try {
-            const resp = await fetch('/keys');
-            if (!resp.ok) throw new Error(await resp.text());
-            this.keys = await resp.json();
-            this.keys.forEach(k => {
-              if (this.inputs[k.provider] === undefined) this.inputs[k.provider] = '';
-            });
-          } catch(e) {
-            this.error = e.message;
-          } finally {
-            this.loading = false;
-          }
-        },
-
-        async save(provider) {
-          const val = (this.inputs[provider] || '').trim();
-          if (!val) {
-            this.saveErrors[provider] = 'Please enter a key before saving.';
-            return;
-          }
-          delete this.saveErrors[provider];
-          try {
-            const resp = await fetch('/keys/' + provider, {
-              method: 'PUT',
-              headers: {'Content-Type': 'application/json'},
-              body: JSON.stringify({ key: val })
-            });
-            if (!resp.ok) throw new Error(await resp.text());
-            this.inputs[provider] = '';
-            this.saved[provider] = true;
-            setTimeout(() => { delete this.saved[provider]; }, 3000);
-            await this.load();
-          } catch(e) {
-            this.saveErrors[provider] = e.message;
-          }
-        },
-
-        async remove(provider) {
-          delete this.saved[provider];
-          delete this.saveErrors[provider];
-          try {
-            const resp = await fetch('/keys/' + provider, { method: 'DELETE' });
-            if (!resp.ok) throw new Error(await resp.text());
-            await this.load();
-          } catch(e) {
-            this.saveErrors[provider] = e.message;
-          }
-        }
-      };
-    }
-
+    // ── Battle detail (sources) ──────────────────────────────
     function battleDetail() {
       return {
-        sources: [],
-        uploading: false,
-        error: null,
-        running: false,
-        fighterCount: 0,
-        runError: null,
-        currentBattleId: null,
+        sources: [], uploading: false, error: null,
+        running: false, fighterCount: 0, runError: null, currentBattleId: null,
 
         async load(battleId) {
           if (!battleId) return;
-          this.currentBattleId = battleId;
-          this.error = null;
+          this.currentBattleId = battleId; this.error = null;
           try {
             const resp = await fetch(`/battles/${battleId}/sources`);
             if (!resp.ok) throw new Error(await resp.text());
             const data = await resp.json();
             this.sources = data.sources || [];
-          } catch(e) {
-            this.error = e.message;
-          }
+          } catch(e) { this.error = e.message; }
         },
 
         async runBattle() {
           if (!this.currentBattleId) return;
-          this.running = true;
-          this.runError = null;
+          this.running = true; this.runError = null;
           try {
             const resp = await fetch('/runs', {
               method: 'POST',
@@ -1095,42 +1168,25 @@ Do not wrap the JSON in markdown fences.`;
             if (!resp.ok) throw new Error(await resp.text());
             const data = await resp.json();
             window.location.hash = '/runs/' + data.run_id;
-          } catch(e) {
-            this.runError = e.message;
-            this.running = false;
-          }
+          } catch(e) { this.runError = e.message; this.running = false; }
         },
 
         async upload(event, battleId) {
           if (!battleId) return;
           const files = Array.from(event.target.files || []);
           if (!files.length) return;
-
-          this.uploading = true;
-          this.error = null;
-
+          this.uploading = true; this.error = null;
           for (const file of files) {
             try {
               const formData = new FormData();
               formData.append('file', file);
-              const resp = await fetch(`/battles/${battleId}/sources`, {
-                method: 'POST',
-                body: formData,
-              });
-              if (!resp.ok) {
-                const msg = await resp.text();
-                throw new Error(`${file.name}: ${msg}`);
-              }
+              const resp = await fetch(`/battles/${battleId}/sources`, { method: 'POST', body: formData });
+              if (!resp.ok) throw new Error(`${file.name}: ${await resp.text()}`);
               const data = await resp.json();
-              // server may return single or multiple sources (CSV)
               const newItems = data.sources || (data.id ? [data] : []);
               this.sources.push(...newItems);
-            } catch(e) {
-              this.error = e.message;
-            }
+            } catch(e) { this.error = e.message; }
           }
-
-          // reset file input
           event.target.value = '';
           this.uploading = false;
         },
@@ -1138,287 +1194,48 @@ Do not wrap the JSON in markdown fences.`;
         async remove(battleId, sourceId) {
           this.error = null;
           try {
-            const resp = await fetch(`/battles/${battleId}/sources/${sourceId}`, {
-              method: 'DELETE',
-            });
+            const resp = await fetch(`/battles/${battleId}/sources/${sourceId}`, { method: 'DELETE' });
             if (!resp.ok) throw new Error(await resp.text());
             this.sources = this.sources.filter(s => s.id !== sourceId);
-          } catch(e) {
-            this.error = e.message;
-          }
+          } catch(e) { this.error = e.message; }
         }
       };
     }
 
-    function runView() {
-      return {
-        runId: null,
-        run: null,
-        polling: null,
-        error: null,
-
-        init(runId) {
-          if (this.polling) { clearInterval(this.polling); this.polling = null; }
-          this.runId = runId;
-          this.run = null;
-          this.error = null;
-          this.startPolling();
-        },
-
-        async fetchStatus() {
-          try {
-            const resp = await fetch('/runs/' + this.runId + '/status');
-            if (!resp.ok) throw new Error(await resp.text());
-            this.run = await resp.json();
-            if (this.run.status === 'complete' || this.run.status === 'error') {
-              this.stopPolling();
-            }
-          } catch(e) {
-            this.error = e.message;
-            this.stopPolling();
-          }
-        },
-
-        startPolling() {
-          this.fetchStatus();
-          this.polling = setInterval(() => this.fetchStatus(), 2000);
-        },
-
-        stopPolling() {
-          if (this.polling) {
-            clearInterval(this.polling);
-            this.polling = null;
-          }
-        },
-
-        sources() {
-          if (!this.run || !this.run.fighter_results) return [];
-          const seen = new Set();
-          return this.run.fighter_results.filter(fr => {
-            if (seen.has(fr.source_id)) return false;
-            seen.add(fr.source_id);
-            return true;
-          }).map(fr => ({
-            source_id: fr.source_id,
-            source_label: fr.source_id ? fr.source_id.slice(0, 12) + '...' : fr.source_id
-          }));
-        },
-
-        fighters() {
-          if (!this.run || !this.run.fighter_results) return [];
-          const seen = new Set();
-          return this.run.fighter_results.filter(fr => {
-            if (seen.has(fr.fighter_id)) return false;
-            seen.add(fr.fighter_id);
-            return true;
-          }).map(fr => ({
-            fighter_id: fr.fighter_id,
-            fighter_name: fr.fighter_name || fr.fighter_id
-          }));
-        },
-
-        getCellResult(fighter_id, source_id) {
-          if (!this.run || !this.run.fighter_results) return null;
-          return this.run.fighter_results.find(
-            fr => fr.fighter_id === fighter_id && fr.source_id === source_id
-          ) || null;
-        },
-
-        async submit(stepResultId, content) {
-          const resp = await fetch('/runs/' + this.runId + '/steps/' + stepResultId + '/submit', {
-            method: 'POST',
-            headers: {'Content-Type': 'application/json'},
-            body: JSON.stringify({ content })
-          });
-          if (!resp.ok) throw new Error(await resp.text());
-          return resp.json();
-        }
-      };
-    }
-
-    function resultsView() {
-      return {
-        runId: null,
-        results: null,
-        expanded: {},
-        error: null,
-        loading: false,
-
-        async load(runId) {
-          this.runId = runId;
-          this.results = null;
-          this.error = null;
-          this.expanded = {};
-          this.loading = true;
-          try {
-            const resp = await fetch('/runs/' + runId + '/results');
-            if (!resp.ok) throw new Error(await resp.text());
-            this.results = await resp.json();
-          } catch(e) {
-            this.error = e.message;
-          } finally {
-            this.loading = false;
-          }
-        },
-
-        toggleExpand(key) {
-          this.expanded[key] = !this.expanded[key];
-        },
-
-        fighterSummary() {
-          if (!this.results || !this.results.summary) return [];
-          const map = {};
-          for (const item of this.results.summary) {
-            const name = item.fighter_name;
-            if (!map[name]) {
-              map[name] = { fighter_name: name, scores: [], total_cost: 0, token_cost: 0, credit_cost: 0, total_steps: 0, item_count: 0 };
-            }
-            if (item.score !== null && item.score !== undefined) map[name].scores.push(item.score);
-            map[name].total_cost += item.total_cost_usd || 0;
-            // Token cost: steps that consumed tokens
-            if (item.total_input_tokens || item.total_output_tokens) {
-              map[name].token_cost += item.total_cost_usd || 0;
-            } else if (item.total_cost_usd) {
-              // No tokens → credit-based cost
-              map[name].credit_cost += item.total_cost_usd || 0;
-            }
-            map[name].total_steps += item.step_count || 0;
-            map[name].item_count += 1;
-          }
-          return Object.values(map).map(f => ({
-            ...f,
-            avg_score: f.scores.length ? f.scores.reduce((a, b) => a + b, 0) / f.scores.length : 0,
-          })).sort((a, b) => b.avg_score - a.avg_score);
-        },
-
-        sourceGroups() {
-          if (!this.results || !this.results.summary) return [];
-          const order = [];
-          const map = {};
-          for (const item of this.results.summary) {
-            const label = item.source_label || item.source_id || 'Unknown';
-            if (!map[label]) {
-              map[label] = { label, fighters: [] };
-              order.push(label);
-            }
-            map[label].fighters.push(item);
-          }
-          return order.map(l => map[l]);
-        },
-
-        scoreColor(score) {
-          if (score === null || score === undefined) return 'color:#888;';
-          if (score >= 8) return 'color:#27ae60;';
-          if (score >= 5) return 'color:#e67e22;';
-          return 'color:#c0392b;';
-        },
-
-        renderMarkdown(text) {
-          if (typeof marked !== 'undefined') {
-            return marked.parse ? marked.parse(text) : marked(text);
-          }
-          return text.replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;');
-        },
-
-        downloadMarkdown() {
-          if (!this.results) return;
-          const summary = this.fighterSummary();
-          const lines = [];
-          lines.push('# LLM Battle Results');
-          lines.push('');
-          lines.push('**Run ID:** ' + (this.results.run_id || this.runId));
-          if (this.results.battle_id) lines.push('**Battle ID:** ' + this.results.battle_id);
-          lines.push('');
-          lines.push('## Fighter Summary');
-          lines.push('');
-          lines.push('| Fighter | Avg Score | Total Cost USD | Steps | Items |');
-          lines.push('|---------|-----------|---------------|-------|-------|');
-          for (const f of summary) {
-            lines.push('| ' + f.fighter_name + ' | ' + f.avg_score.toFixed(2) + ' | $' + f.total_cost.toFixed(4) + ' | ' + f.total_steps + ' | ' + f.item_count + ' |');
-          }
-          lines.push('');
-          lines.push('## Per-Source Breakdown');
-          lines.push('');
-          for (const source of this.sourceGroups()) {
-            lines.push('### ' + source.label);
-            lines.push('');
-            for (const fighter of source.fighters) {
-              lines.push('**' + fighter.fighter_name + '** — Score: ' + (fighter.score !== null && fighter.score !== undefined ? fighter.score.toFixed(1) : 'N/A'));
-              lines.push('');
-              lines.push('```');
-              lines.push(fighter.final_output || '(no output)');
-              lines.push('```');
-              lines.push('');
-            }
-          }
-          if (this.results.report_markdown) {
-            lines.push('## Judge Report');
-            lines.push('');
-            lines.push(this.results.report_markdown);
-            lines.push('');
-          }
-          const blob = new Blob([lines.join('\n')], { type: 'text/markdown' });
-          const url = URL.createObjectURL(blob);
-          const a = document.createElement('a');
-          a.href = url;
-          a.download = 'battle-results-' + (this.runId || 'export') + '.md';
-          a.click();
-          URL.revokeObjectURL(url);
-        },
-      };
-    }
-
+    // ── Fighter list ─────────────────────────────────────────
     function fighterList() {
       return {
-        fighters: [],
-        loadingFighters: false,
-        fightersError: null,
-
-        showAddFighter: false,
-        newFighter: { name: '', is_manual: false },
-        addingFighter: false,
-        addFighterError: null,
-
+        fighters: [], loadingFighters: false, fightersError: null,
+        showAddFighter: false, newFighter: { name: '', is_manual: false },
+        addingFighter: false, addFighterError: null,
         activeStepFighterId: null,
         newStep: { system_prompt: '', provider: 'openai', model_id: '', model_id_custom: '', provider_config: '{}', selected_tools: [] },
-        addingStep: false,
-        addStepError: null,
-
+        addingStep: false, addStepError: null,
         providers: ['openai', 'anthropic', 'google', 'groq', 'openrouter', 'ollama'],
-        providerInfoList: [],  // [{name, display_name, provider_type, models:[{id,pricing_label}], native_tools:[]}]
+        providerInfoList: [],
 
         _dispatchCount() {
           window.dispatchEvent(new CustomEvent('fighters-updated', { detail: { count: this.fighters.length } }));
         },
 
-        // Return provider_type ('llm'|'tool'|null) for currently selected provider
         stepProviderType() {
           const info = this.providerInfoList.find(p => p.name === this.newStep.provider);
           return info ? info.provider_type : null;
         },
-
-        // Return model/function list for selected provider
         stepProviderModels() {
           const info = this.providerInfoList.find(p => p.name === this.newStep.provider);
           return info ? info.models : [];
         },
-
-        // Return pricing hint for selected model/function
         stepPricingHint() {
-          const models = this.stepProviderModels();
           const mid = this.newStep.model_id;
-          if (!mid || !models.length) return null;
-          const m = models.find(x => x.id === mid);
+          if (!mid) return null;
+          const m = this.stepProviderModels().find(x => x.id === mid);
           return m ? m.pricing_label : null;
         },
-
-        // Return native tools for selected LLM provider
         stepNativeTools() {
           const info = this.providerInfoList.find(p => p.name === this.newStep.provider);
           return (info && info.native_tools) ? info.native_tools : [];
         },
-
-        // When provider changes, reset model selection and auto-select first model
         onStepProviderChange() {
           const models = this.stepProviderModels();
           this.newStep.model_id = models.length ? models[0].id : '';
@@ -1427,9 +1244,7 @@ Do not wrap the JSON in markdown fences.`;
         },
 
         async load(battleId) {
-          this.loadingFighters = true;
-          this.fightersError = null;
-          // Load provider info in parallel
+          this.loadingFighters = true; this.fightersError = null;
           try {
             const [fightersResp, provResp] = await Promise.all([
               fetch('/battles/' + battleId + '/fighters'),
@@ -1441,14 +1256,11 @@ Do not wrap the JSON in markdown fences.`;
               this.providerInfoList = await provResp.json();
               this.providers = this.providerInfoList.map(p => p.name);
             }
-            // Default provider = first LLM provider available
             const firstLlm = this.providerInfoList.find(p => p.provider_type === 'llm');
             if (firstLlm) {
               this.newStep.provider = firstLlm.name;
-              const models = firstLlm.models;
-              this.newStep.model_id = models.length ? models[0].id : '';
+              this.newStep.model_id = firstLlm.models.length ? firstLlm.models[0].id : '';
             }
-            // Load steps for each fighter
             const withSteps = await Promise.all(fighters.map(async f => {
               try {
                 const r = await fetch('/battles/' + battleId + '/fighters/' + f.id);
@@ -1458,16 +1270,12 @@ Do not wrap the JSON in markdown fences.`;
             }));
             this.fighters = withSteps;
             this._dispatchCount();
-          } catch(e) {
-            this.fightersError = e.message;
-          } finally {
-            this.loadingFighters = false;
-          }
+          } catch(e) { this.fightersError = e.message; }
+          finally { this.loadingFighters = false; }
         },
 
         async addFighter(battleId) {
-          this.addingFighter = true;
-          this.addFighterError = null;
+          this.addingFighter = true; this.addFighterError = null;
           try {
             const resp = await fetch('/battles/' + battleId + '/fighters', {
               method: 'POST',
@@ -1480,11 +1288,8 @@ Do not wrap the JSON in markdown fences.`;
             this.newFighter = { name: '', is_manual: false };
             this.showAddFighter = false;
             this._dispatchCount();
-          } catch(e) {
-            this.addFighterError = e.message;
-          } finally {
-            this.addingFighter = false;
-          }
+          } catch(e) { this.addFighterError = e.message; }
+          finally { this.addingFighter = false; }
         },
 
         toggleAddStep(fighterId) {
@@ -1492,31 +1297,24 @@ Do not wrap the JSON in markdown fences.`;
             this.activeStepFighterId = null;
           } else {
             this.activeStepFighterId = fighterId;
-            // Default to first LLM provider
             const firstLlm = this.providerInfoList.find(p => p.provider_type === 'llm');
             const defaultProvider = firstLlm ? firstLlm.name : 'openai';
             const defaultModels = firstLlm ? firstLlm.models : [];
             this.newStep = {
-              system_prompt: '',
-              provider: defaultProvider,
+              system_prompt: '', provider: defaultProvider,
               model_id: defaultModels.length ? defaultModels[0].id : '',
-              model_id_custom: '',
-              provider_config: '{}',
-              selected_tools: [],
+              model_id_custom: '', provider_config: '{}', selected_tools: [],
             };
             this.addStepError = null;
           }
         },
 
         async addStep(battleId, fighterId) {
-          this.addingStep = true;
-          this.addStepError = null;
+          this.addingStep = true; this.addStepError = null;
           try {
             const fighter = this.fighters.find(f => f.id === fighterId);
             const position = fighter ? (fighter.steps ? fighter.steps.length : 0) : 0;
-            // Resolve final model_id (may be 'Custom...' sentinel → use model_id_custom)
             const finalModelId = this.newStep.model_id === '' ? this.newStep.model_id_custom : this.newStep.model_id;
-            // Merge selected_tools into provider_config if any are selected
             let configObj = {};
             try { configObj = JSON.parse(this.newStep.provider_config || '{}'); } catch(_) {}
             if (this.newStep.selected_tools && this.newStep.selected_tools.length > 0) {
@@ -1526,40 +1324,202 @@ Do not wrap the JSON in markdown fences.`;
               method: 'POST',
               headers: { 'Content-Type': 'application/json' },
               body: JSON.stringify({
-                position: position,
-                system_prompt: this.newStep.system_prompt || null,
-                provider: this.newStep.provider,
-                model_id: finalModelId,
+                position, system_prompt: this.newStep.system_prompt || null,
+                provider: this.newStep.provider, model_id: finalModelId,
                 provider_config: JSON.stringify(configObj),
               })
             });
             if (!resp.ok) throw new Error(await resp.text());
             const step = await resp.json();
-            if (fighter) {
-              if (!fighter.steps) fighter.steps = [];
-              fighter.steps.push(step);
-            }
+            if (fighter) { if (!fighter.steps) fighter.steps = []; fighter.steps.push(step); }
             this.activeStepFighterId = null;
             const firstLlm = this.providerInfoList.find(p => p.provider_type === 'llm');
-            const defaultProvider = firstLlm ? firstLlm.name : 'openai';
-            const defaultModels = firstLlm ? firstLlm.models : [];
             this.newStep = {
               system_prompt: '',
-              provider: defaultProvider,
-              model_id: defaultModels.length ? defaultModels[0].id : '',
-              model_id_custom: '',
-              provider_config: '{}',
-              selected_tools: [],
+              provider: firstLlm ? firstLlm.name : 'openai',
+              model_id: firstLlm && firstLlm.models.length ? firstLlm.models[0].id : '',
+              model_id_custom: '', provider_config: '{}', selected_tools: [],
             };
-          } catch(e) {
-            this.addStepError = e.message;
-          } finally {
-            this.addingStep = false;
-          }
+          } catch(e) { this.addStepError = e.message; }
+          finally { this.addingStep = false; }
         }
       };
     }
 
+    // ── API Keys ─────────────────────────────────────────────
+    function keysList() {
+      return {
+        keys: [], loading: false, error: null, inputs: {}, saved: {}, saveErrors: {},
+
+        async load() {
+          this.loading = true; this.error = null;
+          try {
+            const resp = await fetch('/keys');
+            if (!resp.ok) throw new Error(await resp.text());
+            this.keys = await resp.json();
+            this.keys.forEach(k => { if (this.inputs[k.provider] === undefined) this.inputs[k.provider] = ''; });
+          } catch(e) { this.error = e.message; }
+          finally { this.loading = false; }
+        },
+
+        async save(provider) {
+          const val = (this.inputs[provider] || '').trim();
+          if (!val) { this.saveErrors[provider] = 'Please enter a key before saving.'; return; }
+          delete this.saveErrors[provider];
+          try {
+            const resp = await fetch('/keys/' + provider, {
+              method: 'PUT',
+              headers: {'Content-Type': 'application/json'},
+              body: JSON.stringify({ key: val })
+            });
+            if (!resp.ok) throw new Error(await resp.text());
+            this.inputs[provider] = '';
+            this.saved[provider] = true;
+            setTimeout(() => { delete this.saved[provider]; }, 3000);
+            await this.load();
+          } catch(e) { this.saveErrors[provider] = e.message; }
+        },
+
+        async remove(provider) {
+          delete this.saved[provider]; delete this.saveErrors[provider];
+          try {
+            const resp = await fetch('/keys/' + provider, { method: 'DELETE' });
+            if (!resp.ok) throw new Error(await resp.text());
+            await this.load();
+          } catch(e) { this.saveErrors[provider] = e.message; }
+        }
+      };
+    }
+
+    // ── Run view ─────────────────────────────────────────────
+    function runView() {
+      return {
+        runId: null, run: null, polling: null, error: null,
+
+        init(runId) {
+          if (this.polling) { clearInterval(this.polling); this.polling = null; }
+          this.runId = runId; this.run = null; this.error = null;
+          this.startPolling();
+        },
+
+        async fetchStatus() {
+          try {
+            const resp = await fetch('/runs/' + this.runId + '/status');
+            if (!resp.ok) throw new Error(await resp.text());
+            this.run = await resp.json();
+            if (this.run.status === 'complete' || this.run.status === 'error') this.stopPolling();
+          } catch(e) { this.error = e.message; this.stopPolling(); }
+        },
+
+        startPolling() { this.fetchStatus(); this.polling = setInterval(() => this.fetchStatus(), 2000); },
+        stopPolling() { if (this.polling) { clearInterval(this.polling); this.polling = null; } },
+
+        sources() {
+          if (!this.run || !this.run.fighter_results) return [];
+          const seen = new Set();
+          return this.run.fighter_results.filter(fr => {
+            if (seen.has(fr.source_id)) return false; seen.add(fr.source_id); return true;
+          }).map(fr => ({ source_id: fr.source_id, source_label: fr.source_id ? fr.source_id.slice(0,12) + '...' : fr.source_id }));
+        },
+
+        fighters() {
+          if (!this.run || !this.run.fighter_results) return [];
+          const seen = new Set();
+          return this.run.fighter_results.filter(fr => {
+            if (seen.has(fr.fighter_id)) return false; seen.add(fr.fighter_id); return true;
+          }).map(fr => ({ fighter_id: fr.fighter_id, fighter_name: fr.fighter_name || fr.fighter_id }));
+        },
+
+        getCellResult(fighter_id, source_id) {
+          if (!this.run || !this.run.fighter_results) return null;
+          return this.run.fighter_results.find(fr => fr.fighter_id === fighter_id && fr.source_id === source_id) || null;
+        }
+      };
+    }
+
+    // ── Results view ─────────────────────────────────────────
+    function resultsView() {
+      return {
+        runId: null, results: null, expanded: {}, error: null, loading: false,
+
+        async load(runId) {
+          this.runId = runId; this.results = null; this.error = null; this.expanded = {}; this.loading = true;
+          try {
+            const resp = await fetch('/runs/' + runId + '/results');
+            if (!resp.ok) throw new Error(await resp.text());
+            this.results = await resp.json();
+          } catch(e) { this.error = e.message; }
+          finally { this.loading = false; }
+        },
+
+        toggleExpand(key) { this.expanded[key] = !this.expanded[key]; },
+
+        fighterSummary() {
+          if (!this.results || !this.results.summary) return [];
+          const map = {};
+          for (const item of this.results.summary) {
+            const name = item.fighter_name;
+            if (!map[name]) map[name] = { fighter_name: name, scores: [], total_cost: 0, token_cost: 0, credit_cost: 0, total_steps: 0, item_count: 0 };
+            if (item.score !== null && item.score !== undefined) map[name].scores.push(item.score);
+            map[name].total_cost += item.total_cost_usd || 0;
+            if (item.total_input_tokens || item.total_output_tokens) map[name].token_cost += item.total_cost_usd || 0;
+            else if (item.total_cost_usd) map[name].credit_cost += item.total_cost_usd || 0;
+            map[name].total_steps += item.step_count || 0;
+            map[name].item_count += 1;
+          }
+          return Object.values(map).map(f => ({
+            ...f, avg_score: f.scores.length ? f.scores.reduce((a, b) => a + b, 0) / f.scores.length : 0,
+          })).sort((a, b) => b.avg_score - a.avg_score);
+        },
+
+        sourceGroups() {
+          if (!this.results || !this.results.summary) return [];
+          const order = []; const map = {};
+          for (const item of this.results.summary) {
+            const label = item.source_label || item.source_id || 'Unknown';
+            if (!map[label]) { map[label] = { label, fighters: [] }; order.push(label); }
+            map[label].fighters.push(item);
+          }
+          return order.map(l => map[l]);
+        },
+
+        scoreColor(score) {
+          if (score === null || score === undefined) return 'color:var(--mid);';
+          if (score >= 8) return 'color:var(--success);';
+          if (score >= 5) return 'color:#e67e22;';
+          return 'color:var(--danger);';
+        },
+
+        renderMarkdown(text) {
+          if (typeof marked !== 'undefined') return marked.parse ? marked.parse(text) : marked(text);
+          return text.replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;');
+        },
+
+        downloadMarkdown() {
+          if (!this.results) return;
+          const summary = this.fighterSummary();
+          const lines = ['# LLM Battle Results', '', '**Run ID:** ' + (this.results.run_id || this.runId)];
+          if (this.results.battle_id) lines.push('**Battle ID:** ' + this.results.battle_id);
+          lines.push('', '## Fighter Summary', '', '| Fighter | Avg Score | Total Cost USD | Steps | Items |', '|---------|-----------|---------------|-------|-------|');
+          for (const f of summary) lines.push('| ' + f.fighter_name + ' | ' + f.avg_score.toFixed(2) + ' | $' + f.total_cost.toFixed(4) + ' | ' + f.total_steps + ' | ' + f.item_count + ' |');
+          lines.push('', '## Per-Source Breakdown', '');
+          for (const source of this.sourceGroups()) {
+            lines.push('### ' + source.label, '');
+            for (const fighter of source.fighters) {
+              lines.push('**' + fighter.fighter_name + '** — Score: ' + (fighter.score !== null && fighter.score !== undefined ? fighter.score.toFixed(1) : 'N/A'), '', '```', fighter.final_output || '(no output)', '```', '');
+            }
+          }
+          if (this.results.report_markdown) lines.push('## Judge Report', '', this.results.report_markdown, '');
+          const blob = new Blob([lines.join('\n')], { type: 'text/markdown' });
+          const url = URL.createObjectURL(blob);
+          const a = document.createElement('a');
+          a.href = url; a.download = 'battle-results-' + (this.runId || 'export') + '.md'; a.click();
+          URL.revokeObjectURL(url);
+        }
+      };
+    }
+
+    // ── App (router) ─────────────────────────────────────────
     function app() {
       return {
         route: 'battles',
@@ -1568,17 +1528,17 @@ Do not wrap the JSON in markdown fences.`;
         async init() {
           this.parseRoute();
           window.addEventListener('hashchange', () => this.parseRoute());
-          // Smart landing: if no specific route is requested, go to most recent battle or new battle form
           if (!window.location.hash || window.location.hash === '#/' || window.location.hash === '#/battles') {
-            const resp = await fetch('/battles');
-            const battles = await resp.json();
-            if (battles && battles.length > 0) {
-              // Sort by created_at desc to get most recent, navigate to it
-              const sorted = battles.sort((a, b) => b.created_at > a.created_at ? 1 : -1);
-              window.location.hash = '/battles/' + sorted[0].id;
-            } else {
-              window.location.hash = '/battles/new';
-            }
+            try {
+              const resp = await fetch('/battles');
+              const battles = (await resp.json()).filter(b => b && b.id);
+              if (battles.length > 0) {
+                const sorted = battles.sort((a, b) => b.created_at > a.created_at ? 1 : -1);
+                window.location.hash = '/battles/' + sorted[0].id;
+              } else {
+                window.location.hash = '/battles/new';
+              }
+            } catch(_) { window.location.hash = '/battles/new'; }
           }
         },
 
@@ -1587,39 +1547,20 @@ Do not wrap the JSON in markdown fences.`;
           const hash = raw || 'battles';
           const parts = hash.split('/');
 
-          // #/ or #/battles
           if (hash === 'battles' || hash === '') {
-            this.route = 'battles';
-            this.params = {};
-
-          // #/battles/new
+            this.route = 'battles'; this.params = {};
           } else if (parts[0] === 'battles' && parts[1] === 'new') {
-            this.route = 'battles/new';
-            this.params = {};
-
-          // #/battles/:id
+            this.route = 'battles/new'; this.params = {};
           } else if (parts[0] === 'battles' && parts[1]) {
-            this.route = 'battles/detail';
-            this.params = { id: parts[1] };
-
-          // #/runs/:id
+            this.route = 'battles/detail'; this.params = { id: parts[1] };
           } else if (parts[0] === 'runs' && parts[1]) {
-            this.route = 'runs/detail';
-            this.params = { id: parts[1] };
-
-          // #/results/:id
+            this.route = 'runs/detail'; this.params = { id: parts[1] };
           } else if (parts[0] === 'results' && parts[1]) {
-            this.route = 'results/detail';
-            this.params = { id: parts[1] };
-
-          // #/keys
+            this.route = 'results/detail'; this.params = { id: parts[1] };
           } else if (parts[0] === 'keys') {
-            this.route = 'keys';
-            this.params = {};
-
+            this.route = 'keys'; this.params = {};
           } else {
-            this.route = 'not-found';
-            this.params = {};
+            this.route = 'not-found'; this.params = {};
           }
         },
 


### PR DESCRIPTION
## Summary

- Replaces single-column light layout with persistent 260px sidebar + scrollable main content area
- Sidebar: battle list with click-to-navigate, delete button, `+ New` shortcut, API Keys footer link
- Applies Gold-on-Ink dark theme throughout (`#0d0f13` ink, `#14181f` card, `#F0B90B` gold accent, `#E7ECF3` text)
- All existing flows preserved: battle creation, sources, fighters, run view, results, API keys

## Test plan

- [ ] Sidebar visible with battle list on all views
- [ ] Click battle in sidebar → loads detail in main area
- [ ] `+ New` in sidebar → navigates to new battle form
- [ ] Delete button (×) in sidebar → removes battle, navigates away if active
- [ ] Dark theme applied throughout (no light backgrounds)
- [ ] Create battle, add sources, add fighter+step, run battle, view results all work
- [ ] API Keys page accessible from sidebar footer

Closes #120

🤖 Generated with [Claude Code](https://claude.com/claude-code)