### PR TITLE
fix: sidebar delete battle button does not work

### DIFF
--- a/t01_llm_battle/static/index.html
+++ b/t01_llm_battle/static/index.html
@@ -1044,10 +1044,11 @@
         async deleteBattle(id, root) {
           if (!confirm('Delete this battle?')) return;
           try {
-            await fetch('/battles/' + id, { method: 'DELETE' });
+            const resp = await fetch('/battles/' + id, { method: 'DELETE' });
+            if (!resp.ok) throw new Error(await resp.text());
             if (root.params.id === id) root.navigate('/battles');
             window.dispatchEvent(new CustomEvent('battle-deleted'));
-          } catch(_) {}
+          } catch(e) { alert('Delete failed: ' + e.message); }
         }
       };
     }


### PR DESCRIPTION
## Summary

- Check `resp.ok` after `DELETE /battles/{id}` fetch — previously silently swallowed errors
- Surface error to user via `alert()` if delete fails
- Sidebar still reloads on success via existing `battle-deleted` event

## Test plan
- [ ] Click × on a battle in sidebar — confirm dialog appears
- [ ] Delete succeeds: battle removed from sidebar, navigates away if active
- [ ] Simulate error (bad network): alert shown with error message

Closes #125

🤖 Generated with [Claude Code](https://claude.com/claude-code)