### PR TITLE
feat: show battle name and inline edit button in detail header

### DIFF
--- a/t01_llm_battle/static/index.html
+++ b/t01_llm_battle/static/index.html
@@ -459,9 +459,26 @@
                x-data="battleDetail()"
                x-init="$watch('$root.params.id', id => { if (id) load(id); }); if ($root.params.id) load($root.params.id);">
 
-        <div style="display:flex;align-items:center;gap:0.75rem;margin-bottom:1.5rem;">
+        <div style="display:flex;align-items:center;gap:0.75rem;margin-bottom:1.5rem;flex-wrap:wrap;">
           <h1 style="margin:0;">Battle Detail</h1>
+          <template x-if="battleName && !editingName">
+            <span style="font-weight:600;color:var(--high);font-size:1.1rem;" x-text="'— ' + battleName"></span>
+          </template>
           <span class="badge-muted" x-text="params.id ? params.id.slice(0,8) + '...' : ''"></span>
+          <template x-if="!editingName">
+            <button @click="startEditName()" style="background:none;border:none;cursor:pointer;color:var(--gold);font-size:0.85rem;padding:2px 6px;" title="Rename battle">✏️ Edit</button>
+          </template>
+          <template x-if="editingName">
+            <div style="display:flex;align-items:center;gap:0.5rem;">
+              <input x-ref="nameInput" type="text" x-model="nameInput"
+                style="font-size:0.95rem;padding:4px 8px;width:220px;"
+                @keydown.enter="saveName()" @keydown.escape="cancelEditName()">
+              <button @click="saveName()" class="btn-primary" :disabled="nameSaving" style="padding:4px 12px;font-size:0.83rem;">
+                <span x-text="nameSaving ? 'Saving...' : 'Save'"></span>
+              </button>
+              <button @click="cancelEditName()" style="background:none;border:none;cursor:pointer;color:var(--mid);font-size:0.83rem;">Cancel</button>
+            </div>
+          </template>
         </div>
 
         <!-- Sources card -->
@@ -1144,16 +1161,49 @@ Do not wrap the JSON in markdown fences.`;
       return {
         sources: [], uploading: false, error: null,
         running: false, fighterCount: 0, runError: null, currentBattleId: null,
+        battleName: '', editingName: false, nameInput: '', nameSaving: false,
 
         async load(battleId) {
           if (!battleId) return;
-          this.currentBattleId = battleId; this.error = null;
+          this.currentBattleId = battleId; this.error = null; this.editingName = false;
           try {
-            const resp = await fetch(`/battles/${battleId}/sources`);
-            if (!resp.ok) throw new Error(await resp.text());
-            const data = await resp.json();
+            const [srcResp, bResp] = await Promise.all([
+              fetch(`/battles/${battleId}/sources`),
+              fetch(`/battles/${battleId}`)
+            ]);
+            if (!srcResp.ok) throw new Error(await srcResp.text());
+            const data = await srcResp.json();
             this.sources = data.sources || [];
+            if (bResp.ok) {
+              const b = await bResp.json();
+              this.battleName = b.name || '';
+            }
           } catch(e) { this.error = e.message; }
+        },
+
+        startEditName() {
+          this.nameInput = this.battleName;
+          this.editingName = true;
+          this.$nextTick(() => this.$refs.nameInput && this.$refs.nameInput.focus());
+        },
+
+        cancelEditName() { this.editingName = false; },
+
+        async saveName() {
+          if (!this.currentBattleId || !this.nameInput.trim()) return;
+          this.nameSaving = true;
+          try {
+            const resp = await fetch(`/battles/${this.currentBattleId}`, {
+              method: 'PUT',
+              headers: {'Content-Type': 'application/json'},
+              body: JSON.stringify({ name: this.nameInput.trim() })
+            });
+            if (!resp.ok) throw new Error(await resp.text());
+            this.battleName = this.nameInput.trim();
+            this.editingName = false;
+            window.dispatchEvent(new CustomEvent('battle-created'));
+          } catch(e) { this.error = e.message; }
+          finally { this.nameSaving = false; }
         },
 
         async runBattle() {


### PR DESCRIPTION
## Summary

- Load battle name via `GET /battles/{id}` on detail load; display it next to "Battle Detail" heading
- Add ✏️ Edit button that toggles an inline text input pre-filled with current name
- Save calls `PUT /battles/{id}` with new name; refreshes sidebar via `battle-created` event
- Cancel returns to display mode without API call
- Enter key saves, Escape cancels

## Test plan
- [ ] Load a battle detail — name shown in header
- [ ] Click Edit — input appears pre-filled with current name
- [ ] Save new name — header updates, sidebar refreshes
- [ ] Press Escape — edit cancelled, no API call
- [ ] Cancel button works the same way

Closes #126

🤖 Generated with [Claude Code](https://claude.com/claude-code)