### PR TITLE
docs: update PRD brand theme from Gold-on-Ink to Paper Light

### DIFF
--- a/prd/01-prd.md
+++ b/prd/01-prd.md
@@ -53,7 +53,7 @@ After running, the final output of each fighter is judged side-by-side: quality 
 **In scope**
 
 - CLI that starts a local FastAPI server on a configurable port (default 7878) and opens the browser
-- Single-page web UI (Alpine.js, no build step): sidebar layout with battle list + provider management on the left, battle detail on the right; Gold-on-Ink brand theme
+- Single-page web UI (Alpine.js, no build step): sidebar layout with battle list + provider management on the left, battle detail on the right; Paper Light brand theme
 - **Battle creation**:
   - Name + judge config (provider, model, rubric)
   - **Sources**: upload text/markdown files (one item per file) OR a CSV file (one item per row)

--- a/prd/03-functional-requirements.md
+++ b/prd/03-functional-requirements.md
@@ -47,20 +47,22 @@
 
 ---
 
-## Brand Theme (Gold-on-Ink)
+## Brand Theme (Paper Light)
 
-Applies to FR-20 sidebar layout and all UI components:
+Applies to FR-20 sidebar layout and all UI components. Paper-like aesthetic: warm off-white backgrounds, clean white cards, dark readable text.
 
 | Token | Value |
 |-------|-------|
-| `bg.ink` | `#0d0f13` |
-| `bg.card` | `#14181f` |
-| Gold accent | `#F0B90B` |
-| `text.high` | `#E7ECF3` |
-| `text.mid` | `#8A93A3` |
+| `bg.paper` | `#FAF9F6` (warm off-white / parchment) |
+| `bg.card` | `#FFFFFF` (white with subtle shadow/border) |
+| Primary accent | `#F0B90B` (gold — kept for contrast on light bg) |
+| `text.high` | `#1a1a2e` (dark primary text) |
+| `text.mid` | `#6b7280` (muted secondary text) |
+| Borders | `#e5e5e5` (light gray) |
 | Typography | system-ui stack, weight 600, `letter-spacing: -0.01em` |
+| Sidebar bg | slightly tinted off-white or very light gray |
 
-Replaces previous purple (`#7c6af7`) on light background (`#f5f5f5`) theme.
+Replaces previous Gold-on-Ink dark theme (`#0d0f13` background, `#14181f` cards, `#E7ECF3` text).
 
 ---
 


### PR DESCRIPTION
## Summary

- Rename Brand Theme section in `prd/03-functional-requirements.md` from \"Gold-on-Ink\" to \"Paper Light\"
- Replace dark theme tokens with light paper equivalents (warm off-white bg, white cards, dark text, gold accent)
- Update `prd/01-prd.md` line 56: \"Gold-on-Ink brand theme\" → \"Paper Light brand theme\"

## Test plan
- [ ] `prd/03-functional-requirements.md` Brand Theme section reflects Paper Light tokens
- [ ] `prd/01-prd.md` references Paper Light, not Gold-on-Ink
- [ ] No other PRD files mention Gold-on-Ink as current theme

Closes #128

🤖 Generated with [Claude Code](https://claude.com/claude-code)