### PR TITLE
refactor: switch UI to Paper Light theme

### DIFF
--- a/t01_llm_battle/static/index.html
+++ b/t01_llm_battle/static/index.html
@@ -9,16 +9,17 @@
     *, *::before, *::after { box-sizing: border-box; }
 
     :root {
-      --ink:       #0d0f13;
-      --card:      #14181f;
-      --border:    #1e2430;
+      --ink:       #FAF9F6;
+      --card:      #FFFFFF;
+      --border:    #e5e5e5;
       --gold:      #F0B90B;
       --gold-dim:  #c49a09;
-      --high:      #E7ECF3;
-      --mid:       #8A93A3;
-      --low:       #3d4657;
-      --danger:    #e05252;
-      --success:   #27ae60;
+      --high:      #1a1a2e;
+      --mid:       #6b7280;
+      --low:       #9ca3af;
+      --danger:    #dc2626;
+      --success:   #16a34a;
+      --sidebar-bg: #F0EDE8;
     }
 
     html, body {
@@ -40,7 +41,7 @@
     .sidebar {
       width: 260px;
       min-width: 260px;
-      background: var(--card);
+      background: var(--sidebar-bg);
       border-right: 1px solid var(--border);
       display: flex;
       flex-direction: column;
@@ -171,7 +172,7 @@
 
     input[type="text"], input[type="password"], select, textarea {
       width: 100%;
-      background: rgba(0,0,0,0.3);
+      background: #FFFFFF;
       border: 1px solid var(--border);
       color: var(--high);
       border-radius: 6px;
@@ -184,7 +185,7 @@
       outline: none;
       border-color: var(--gold);
     }
-    select option { background: var(--card); }
+    select option { background: #FFFFFF; }
     input[type="file"] { background: none; border: none; padding: 0; color: var(--mid); font-size: 0.86rem; }
 
     .card {
@@ -193,12 +194,13 @@
       border-radius: 8px;
       padding: 1.25rem 1.5rem;
       margin-bottom: 1.25rem;
+      box-shadow: 0 1px 3px rgba(0,0,0,0.06);
     }
 
     .badge {
       display: inline-block;
       background: var(--gold);
-      color: #0d0f13;
+      color: #1a1a2e;
       border-radius: 4px;
       padding: 1px 7px;
       font-size: 0.72rem;
@@ -208,7 +210,7 @@
     }
     .badge-muted {
       display: inline-block;
-      background: var(--border);
+      background: #f3f4f6;
       color: var(--mid);
       border-radius: 4px;
       padding: 1px 7px;
@@ -220,7 +222,7 @@
 
     .btn-primary {
       background: var(--gold);
-      color: #0d0f13;
+      color: #1a1a2e;
       border: none;
       padding: 8px 18px;
       border-radius: 6px;
@@ -267,7 +269,7 @@
     }
 
     .placeholder {
-      background: rgba(255,255,255,0.02);
+      background: #f9fafb;
       border: 2px dashed var(--border);
       border-radius: 8px;
       height: 110px;
@@ -288,7 +290,7 @@
       display: flex;
       align-items: center;
       justify-content: space-between;
-      background: rgba(255,255,255,0.03);
+      background: #f9fafb;
       border: 1px solid var(--border);
       border-radius: 6px;
       padding: 7px 12px;
@@ -297,7 +299,7 @@
     }
 
     .step-row {
-      background: rgba(255,255,255,0.02);
+      background: #f9fafb;
       border: 1px solid var(--border);
       border-radius: 5px;
       padding: 5px 10px;
@@ -310,18 +312,18 @@
 
     /* Tables */
     .data-table { width: 100%; border-collapse: collapse; background: var(--card); border: 1px solid var(--border); border-radius: 8px; overflow: hidden; font-size: 0.86rem; }
-    .data-table th { padding: 10px 14px; text-align: left; font-size: 0.8rem; color: var(--mid); border-bottom: 1px solid var(--border); font-weight: 600; background: rgba(255,255,255,0.02); }
+    .data-table th { padding: 10px 14px; text-align: left; font-size: 0.8rem; color: var(--mid); border-bottom: 1px solid var(--border); font-weight: 600; background: #f9fafb; }
     .data-table td { padding: 10px 14px; border-bottom: 1px solid var(--border); }
     .data-table tr:last-child td { border-bottom: none; }
 
     code { background: var(--border); color: var(--gold); padding: 2px 6px; border-radius: 3px; font-size: 0.83em; }
 
-    /* EasyMDE dark overrides */
-    .EasyMDEContainer .CodeMirror { background: rgba(0,0,0,0.3) !important; color: var(--high) !important; border-color: var(--border) !important; }
-    .editor-toolbar { background: var(--card) !important; border-color: var(--border) !important; }
+    /* EasyMDE light-theme adjustments */
+    .EasyMDEContainer .CodeMirror { background: #FFFFFF !important; color: var(--high) !important; border-color: var(--border) !important; }
+    .editor-toolbar { background: #f9fafb !important; border-color: var(--border) !important; }
     .editor-toolbar a { color: var(--mid) !important; }
     .editor-toolbar a:hover, .editor-toolbar a.active { color: var(--gold) !important; background: var(--border) !important; }
-    .editor-preview { background: var(--ink) !important; color: var(--high) !important; }
+    .editor-preview { background: #FFFFFF !important; color: var(--high) !important; }
 
     ::-webkit-scrollbar { width: 5px; height: 5px; }
     ::-webkit-scrollbar-track { background: transparent; }
@@ -564,7 +566,7 @@
           <!-- Add fighter form -->
           <template x-if="showAddFighter">
             <form @submit.prevent="addFighter($root.params.id)"
-              style="background:rgba(0,0,0,0.25);border:1px solid var(--border);border-radius:8px;padding:1rem;margin-bottom:1rem;display:flex;flex-direction:column;gap:0.75rem;">
+              style="background:#f9fafb;border:1px solid var(--border);border-radius:8px;padding:1rem;margin-bottom:1rem;display:flex;flex-direction:column;gap:0.75rem;">
               <h3>New Fighter</h3>
               <div style="display:flex;gap:1rem;align-items:flex-end;">
                 <div style="flex:1;">
@@ -599,7 +601,7 @@
           <template x-if="!loadingFighters && fighters.length > 0">
             <div style="display:flex;flex-direction:column;gap:0.75rem;">
               <template x-for="fighter in fighters" :key="fighter.id">
-                <div style="background:rgba(0,0,0,0.2);border:1px solid var(--border);border-radius:8px;padding:1rem;">
+                <div style="background:#f9fafb;border:1px solid var(--border);border-radius:8px;padding:1rem;">
                   <div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:0.6rem;">
                     <div>
                       <span style="font-weight:600;font-size:0.9rem;" x-text="fighter.name"></span>
@@ -632,7 +634,7 @@
                   <!-- Add step inline form -->
                   <template x-if="activeStepFighterId === fighter.id">
                     <form @submit.prevent="addStep($root.params.id, fighter.id)"
-                      style="background:rgba(0,0,0,0.3);border:1px solid var(--border);border-radius:6px;padding:0.75rem;margin-top:0.5rem;display:flex;flex-direction:column;gap:0.6rem;">
+                      style="background:#f9fafb;border:1px solid var(--border);border-radius:6px;padding:0.75rem;margin-top:0.5rem;display:flex;flex-direction:column;gap:0.6rem;">
                       <h4 style="margin:0;font-size:0.88rem;">New Step</h4>
 
                       <template x-if="stepProviderType() === 'llm'">
@@ -948,7 +950,7 @@
             <h2>Per-Source Breakdown</h2>
             <template x-for="source in sourceGroups()" :key="source.label">
               <div class="card" style="padding:0;overflow:hidden;margin-bottom:1rem;">
-                <div style="padding:9px 14px;font-weight:600;font-size:0.88rem;border-bottom:1px solid var(--border);background:rgba(255,255,255,0.02);">
+                <div style="padding:9px 14px;font-weight:600;font-size:0.88rem;border-bottom:1px solid var(--border);background:#f9fafb;">
                   <span x-text="source.label"></span>
                 </div>
                 <div :style="'display:grid;grid-template-columns:repeat(' + source.fighters.length + ', 1fr);gap:0;'">
@@ -964,7 +966,7 @@
                           <span x-text="expanded[source.label + '::' + fighter.fighter_name] ? '▼ Hide output' : '▶ Show output'"></span>
                         </div>
                         <template x-if="expanded[source.label + '::' + fighter.fighter_name]">
-                          <pre style="background:rgba(0,0,0,0.3);border:1px solid var(--border);border-radius:4px;padding:10px;font-size:0.78rem;white-space:pre-wrap;word-break:break-word;margin:0;max-height:300px;overflow-y:auto;color:var(--high);" x-text="fighter.final_output || '(no output)'"></pre>
+                          <pre style="background:#f9fafb;border:1px solid var(--border);border-radius:4px;padding:10px;font-size:0.78rem;white-space:pre-wrap;word-break:break-word;margin:0;max-height:300px;overflow-y:auto;color:var(--high);" x-text="fighter.final_output || '(no output)'"></pre>
                         </template>
                         <div style="font-size:0.76rem;color:var(--mid);margin-top:6px;">
                           <span x-text="fighter.step_count + ' step(s)'"></span>


### PR DESCRIPTION
## Summary

- Replace `:root` CSS variables: dark ink/card/border/text → Paper Light equivalents (warm off-white bg `#FAF9F6`, white cards, `#e5e5e5` borders, dark `#1a1a2e` text, `#6b7280` muted)
- Sidebar uses distinct `--sidebar-bg: #F0EDE8` for visual separation
- Remove EasyMDE dark overrides; light theme defaults work; toolbar adjusted to `#f9fafb`
- Replace all `rgba(0,0,0,...)` inline backgrounds with `#f9fafb` light gray
- Cards gain subtle `box-shadow` for paper-like depth
- Gold accent `#F0B90B` retained for interactive elements (contrasts well on light bg)

## Test plan
- [ ] All pages show warm off-white (`#FAF9F6`) background
- [ ] Cards are white with subtle border/shadow
- [ ] Sidebar has distinct tinted background
- [ ] Text is dark and highly readable
- [ ] Gold accent visible on buttons, active states
- [ ] EasyMDE editor renders in light mode (no dark background artifacts)
- [ ] Status chips (success/error/pending/running) visible on light bg
- [ ] No dark-theme backgrounds visible anywhere

Closes #129

🤖 Generated with [Claude Code](https://claude.com/claude-code)