### PR TITLE
fix: make sidebar brand a link navigating to #/battles

### DIFF
--- a/t01_llm_battle/static/index.html
+++ b/t01_llm_battle/static/index.html
@@ -341,7 +341,7 @@
            @battle-created.window="load()"
            @battle-deleted.window="load()">
 
-      <div class="sidebar-brand">T01 LLM Battle</div>
+      <a href="#/battles" class="sidebar-brand" style="text-decoration:none;color:inherit;cursor:pointer;">T01 LLM Battle</a>
 
       <div class="sidebar-battles">
         <div class="sidebar-section-header">


### PR DESCRIPTION
Closes #140

## Summary
Convert sidebar brand from non-interactive div to clickable link that navigates to #/battles.

## Acceptance Criteria
- [x] Clicking "T01 LLM Battle" brand navigates to `#/battles`
- [x] Brand shows pointer cursor on hover
- [x] Visual appearance unchanged (same font, color, padding)
- [x] Works from any page (API Keys, run view, results)

## Changes
- Single-line fix to index.html: replace div with anchor tag
- Inline styles preserve appearance while adding navigation

## Testing
- All 59 unit tests pass
- No new debug code
- Clean diff (1 file, 1 line changed)