### PR TITLE
chore: auto-close issues from non-collaborators

### DIFF
--- a/.github/workflows/close-external-issues.yml
+++ b/.github/workflows/close-external-issues.yml
@@ -1,0 +1,30 @@
+name: Close external issues
+
+on:
+  issues:
+    types: [opened]
+
+jobs:
+  close:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            const { data: perm } = await github.rest.repos.getCollaboratorPermissionLevel({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              username: context.payload.issue.user.login
+            });
+            if (!['admin', 'write', 'maintain'].includes(perm.permission)) {
+              await github.rest.issues.createComment({
+                ...context.repo,
+                issue_number: context.payload.issue.number,
+                body: 'Thanks — this repo does not accept external issues. Please use [GitHub Discussions](../../discussions) for questions or feedback.'
+              });
+              await github.rest.issues.update({
+                ...context.repo,
+                issue_number: context.payload.issue.number,
+                state: 'closed'
+              });
+            }

--- a/t01_llm_battle/static/index.html
+++ b/t01_llm_battle/static/index.html
@@ -341,7 +341,7 @@
            @battle-created.window="load()"
            @battle-deleted.window="load()">
 
-      <div class="sidebar-brand">T01 LLM Battle</div>
+      <a href="#/battles" class="sidebar-brand" style="text-decoration:none;color:inherit;cursor:pointer;">T01 LLM Battle</a>
 
       <div class="sidebar-battles">
         <div class="sidebar-section-header">


### PR DESCRIPTION
## Summary
- Adds GitHub Action that fires on every new issue
- Checks opener's collaborator permission level
- If not admin/write/maintain: posts redirect comment and closes issue

## Test plan
- [ ] Open test issue as external user — should get comment + auto-close
- [ ] Open issue as collaborator — should remain open