### PR TITLE
feat: encrypt API keys at rest and improve masked display

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = [
     "aiosqlite>=0.20",
     "httpx>=0.27",
     "pydantic-ai>=0.0.36",
+    "cryptography>=42",
     "typer>=0.12",
     "python-multipart>=0.0.9",
 ]

--- a/t01_llm_battle/crypto.py
+++ b/t01_llm_battle/crypto.py
@@ -1,0 +1,45 @@
+"""Fernet-based encryption for API keys stored in SQLite.
+
+Key file: ~/.t01-llm-battle/.keyfile (machine-local, never committed).
+If the keyfile doesn't exist it is generated on first call.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+from cryptography.fernet import Fernet, InvalidToken
+
+_KEYFILE: Path = Path.home() / ".t01-llm-battle" / ".keyfile"
+_fernet: Fernet | None = None
+
+
+def _get_fernet() -> Fernet:
+    global _fernet
+    if _fernet is not None:
+        return _fernet
+
+    _KEYFILE.parent.mkdir(parents=True, exist_ok=True)
+    if _KEYFILE.exists():
+        key = _KEYFILE.read_bytes().strip()
+    else:
+        key = Fernet.generate_key()
+        _KEYFILE.write_bytes(key)
+        _KEYFILE.chmod(0o600)
+
+    _fernet = Fernet(key)
+    return _fernet
+
+
+def encrypt_key(plaintext: str) -> str:
+    """Encrypt a plaintext API key; return Fernet token as str."""
+    return _get_fernet().encrypt(plaintext.encode()).decode()
+
+
+def decrypt_key(token: str) -> str:
+    """Decrypt a Fernet token; return plaintext. Raises InvalidToken if corrupted."""
+    return _get_fernet().decrypt(token.encode()).decode()
+
+
+def is_encrypted(value: str) -> bool:
+    """Return True if value looks like a Fernet token (starts with 'gAAA')."""
+    return value.startswith("gAAA")

--- a/t01_llm_battle/db.py
+++ b/t01_llm_battle/db.py
@@ -114,6 +114,25 @@ async def init_db(db_path: str | Path = DB_PATH) -> None:
         await db.executescript(_SCHEMA_SQL)
         await db.commit()
 
+    await _migrate_plaintext_keys(db_path)
+
+
+async def _migrate_plaintext_keys(db_path: str | Path = DB_PATH) -> None:
+    """Encrypt any plaintext API keys still in the DB (one-time migration)."""
+    from .crypto import encrypt_key, is_encrypted
+
+    async with get_db(db_path) as db:
+        cursor = await db.execute("SELECT provider, key_value FROM api_key")
+        rows = await cursor.fetchall()
+        for row in rows:
+            if row["key_value"] and not is_encrypted(row["key_value"]):
+                encrypted = encrypt_key(row["key_value"])
+                await db.execute(
+                    "UPDATE api_key SET key_value = ? WHERE provider = ?",
+                    (encrypted, row["provider"]),
+                )
+        await db.commit()
+
 
 @asynccontextmanager
 async def get_db(
@@ -151,12 +170,15 @@ async def resolve_api_key(provider: str, db_path: str | Path = DB_PATH) -> str |
         if env_val:
             return env_val
 
+    from .crypto import decrypt_key, is_encrypted
+
     async with get_db(db_path) as db:
         cursor = await db.execute(
             "SELECT key_value FROM api_key WHERE provider = ?", (provider,)
         )
         row = await cursor.fetchone()
         if row and row["key_value"]:
-            return row["key_value"]
+            raw = row["key_value"]
+            return decrypt_key(raw) if is_encrypted(raw) else raw
 
     return None

--- a/t01_llm_battle/routers/keys.py
+++ b/t01_llm_battle/routers/keys.py
@@ -12,6 +12,7 @@ from datetime import datetime, timezone
 from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel
 
+from ..crypto import decrypt_key, encrypt_key, is_encrypted
 from ..db import get_db
 
 router = APIRouter(prefix="/keys", tags=["keys"])
@@ -41,10 +42,10 @@ class KeyUpdate(BaseModel):
 
 
 def _mask_key(key: str) -> str:
-    """Return masked version: first 4 chars + '****' for keys longer than 8 chars."""
-    if len(key) > 8:
-        return key[:4] + "****"
-    return "****"
+    """Return masked version: first 3 + '…' + last 3 for keys ≥ 8 chars, else '***'."""
+    if len(key) >= 8:
+        return key[:3] + "…" + key[-3:]
+    return "***"
 
 
 async def _resolve_key(provider: str) -> tuple[bool, str, str | None]:
@@ -67,7 +68,9 @@ async def _resolve_key(provider: str) -> tuple[bool, str, str | None]:
         )
         result = await row.fetchone()
         if result and result["key_value"]:
-            return True, "db", result["key_value"]
+            raw = result["key_value"]
+            plaintext = decrypt_key(raw) if is_encrypted(raw) else raw
+            return True, "db", plaintext
 
     return False, "none", None
 
@@ -114,6 +117,7 @@ async def set_key(provider: str, body: KeyUpdate):
         raise HTTPException(status_code=422, detail="Key must not be empty")
 
     now = datetime.now(timezone.utc).isoformat()
+    encrypted = encrypt_key(body.key.strip())
     async with get_db() as db:
         await db.execute(
             """
@@ -121,7 +125,7 @@ async def set_key(provider: str, body: KeyUpdate):
             VALUES (?, ?, ?)
             ON CONFLICT(provider) DO UPDATE SET key_value = excluded.key_value, updated_at = excluded.updated_at
             """,
-            (provider, body.key.strip(), now),
+            (provider, encrypted, now),
         )
         await db.commit()
 


### PR DESCRIPTION
Closes #139

## Summary
Two improvements to API key handling: better display masking and encryption at rest using Fernet.

## Changes
- New crypto.py: Fernet-based encryption with machine-local keyfile (~/.t01-llm-battle/.keyfile)
- _mask_key() now shows first 3 + … + last 3 chars (e.g. sk-…xyz); short keys show ***
- Keys encrypted before storing in SQLite (PUT /keys/{provider})
- Keys decrypted transparently in _resolve_key() and resolve_api_key()
- Startup migration: plaintext keys auto-encrypted on first run
- Add cryptography>=42 dependency

All 7 acceptance criteria met. Tests pass (59/59).