### PR TITLE
feat: rename API Keys page to Providers with name and URL config

### DIFF
--- a/t01_llm_battle/static/index.html
+++ b/t01_llm_battle/static/index.html
@@ -370,7 +370,7 @@
 
       <div class="sidebar-footer">
         <a href="#/keys" :class="{ active: $root.route === 'keys' }">
-          <span>🔑</span> API Keys
+          <span>⚙️</span> Providers
         </a>
       </div>
     </aside>
@@ -996,9 +996,9 @@
         </template>
       </section>
 
-      <!-- ── API Keys ────────────────────────────── -->
-      <section x-show="route === 'keys'" x-data="keysList()" x-init="load()">
-        <h1>API Keys</h1>
+      <!-- ── Providers ────────────────────────────── -->
+      <section x-show="route === 'keys'" x-data="providersList()" x-init="load()">
+        <h1>Providers</h1>
         <p class="text-muted" style="margin-top:-0.75rem;margin-bottom:1.5rem;font-size:0.88rem;">
           Keys stored in the database are used when no environment variable is set. Environment variables always take precedence.
         </p>
@@ -1042,12 +1042,31 @@
                 </template>
 
                 <template x-if="k.source !== 'env'">
-                  <div style="display:flex;gap:0.5rem;align-items:center;">
-                    <input type="password"
-                      :placeholder="k.source === 'db' ? 'Replace saved key…' : 'Paste API key…'"
-                      x-model="inputs[k.provider]"
-                      style="font-family:monospace;">
-                    <button @click="save(k.provider)" class="btn-primary" style="white-space:nowrap;padding:8px 16px;">
+                  <div style="display:flex;flex-direction:column;gap:0.75rem;">
+                    <div>
+                      <label style="display:block;font-size:0.85rem;margin-bottom:0.3rem;color:var(--text-mid);">Display Name (optional)</label>
+                      <input type="text"
+                        placeholder="e.g. My OpenAI account"
+                        x-model="displayNames[k.provider]"
+                        style="width:100%;">
+                    </div>
+                    <div>
+                      <label style="display:block;font-size:0.85rem;margin-bottom:0.3rem;color:var(--text-mid);">API Key</label>
+                      <input type="password"
+                        :placeholder="k.source === 'db' ? 'Replace saved key…' : 'Paste API key…'"
+                        x-model="inputs[k.provider]"
+                        style="font-family:monospace;width:100%;">
+                    </div>
+                    <template x-if="showBaseUrl(k.provider)">
+                      <div>
+                        <label style="display:block;font-size:0.85rem;margin-bottom:0.3rem;color:var(--text-mid);">Server URL (optional)</label>
+                        <input type="text"
+                          :placeholder="getUrlPlaceholder(k.provider)"
+                          x-model="baseUrls[k.provider]"
+                          style="width:100%;">
+                      </div>
+                    </template>
+                    <button @click="save(k.provider)" class="btn-primary">
                       Save
                     </button>
                   </div>
@@ -1454,10 +1473,10 @@ Do not wrap the JSON in markdown fences.`;
       };
     }
 
-    // ── API Keys ─────────────────────────────────────────────
-    function keysList() {
+    // ── Providers ─────────────────────────────────────────────
+    function providersList() {
       return {
-        keys: [], loading: false, error: null, inputs: {}, saved: {}, saveErrors: {},
+        keys: [], loading: false, error: null, inputs: {}, displayNames: {}, baseUrls: {}, saved: {}, saveErrors: {},
 
         async load() {
           this.loading = true; this.error = null;
@@ -1465,9 +1484,23 @@ Do not wrap the JSON in markdown fences.`;
             const resp = await fetch('/keys');
             if (!resp.ok) throw new Error(await resp.text());
             this.keys = await resp.json();
-            this.keys.forEach(k => { if (this.inputs[k.provider] === undefined) this.inputs[k.provider] = ''; });
+            this.keys.forEach(k => {
+              if (this.inputs[k.provider] === undefined) this.inputs[k.provider] = '';
+              if (this.displayNames[k.provider] === undefined) this.displayNames[k.provider] = '';
+              if (this.baseUrls[k.provider] === undefined) this.baseUrls[k.provider] = '';
+            });
           } catch(e) { this.error = e.message; }
           finally { this.loading = false; }
+        },
+
+        showBaseUrl(provider) {
+          return ['ollama', 'llm-studio'].includes(provider);
+        },
+
+        getUrlPlaceholder(provider) {
+          if (provider === 'ollama') return 'e.g. http://localhost:11434';
+          if (provider === 'llm-studio') return 'e.g. http://localhost:8000';
+          return 'Server URL…';
         },
 
         async save(provider) {
@@ -1475,10 +1508,13 @@ Do not wrap the JSON in markdown fences.`;
           if (!val) { this.saveErrors[provider] = 'Please enter a key before saving.'; return; }
           delete this.saveErrors[provider];
           try {
+            const body = { key: val };
+            if (this.displayNames[provider]) body.display_name = this.displayNames[provider];
+            if (this.baseUrls[provider]) body.base_url = this.baseUrls[provider];
             const resp = await fetch('/keys/' + provider, {
               method: 'PUT',
               headers: {'Content-Type': 'application/json'},
-              body: JSON.stringify({ key: val })
+              body: JSON.stringify(body)
             });
             if (!resp.ok) throw new Error(await resp.text());
             this.inputs[provider] = '';


### PR DESCRIPTION
Closes #138

## Summary
Rename 'API Keys' page to 'Providers' and expand provider cards with display name and server URL fields.

## Changes
- Page title: 'API Keys' → 'Providers'
- Sidebar link: '🔑 API Keys' → '⚙️ Providers'
- Each provider card now has: display name, API key, and base URL inputs
- Base URL field shown for Ollama and LLM Studio with placeholder defaults
- Save logic updated to send display_name + base_url in request body
- Frontend complete and ready; backend storage awaits PR #137 expansion

## Test plan
- [x] Tests pass (59/59)
- [x] No debug code
- [x] All 6 acceptance criteria met (frontend-side)