### PR TITLE
fix: duplicate EasyMDE editor on New Battle page

### DIFF
--- a/t01_llm_battle/static/index.html
+++ b/t01_llm_battle/static/index.html
@@ -1187,6 +1187,9 @@ Do not wrap the JSON in markdown fences.`;
           await this.$nextTick();
           const ta = this.$refs.rubricTextarea;
           if (ta && typeof EasyMDE !== 'undefined') {
+            // Remove any orphaned EasyMDE containers from a previous init cycle
+            const prev = ta.parentElement && ta.parentElement.querySelector('.EasyMDEContainer');
+            if (prev) prev.remove();
             this._mde = new EasyMDE({
               element: ta, initialValue: this.judge_rubric, spellChecker: false,
               autosave: { enabled: false },


### PR DESCRIPTION
Closes #141

Destroys any orphaned EasyMDE container elements before re-initializing the editor in battleForm().

When navigating away from and back to the New Battle page, Alpine.js would re-initialize the battleForm component without properly destroying the previous EasyMDE instance. This left DOM containers orphaned, causing duplicates to stack visually.

The fix queries for any pre-existing .EasyMDEContainer in the parent element and removes it before calling new EasyMDE().