### PR TITLE
feat: expand keys API into provider config (display name, base URL)

### DIFF
--- a/t01_llm_battle/db.py
+++ b/t01_llm_battle/db.py
@@ -96,12 +96,18 @@ CREATE TABLE IF NOT EXISTS api_key (
 );
 
 CREATE TABLE IF NOT EXISTS provider_config (
-    provider    TEXT PRIMARY KEY,
-    enabled     INTEGER NOT NULL DEFAULT 1,
-    server_url  TEXT,
-    updated_at  TEXT NOT NULL
+    provider     TEXT PRIMARY KEY,
+    enabled      INTEGER NOT NULL DEFAULT 1,
+    server_url   TEXT,
+    display_name TEXT,
+    updated_at   TEXT NOT NULL
 );
 """
+
+# Migrations for existing DBs
+_MIGRATIONS_SQL = [
+    "ALTER TABLE provider_config ADD COLUMN display_name TEXT",
+]
 
 
 async def init_db(db_path: str | Path = DB_PATH) -> None:
@@ -113,6 +119,12 @@ async def init_db(db_path: str | Path = DB_PATH) -> None:
     async with aiosqlite.connect(path) as db:
         await db.executescript(_SCHEMA_SQL)
         await db.commit()
+        for sql in _MIGRATIONS_SQL:
+            try:
+                await db.execute(sql)
+                await db.commit()
+            except Exception:
+                pass  # column already exists
 
     await _migrate_plaintext_keys(db_path)
 
@@ -181,4 +193,16 @@ async def resolve_api_key(provider: str, db_path: str | Path = DB_PATH) -> str |
             raw = row["key_value"]
             return decrypt_key(raw) if is_encrypted(raw) else raw
 
+    return None
+
+
+async def resolve_base_url(provider: str, db_path: str | Path = DB_PATH) -> str | None:
+    """Return the configured base URL for a provider from provider_config, or None."""
+    async with get_db(db_path) as db:
+        cursor = await db.execute(
+            "SELECT server_url FROM provider_config WHERE provider = ?", (provider,)
+        )
+        row = await cursor.fetchone()
+        if row and row["server_url"]:
+            return row["server_url"]
     return None

--- a/t01_llm_battle/providers/lmstudio.py
+++ b/t01_llm_battle/providers/lmstudio.py
@@ -1,4 +1,4 @@
-import httpx
+"""LLM Studio provider adapter — OpenAI-compatible local server."""
 from pydantic_ai import Agent
 from pydantic_ai.models.openai import OpenAIChatModel
 from pydantic_ai.providers.openai import OpenAIProvider as PAIOpenAIProvider
@@ -6,12 +6,12 @@ from pydantic_ai.providers.openai import OpenAIProvider as PAIOpenAIProvider
 from ..db import resolve_base_url
 from .base import BaseProvider, ProviderRequest, ProviderResult, ProviderType
 
-_DEFAULT_BASE_URL = "http://localhost:11434"
+_DEFAULT_BASE_URL = "http://localhost:1234"
 
 
-class OllamaProvider(BaseProvider):
-    name = "ollama"
-    display_name = "Ollama"
+class LMStudioProvider(BaseProvider):
+    name = "llm-studio"
+    display_name = "LM Studio"
     provider_type = ProviderType.LLM
 
     def __init__(self, base_url: str = _DEFAULT_BASE_URL) -> None:
@@ -19,25 +19,18 @@ class OllamaProvider(BaseProvider):
 
     async def _effective_base_url(self) -> str:
         """Return base_url from DB if configured, otherwise use instance default."""
-        db_url = await resolve_base_url("ollama")
+        db_url = await resolve_base_url("llm-studio")
         return (db_url or self.base_url).rstrip("/")
 
     def models(self) -> list[str]:
-        """Query Ollama's /api/tags for installed models; return [] if not running."""
-        try:
-            response = httpx.get(f"{self.base_url}/api/tags", timeout=5.0)
-            if response.status_code != 200:
-                return []
-            data = response.json()
-            return [m["name"] for m in data.get("models", [])]
-        except Exception:
-            return []
+        """LM Studio doesn't expose a standard model list endpoint; return empty."""
+        return []
 
     async def run(self, request: ProviderRequest) -> ProviderResult:
         base_url = await self._effective_base_url()
         provider = PAIOpenAIProvider(
             base_url=f"{base_url}/v1",
-            api_key="ollama",  # Ollama doesn't need a real key
+            api_key="lm-studio",  # LM Studio doesn't need a real key
         )
         model = OpenAIChatModel(request.model, provider=provider)
         agent = Agent(model)
@@ -66,5 +59,5 @@ class OllamaProvider(BaseProvider):
             credits_used=None,
             cost_usd=0.0,
             model=request.model,
-            provider="ollama",
+            provider="llm-studio",
         )

--- a/t01_llm_battle/providers/registry.py
+++ b/t01_llm_battle/providers/registry.py
@@ -13,6 +13,7 @@ _BUILTIN_MODULES = [
     "t01_llm_battle.providers.groq",
     "t01_llm_battle.providers.openrouter",
     "t01_llm_battle.providers.ollama",
+    "t01_llm_battle.providers.lmstudio",
     "t01_llm_battle.providers.serper",
     "t01_llm_battle.providers.tavily",
     "t01_llm_battle.providers.firecrawl",

--- a/t01_llm_battle/routers/keys.py
+++ b/t01_llm_battle/routers/keys.py
@@ -3,7 +3,7 @@ API key management.
 Env-wins logic: if PROVIDER_API_KEY env var is set, it overrides any DB value.
 GET /keys — list all providers with key status (set/unset, source: env/db)
 GET /keys/{provider} — get key for provider (masked)
-PUT /keys/{provider} — store key in DB
+PUT /keys/{provider} — store key in DB (also accepts display_name, base_url)
 DELETE /keys/{provider} — remove key from DB
 """
 import os
@@ -17,8 +17,8 @@ from ..db import get_db
 
 router = APIRouter(prefix="/keys", tags=["keys"])
 
-# Map provider name → env var name
-_ENV_VARS = {
+# Map provider name → env var name (None = no API key needed, e.g. local providers)
+_ENV_VARS: dict[str, str | None] = {
     "openai": "OPENAI_API_KEY",
     "anthropic": "ANTHROPIC_API_KEY",
     "google": "GOOGLE_API_KEY",
@@ -27,6 +27,14 @@ _ENV_VARS = {
     "serper": "SERPER_API_KEY",
     "tavily": "TAVILY_API_KEY",
     "firecrawl": "FIRECRAWL_API_KEY",
+    "ollama": None,      # local — no API key
+    "llm-studio": None,  # local — no API key
+}
+
+# Default base URLs for local providers
+_DEFAULT_BASE_URLS: dict[str, str] = {
+    "ollama": "http://localhost:11434",
+    "llm-studio": "http://localhost:1234",
 }
 
 
@@ -35,10 +43,14 @@ class KeyStatus(BaseModel):
     set: bool
     source: str  # "env", "db", or "none"
     masked_key: str | None = None
+    display_name: str | None = None
+    base_url: str | None = None
 
 
 class KeyUpdate(BaseModel):
-    key: str
+    key: str | None = None
+    display_name: str | None = None
+    base_url: str | None = None
 
 
 def _mask_key(key: str) -> str:
@@ -55,7 +67,7 @@ async def _resolve_key(provider: str) -> tuple[bool, str, str | None]:
     """
     env_var = _ENV_VARS.get(provider)
 
-    # 1. Check env var
+    # 1. Check env var (only for providers that have one)
     if env_var:
         env_val = os.environ.get(env_var)
         if env_val:
@@ -75,18 +87,34 @@ async def _resolve_key(provider: str) -> tuple[bool, str, str | None]:
     return False, "none", None
 
 
+async def _resolve_provider_config(provider: str) -> tuple[str | None, str | None]:
+    """Return (display_name, base_url) from provider_config table."""
+    async with get_db() as db:
+        row = await db.execute(
+            "SELECT display_name, server_url FROM provider_config WHERE provider = ?",
+            (provider,),
+        )
+        result = await row.fetchone()
+        if result:
+            return result["display_name"], result["server_url"]
+    return None, None
+
+
 @router.get("", response_model=list[KeyStatus])
 async def list_keys():
-    """List all provider key statuses."""
+    """List all provider key statuses including display_name and base_url."""
     statuses = []
     for provider in _ENV_VARS:
         is_set, source, raw_key = await _resolve_key(provider)
+        display_name, base_url = await _resolve_provider_config(provider)
         statuses.append(
             KeyStatus(
                 provider=provider,
                 set=is_set,
                 source=source,
                 masked_key=_mask_key(raw_key) if raw_key else None,
+                display_name=display_name,
+                base_url=base_url or _DEFAULT_BASE_URLS.get(provider),
             )
         )
     return statuses
@@ -99,34 +127,54 @@ async def get_key(provider: str):
         raise HTTPException(status_code=404, detail=f"Unknown provider: {provider}")
 
     is_set, source, raw_key = await _resolve_key(provider)
+    display_name, base_url = await _resolve_provider_config(provider)
     return KeyStatus(
         provider=provider,
         set=is_set,
         source=source,
         masked_key=_mask_key(raw_key) if raw_key else None,
+        display_name=display_name,
+        base_url=base_url or _DEFAULT_BASE_URLS.get(provider),
     )
 
 
 @router.put("/{provider}")
 async def set_key(provider: str, body: KeyUpdate):
-    """Store a key in the DB (env var takes precedence at runtime)."""
+    """Store key, display_name, and/or base_url in DB."""
     if provider not in _ENV_VARS:
         raise HTTPException(status_code=404, detail=f"Unknown provider: {provider}")
 
-    if not body.key or not body.key.strip():
-        raise HTTPException(status_code=422, detail="Key must not be empty")
-
     now = datetime.now(timezone.utc).isoformat()
-    encrypted = encrypt_key(body.key.strip())
+
     async with get_db() as db:
-        await db.execute(
-            """
-            INSERT INTO api_key (provider, key_value, updated_at)
-            VALUES (?, ?, ?)
-            ON CONFLICT(provider) DO UPDATE SET key_value = excluded.key_value, updated_at = excluded.updated_at
-            """,
-            (provider, encrypted, now),
-        )
+        # Update API key if provided
+        if body.key is not None:
+            if not body.key.strip():
+                raise HTTPException(status_code=422, detail="Key must not be empty")
+            encrypted = encrypt_key(body.key.strip())
+            await db.execute(
+                """
+                INSERT INTO api_key (provider, key_value, updated_at)
+                VALUES (?, ?, ?)
+                ON CONFLICT(provider) DO UPDATE SET key_value = excluded.key_value, updated_at = excluded.updated_at
+                """,
+                (provider, encrypted, now),
+            )
+
+        # Update display_name and/or base_url if provided
+        if body.display_name is not None or body.base_url is not None:
+            await db.execute(
+                """
+                INSERT INTO provider_config (provider, display_name, server_url, updated_at)
+                VALUES (?, ?, ?, ?)
+                ON CONFLICT(provider) DO UPDATE SET
+                    display_name = COALESCE(excluded.display_name, display_name),
+                    server_url = COALESCE(excluded.server_url, server_url),
+                    updated_at = excluded.updated_at
+                """,
+                (provider, body.display_name, body.base_url, now),
+            )
+
         await db.commit()
 
     return {"provider": provider, "status": "saved"}
@@ -137,6 +185,9 @@ async def delete_key(provider: str):
     """Remove a key from the DB."""
     if provider not in _ENV_VARS:
         raise HTTPException(status_code=404, detail=f"Unknown provider: {provider}")
+    env_var = _ENV_VARS[provider]
+    if env_var is None:
+        raise HTTPException(status_code=422, detail=f"Provider {provider!r} uses no API key")
 
     async with get_db() as db:
         cursor = await db.execute(

--- a/tests/test_keys_router.py
+++ b/tests/test_keys_router.py
@@ -1,0 +1,123 @@
+"""Tests for FR-8 / #137: expanded keys API with display_name, base_url, ollama, llm-studio."""
+import pytest
+import t01_llm_battle.routers.keys as keys_module
+from contextlib import asynccontextmanager
+from httpx import AsyncClient, ASGITransport
+import t01_llm_battle.db as db_module
+from t01_llm_battle.db import init_db, get_db
+from t01_llm_battle.server import create_app
+
+
+@pytest.fixture
+async def keys_client(tmp_path, monkeypatch):
+    db_path = str(tmp_path / "test.db")
+    await init_db(db_path)
+
+    @asynccontextmanager
+    async def _get_db_override(path=None):
+        async with get_db(db_path) as db:
+            yield db
+
+    monkeypatch.setattr(db_module, "DB_PATH", __import__("pathlib").Path(db_path))
+    monkeypatch.setattr(keys_module, "get_db", _get_db_override)
+
+    app = create_app(db_path=db_path)
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        yield c
+
+
+@pytest.mark.asyncio
+async def test_list_keys_includes_ollama_and_lmstudio(keys_client):
+    resp = await keys_client.get("/keys")
+    assert resp.status_code == 200
+    providers = [p["provider"] for p in resp.json()]
+    assert "ollama" in providers
+    assert "llm-studio" in providers
+
+
+@pytest.mark.asyncio
+async def test_list_keys_has_display_name_and_base_url_fields(keys_client):
+    resp = await keys_client.get("/keys")
+    assert resp.status_code == 200
+    for item in resp.json():
+        assert "display_name" in item
+        assert "base_url" in item
+
+
+@pytest.mark.asyncio
+async def test_ollama_has_default_base_url(keys_client):
+    resp = await keys_client.get("/keys")
+    assert resp.status_code == 200
+    ollama = next(p for p in resp.json() if p["provider"] == "ollama")
+    assert ollama["base_url"] == "http://localhost:11434"
+
+
+@pytest.mark.asyncio
+async def test_lmstudio_has_default_base_url(keys_client):
+    resp = await keys_client.get("/keys")
+    assert resp.status_code == 200
+    lmstudio = next(p for p in resp.json() if p["provider"] == "llm-studio")
+    assert lmstudio["base_url"] == "http://localhost:1234"
+
+
+@pytest.mark.asyncio
+async def test_put_key_accepts_display_name_and_base_url(keys_client):
+    resp = await keys_client.put(
+        "/keys/openai",
+        json={"key": "sk-test-1234567890", "display_name": "My OpenAI", "base_url": None},
+    )
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "saved"
+
+
+@pytest.mark.asyncio
+async def test_put_ollama_base_url_persisted(keys_client):
+    resp = await keys_client.put(
+        "/keys/ollama",
+        json={"base_url": "http://192.168.1.10:11434"},
+    )
+    assert resp.status_code == 200
+
+    resp2 = await keys_client.get("/keys/ollama")
+    assert resp2.status_code == 200
+    assert resp2.json()["base_url"] == "http://192.168.1.10:11434"
+
+
+@pytest.mark.asyncio
+async def test_put_display_name_persisted(keys_client):
+    resp = await keys_client.put(
+        "/keys/anthropic",
+        json={"display_name": "Anthropic (work)"},
+    )
+    assert resp.status_code == 200
+
+    resp2 = await keys_client.get("/keys/anthropic")
+    assert resp2.status_code == 200
+    assert resp2.json()["display_name"] == "Anthropic (work)"
+
+
+@pytest.mark.asyncio
+async def test_existing_key_management_unchanged(keys_client, monkeypatch):
+    """env wins logic: env var overrides db key."""
+    import os
+    monkeypatch.setenv("OPENAI_API_KEY", "env-key-abc")
+
+    resp = await keys_client.get("/keys/openai")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["set"] is True
+    assert data["source"] == "env"
+    assert data["masked_key"] is not None
+
+
+@pytest.mark.asyncio
+async def test_unknown_provider_returns_404(keys_client):
+    resp = await keys_client.get("/keys/nonexistent")
+    assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_delete_ollama_returns_422(keys_client):
+    """Ollama has no API key — delete should fail with 422."""
+    resp = await keys_client.delete("/keys/ollama")
+    assert resp.status_code == 422


### PR DESCRIPTION
Closes #137

## Changes

- `GET /keys` now includes Ollama and LLM Studio providers with `display_name` and `base_url` fields
- `PUT /keys/{provider}` accepts optional `display_name` and `base_url`
- Ollama provider reads `base_url` from `provider_config` table (default `http://localhost:11434`)
- New LLM Studio provider adapter (OpenAI-compatible, default `http://localhost:1234`)
- DB migration: `display_name` column added to `provider_config` table
- Tests added for all new/modified endpoints (69 passing)