### PR TITLE
docs: update PRD for Providers page (rename API Keys, add config fields)

### DIFF
--- a/prd/02-tech-stack.md
+++ b/prd/02-tech-stack.md
@@ -25,7 +25,7 @@ No HTML generation. After a run completes, the judge model is prompted to produc
 See `01-prd.md` → Architecture Principles for the full list. Key constraints:
 
 - **One process**: FastAPI + asyncio + SQLite in one Python process. No Celery, Redis, or worker pool.
-- **Keys in browser → provider direct**: No server-side proxy of API calls (exception: Ollama requires CORS bypass via backend).
+- **Keys in browser → provider direct**: No server-side proxy of API calls (exception: Ollama and LLM Studio require CORS bypass via backend).
 - **No streaming in v0.1**: Full responses only for fair latency/token comparison.
 - **Pydantic AI for LLM providers**: `pydantic-ai` is the unified abstraction layer for all LLM providers — tool-calling, structured output, and model switching without SDK churn. Tool providers (Serper, Tavily, Firecrawl) use plain `httpx` — no SDK needed.
 
@@ -92,7 +92,7 @@ t01-llm-battle/
 │   ├── routers/
 │   │   ├── battles.py
 │   │   ├── runs.py
-│   │   └── keys.py
+│   │   └── providers.py
 │   └── static/
 │       ├── index.html              # Alpine.js SPA shell
 │       ├── alpine.min.js           # 15 KB — no CDN dependency

--- a/prd/03-functional-requirements.md
+++ b/prd/03-functional-requirements.md
@@ -7,11 +7,11 @@
 | FR-3 | Sources | Upload text/md files or a CSV; each file or CSV row = one input item |
 | FR-4 | Fighters & Steps | Named pipelines; each step has system prompt, provider, model, config |
 | FR-5 | Manual Fighter | No steps; user enters result per source item during a run |
-| FR-6 | Provider Adapters | LLM (via Pydantic AI): OpenAI, Anthropic, Google, Groq, OpenRouter, Ollama; Tool (httpx): Serper (search/scrape), Tavily (search), Firecrawl (scrape/crawl) |
+| FR-6 | Provider Adapters | LLM (via Pydantic AI): OpenAI, Anthropic, Google, Groq, OpenRouter, Ollama, LLM Studio; Tool (httpx): Serper (search/scrape), Tavily (search), Firecrawl (scrape/crawl) |
 | FR-7 | Provider Config | Per-step: temperature, max_tokens, function (for tool providers, e.g. `serper:search`), etc. |
 | FR-17 | Provider Types | Each provider has a type (LLM or TOOL); LLM providers use token-based pricing; tool providers use credit-based pricing |
 | FR-18 | Pricing Models | Token-based (LLM): input/output $/1M tokens; credit-based (TOOL): fixed cost per function call. Provider calculates and reports usage after each run |
-| FR-8 | API Key Management | Env vars OR UI entry → stored in SQLite; env wins; masked in UI |
+| FR-8 | Provider Management | Per-provider config: display name (optional, defaults to provider slug), API key, server URL / base URL (optional, for Ollama, LLM Studio, self-hosted); stored in SQLite; env vars override key at runtime; API key masked in UI |
 | FR-9 | Rate Limiting | Per-provider RPM throttling with bounded concurrency |
 | FR-10 | Run Execution | Parallel across fighters × sources; sequential within a fighter's steps |
 | FR-11 | Live Run View | Polling UI; step-level status per fighter per source item |
@@ -20,17 +20,26 @@
 | FR-14 | Results View | Side-by-side final scores, cost, latency; expandable step drill-down |
 | FR-15 | SQLite Persistence | All battles, sources, fighters, steps, runs, results, judgments, api_keys |
 | FR-16 | Custom Model IDs | Override catalog slugs; pricing shown as "unknown" |
-| FR-19 | Provider Management UI | Sidebar lists providers with enable/disable toggle; edit popup for API key, server URL (Ollama/LLM Studio); uninstall non-system providers |
-| FR-20 | Sidebar Layout | Single page: left sidebar (app name, battle list, providers section) + main content area (selected battle or default empty battle with 2 fighters) |
+| FR-19 | Provider Management UI | Sidebar footer link labelled "Providers"; lists providers with enable/disable toggle; edit popup for display name, API key, server URL (Ollama/LLM Studio/self-hosted); uninstall non-system providers |
+| FR-20 | Sidebar Layout | Single page: left sidebar (app name, battle list, "Providers" footer link) + main content area (selected battle or default empty battle with 2 fighters) |
+
+---
+
+## Detail: FR-8 Provider Management
+
+- **Display name**: optional label shown in the UI; defaults to provider slug if blank
+- **API key**: stored encrypted in SQLite; env var `<PROVIDER>_API_KEY` always overrides at runtime; masked in UI
+- **Server URL / Base URL**: optional; used by Ollama, LLM Studio, and self-hosted OpenAI-compatible endpoints
 
 ---
 
 ## Detail: FR-19 Provider Management UI
 
-- **Provider list** in sidebar: name, enabled/disabled toggle, edit button
-- **Edit popup**: API key field, server URL field (Ollama/LLM Studio only), uninstall button (non-system providers only)
+- **Sidebar footer link**: labelled "Providers" (previously "API Keys")
+- **Provider list**: name, enabled/disabled toggle, edit button
+- **Edit popup**: display name field, API key field, server URL field (Ollama/LLM Studio/self-hosted only), uninstall button (non-system providers only)
 - System providers (built-in) cannot be uninstalled; uninstall returns 403
-- Provider config (enabled state, server URL) stored in SQLite alongside API keys
+- Provider config (enabled state, display name, server URL) stored in SQLite alongside API keys
 - Disabled providers are excluded from fighter step provider dropdowns
 
 ---

--- a/prd/06-data-models.md
+++ b/prd/06-data-models.md
@@ -126,10 +126,12 @@ One row per (run × fighter × source item). Aggregates step results and stores 
 | Column | Type | Notes |
 |--------|------|-------|
 | provider | TEXT PK | Provider slug |
-| key_value | TEXT | Stored in plaintext (local machine only). Used by both LLM and tool providers (Serper, Tavily, Firecrawl). |
+| display_name | TEXT | Optional human-readable label; defaults to provider slug if NULL |
+| key_value | TEXT | Encrypted at rest (local machine only). Used by both LLM and tool providers (Serper, Tavily, Firecrawl). |
+| server_url | TEXT | Optional base URL for self-hosted providers (Ollama, LLM Studio, OpenAI-compatible). NULL for cloud providers. |
 | updated_at | TEXT | ISO-8601 |
 
-> Env vars always override `api_key` table values at runtime.
+> Env vars (e.g. `OPENAI_API_KEY`) always override `key_value` at runtime. `server_url` is used when the provider requires a custom endpoint (Ollama default: `http://localhost:11434`).
 
 ---
 


### PR DESCRIPTION
Closes #136

Updates PRD to reflect the Providers page expansion:

- **FR-8** renamed "API Key Management" → "Provider Management"; adds display name, server URL fields
- **FR-19/FR-20** sidebar footer link "API Keys" → "Providers"; edit popup includes display name + server URL
- **prd/06-data-models.md** `api_key` table: adds `display_name TEXT`, documents `server_url` for Ollama/LLM Studio
- **prd/02-tech-stack.md** adds LLM Studio alongside Ollama

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>