### PR TITLE
fix: replace $root.params.id with params.id in all x-init bindings

### DIFF
--- a/t01_llm_battle/static/index.html
+++ b/t01_llm_battle/static/index.html
@@ -386,7 +386,7 @@
 
         <template x-for="b in battles" :key="b.id">
           <div class="battle-item"
-               :class="{ active: $root.params.id === b.id }"
+               :class="{ active: params.id === b.id }"
                @click="$root.navigate('/battles/' + b.id)">
             <span class="battle-item-name" x-text="b.name"></span>
             <button class="btn-delete-battle" title="Delete"
@@ -495,7 +495,7 @@
       <!-- ── Battle detail ───────────────────────── -->
       <section x-show="route === 'battles/detail'"
                x-data="battleDetail()"
-               x-init="$watch('$root.params.id', id => { if (id) load(id); }); if ($root.params.id) load($root.params.id);">
+               x-init="$watch('params.id', id => { if (id) load(id); }); if (params.id) load(params.id);">
 
         <div style="display:flex;align-items:center;gap:0.75rem;margin-bottom:1.5rem;flex-wrap:wrap;">
           <h1 style="margin:0;">Battle Detail</h1>
@@ -591,7 +591,7 @@
         </div>
 
         <!-- Fighters card -->
-        <div class="card" x-data="fighterList()" x-init="load($root.params.id)">
+        <div class="card" x-data="fighterList()" x-init="$watch('params.id', id => { if (id) load(id); }); if (params.id) load(params.id);">
           <div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:1rem;">
             <h2 style="margin:0;">Fighters</h2>
             <button class="btn-primary" @click="showAddFighter = !showAddFighter" style="padding:6px 14px;font-size:0.83rem;">
@@ -805,7 +805,7 @@
 
       <!-- ── Live run view ───────────────────────── -->
       <section x-show="route === 'runs/detail'" x-data="runView()"
-               x-init="$watch('$root.params.id', id => { if (id && $root.route === 'runs/detail') init(id); }); if ($root.params.id && $root.route === 'runs/detail') init($root.params.id);">
+               x-init="$watch('params.id', id => { if (id && route === 'runs/detail') init(id); }); if (params.id && route === 'runs/detail') init(params.id);">
 
         <div style="display:flex;align-items:center;gap:0.75rem;margin-bottom:1.25rem;">
           <h1 style="margin:0;">Live Run</h1>
@@ -926,7 +926,7 @@
 
       <!-- ── Results view ────────────────────────── -->
       <section x-show="route === 'results/detail'" x-data="resultsView()"
-               x-init="$watch('$root.route', r => { if (r === 'results/detail' && $root.params.id) load($root.params.id); }); if (route === 'results/detail' && params.id) load(params.id);">
+               x-init="$watch('route', r => { if (r === 'results/detail' && params.id) load(params.id); }); if (route === 'results/detail' && params.id) load(params.id);">
 
         <div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:1.25rem;">
           <div style="display:flex;align-items:center;gap:0.75rem;">


### PR DESCRIPTION
## Summary

- `$root.params.id` in nested Alpine components resolved to the component's own root element (not `app()`), making `params` undefined in all x-init expressions
- Replaced with `params.id` which correctly traverses Alpine's scope chain up to `app()` where `params` is defined
- Affected: `battleDetail`, `fighterList`, `runView`, `resultsView` x-init bindings + sidebar active class

## Test plan

- [ ] Navigate to a battle → fighters load correctly
- [ ] Create new battle → 2 default fighters (Fighter 1 with step, Fighter 2 manual) appear immediately
- [ ] Switch between battles in sidebar → fighters reload for the new battle
- [ ] Navigate to a run → run view loads correctly
- [ ] Active battle highlighted in sidebar

Closes #152

🤖 Generated with [Claude Code](https://claude.com/claude-code)