### PR TITLE
fix: add llm-studio to _SERVER_URL_PROVIDERS

### DIFF
--- a/t01_llm_battle/routers/providers.py
+++ b/t01_llm_battle/routers/providers.py
@@ -22,7 +22,7 @@ _SYSTEM_PROVIDERS = {
 }
 
 # Providers that support a configurable server_url
-_SERVER_URL_PROVIDERS = {"ollama"}
+_SERVER_URL_PROVIDERS = {"ollama", "llm-studio"}
 
 
 class ProviderPatch(BaseModel):


### PR DESCRIPTION
Closes #171

LLM Studio backend already supports server_url configuration via _effective_base_url(). This fix adds llm-studio to _SERVER_URL_PROVIDERS so the UI edit popup shows the server_url field for LLM Studio providers.

Fixes issue: _SERVER_URL_PROVIDERS only includes ollama, preventing LLM Studio server URL configuration from the UI.