### PR TITLE
fix: add llm-studio to _SYSTEM_PROVIDERS

### DIFF
--- a/t01_llm_battle/routers/providers.py
+++ b/t01_llm_battle/routers/providers.py
@@ -18,7 +18,7 @@ router = APIRouter(prefix="/providers", tags=["providers"])
 # Built-in (system) providers — cannot be uninstalled
 _SYSTEM_PROVIDERS = {
     "openai", "anthropic", "google", "groq",
-    "openrouter", "ollama", "serper", "tavily", "firecrawl",
+    "openrouter", "ollama", "llm-studio", "serper", "tavily", "firecrawl",
 }
 
 # Providers that support a configurable server_url


### PR DESCRIPTION
Closes #170

## Description
llm-studio is a built-in provider registered in _BUILTIN_MODULES but was missing from _SYSTEM_PROVIDERS. This allowed users to uninstall it, which violates FR-19 (system providers cannot be uninstalled).

## Solution
Added llm-studio to the _SYSTEM_PROVIDERS set alongside other built-in providers like openai, anthropic, ollama, etc.

## Testing
- All existing tests pass (69 tests)
- Minimal change: 1 line modified in providers.py