### PR TITLE
feat: step reordering via up/down buttons

### DIFF
--- a/t01_llm_battle/routers/fighters.py
+++ b/t01_llm_battle/routers/fighters.py
@@ -6,6 +6,7 @@ GET    /battles/{battle_id}/fighters                         — list fighters f
 GET    /battles/{battle_id}/fighters/{fighter_id}            — get fighter with steps
 DELETE /battles/{battle_id}/fighters/{fighter_id}            — delete fighter + steps
 POST   /battles/{battle_id}/fighters/{fighter_id}/steps      — add a step to a fighter
+PATCH  /battles/{battle_id}/fighters/{fighter_id}/steps/{step_id}/move  — move step up or down
 DELETE /battles/{battle_id}/fighters/{fighter_id}/steps/{step_id}  — delete step
 
 GET    /providers                                             — list all providers with type, models/functions, pricing
@@ -237,6 +238,37 @@ async def update_step(battle_id: str, fighter_id: str, step_id: str, body: StepC
         cur = await db.execute("SELECT * FROM fighter_step WHERE id = ?", (step_id,))
         row = await cur.fetchone()
     return _row_to_step_out(row)
+
+
+@router.patch("/{fighter_id}/steps/{step_id}/move", response_model=list[StepOut])
+async def move_step(battle_id: str, fighter_id: str, step_id: str, direction: str):
+    """Move a step up or down within its fighter. direction must be 'up' or 'down'."""
+    if direction not in ("up", "down"):
+        raise HTTPException(status_code=400, detail="direction must be 'up' or 'down'")
+    async with get_db() as db:
+        await _get_fighter_or_404(db, battle_id, fighter_id)
+        cur = await db.execute(
+            "SELECT * FROM fighter_step WHERE fighter_id = ? ORDER BY position ASC",
+            (fighter_id,),
+        )
+        rows = await cur.fetchall()
+        ids = [r["id"] for r in rows]
+        if step_id not in ids:
+            raise HTTPException(status_code=404, detail="Step not found")
+        idx = ids.index(step_id)
+        swap_idx = idx - 1 if direction == "up" else idx + 1
+        if swap_idx < 0 or swap_idx >= len(ids):
+            return [_row_to_step_out(r) for r in rows]
+        pos_a, pos_b = rows[idx]["position"], rows[swap_idx]["position"]
+        await db.execute("UPDATE fighter_step SET position=? WHERE id=?", (pos_b, ids[idx]))
+        await db.execute("UPDATE fighter_step SET position=? WHERE id=?", (pos_a, ids[swap_idx]))
+        await db.commit()
+        cur = await db.execute(
+            "SELECT * FROM fighter_step WHERE fighter_id = ? ORDER BY position ASC",
+            (fighter_id,),
+        )
+        updated = await cur.fetchall()
+    return [_row_to_step_out(r) for r in updated]
 
 
 @router.delete("/{fighter_id}/steps/{step_id}", status_code=204, response_model=None)

--- a/t01_llm_battle/static/index.html
+++ b/t01_llm_battle/static/index.html
@@ -595,7 +595,11 @@
                               <span class="text-muted" x-text="step.provider"></span>
                               <span style="color:var(--high);font-weight:500;" x-text="step.model_id"></span>
                               <span x-show="step.system_prompt" style="color:var(--low);font-style:italic;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;max-width:160px;" x-text="step.system_prompt"></span>
-                              <button @click.stop="deleteStep(fighter.id, step.id)" style="margin-left:auto;background:none;border:none;cursor:pointer;color:var(--mid);font-size:0.9rem;padding:0 2px;" title="Delete step">×</button>
+                              <span style="margin-left:auto;display:flex;gap:2px;">
+                                <button @click.stop="moveStep(fighter.id, step.id, 'up')" :disabled="idx === 0" style="background:none;border:none;cursor:pointer;color:var(--mid);font-size:0.8rem;padding:0 3px;line-height:1;" title="Move up">▲</button>
+                                <button @click.stop="moveStep(fighter.id, step.id, 'down')" :disabled="idx === fighter.steps.length - 1" style="background:none;border:none;cursor:pointer;color:var(--mid);font-size:0.8rem;padding:0 3px;line-height:1;" title="Move down">▼</button>
+                                <button @click.stop="deleteStep(fighter.id, step.id)" style="background:none;border:none;cursor:pointer;color:var(--mid);font-size:0.9rem;padding:0 2px;" title="Delete step">×</button>
+                              </span>
                             </div>
                           </template>
                           <!-- Inline edit form -->
@@ -1384,6 +1388,17 @@ Do not wrap the JSON in markdown fences.`;
             this.activeEditStepId = null;
           } catch(e) { this.editStepError = e.message; }
           finally { this.savingStep = false; }
+        },
+
+        async moveStep(fighterId, stepId, direction) {
+          if (!this.battleId) return;
+          try {
+            const resp = await fetch(`/battles/${this.battleId}/fighters/${fighterId}/steps/${stepId}/move?direction=${direction}`, { method: 'PATCH' });
+            if (!resp.ok) throw new Error(await resp.text());
+            const steps = await resp.json();
+            const fighter = this.fighters.find(f => f.id === fighterId);
+            if (fighter) fighter.steps = steps;
+          } catch(e) { alert('Move failed: ' + e.message); }
         },
 
         async deleteStep(fighterId, stepId) {


### PR DESCRIPTION
Closes #167

Adds step reordering functionality:
- Backend PATCH endpoint at /.../steps/{step_id}/move?direction=up|down
- Swaps adjacent step positions in the database
- Frontend up/down buttons in step-row UI
- Refreshes fighter.steps list after reorder

Satisfies FR-4: Steps are reorderable via up/down buttons.