### PR TITLE
fix: after deleting a battle, navigate to newest remaining battle

### DIFF
--- a/t01_llm_battle/static/index.html
+++ b/t01_llm_battle/static/index.html
@@ -1226,8 +1226,19 @@
             const resp = await fetch('/battles/' + id, { method: 'DELETE' });
             if (!resp.ok) throw new Error(await resp.text());
             const m = window.location.hash.match(/^#\/battles\/([^\/]+)$/);
-            if (m && m[1] === id) window.location.hash = '#/battles';
+            const wasCurrent = m && m[1] === id;
             window.dispatchEvent(new CustomEvent('battle-deleted'));
+            if (wasCurrent) {
+              const remaining = await fetch('/battles').then(r => r.json()).then(data =>
+                (Array.isArray(data) ? data : []).filter(b => b && b.id && b.id !== id)
+                  .sort((a, b) => (b.created_at > a.created_at ? 1 : -1))
+              );
+              if (remaining.length > 0) {
+                window.location.hash = '/battles/' + remaining[0].id;
+              } else {
+                await this.newBattle();
+              }
+            }
           } catch(e) { alert('Delete failed: ' + e.message); }
         }
       };


### PR DESCRIPTION
Closes #180

After successful delete, if the deleted battle was currently viewed:
- Navigate to newest remaining battle if any exist  
- Auto-create a new battle if none remain

Deleting a non-current battle does not affect the current view.