### PR TITLE
fix: sidebar + New button creates battle instead of navigating

### DIFF
--- a/t01_llm_battle/static/index.html
+++ b/t01_llm_battle/static/index.html
@@ -450,7 +450,7 @@
       <div class="sidebar-battles">
         <div class="sidebar-section-header">
           <span class="sidebar-section-title">Battles</span>
-          <button class="btn-sidebar-new" @click="$root.navigate('/battles/new')">+ New</button>
+          <button class="btn-sidebar-new" @click="newBattle()">+ New</button>
         </div>
 
         <template x-if="loading">


### PR DESCRIPTION
Closes #177

The sidebar **+ New** button was calling navigate('/battles/new') instead of newBattle(), causing it to show the empty state instead of creating a battle.

Fix: change button handler from navigate() to newBattle().