### PR TITLE
fix: default Fighter 2 as pipeline fighter with initial step

### DIFF
--- a/t01_llm_battle/static/index.html
+++ b/t01_llm_battle/static/index.html
@@ -1211,9 +1211,13 @@
               method: 'POST', headers: {'Content-Type': 'application/json'},
               body: JSON.stringify({ position: 1, provider: 'openai', model_id: 'gpt-4o', provider_config: '{}' })
             });
-            await fetch(`/battles/${battle.id}/fighters`, {
+            const f2 = await (await fetch(`/battles/${battle.id}/fighters`, {
               method: 'POST', headers: {'Content-Type': 'application/json'},
-              body: JSON.stringify({ name: 'Fighter 2', is_manual: true, position: 1 })
+              body: JSON.stringify({ name: 'Fighter 2', is_manual: false, position: 1 })
+            })).json();
+            await fetch(`/battles/${battle.id}/fighters/${f2.id}/steps`, {
+              method: 'POST', headers: {'Content-Type': 'application/json'},
+              body: JSON.stringify({ position: 1, provider: 'anthropic', model_id: 'claude-sonnet-4-5', provider_config: '{}' })
             });
             window.dispatchEvent(new CustomEvent('battle-created'));
             window.location.hash = '/battles/' + battle.id;


### PR DESCRIPTION
Closes #178

## Changes
- Fighter 2 now created as `is_manual: false` (was `true`)
- Adds initial step to Fighter 2 with Anthropic Claude Sonnet 4.5 (vs OpenAI GPT-4o for Fighter 1)
- Enables meaningful model comparison immediately after battle creation

## Acceptance Criteria
- [x] New battles create Fighter 2 as `is_manual: false` with one default step
- [x] Fighter 2 default step uses different provider/model than Fighter 1
- [x] No regression on Fighter 1 creation