### PR TITLE
fix: step list view shows stale provider/model after editing

### DIFF
--- a/t01_llm_battle/static/index.html
+++ b/t01_llm_battle/static/index.html
@@ -1445,7 +1445,7 @@ Do not wrap the JSON in markdown fences.`;
             const fighter = this.fighters.find(f => f.id === fighterId);
             if (fighter) {
               const idx = fighter.steps.findIndex(s => s.id === step.id);
-              if (idx !== -1) fighter.steps[idx] = updated;
+              if (idx !== -1) fighter.steps.splice(idx, 1, updated);
             }
             this.activeEditStepId = null;
           } catch(e) { this.editStepError = e.message; }


### PR DESCRIPTION
Closes #179

Alpine.js reactivity: use Array.splice() instead of direct assignment to trigger change detection on step update.