### PR TITLE
feat: add copy-markdown and print buttons to report view

### DIFF
--- a/t01_llm_battle/static/index.html
+++ b/t01_llm_battle/static/index.html
@@ -1061,7 +1061,13 @@
 
             <template x-if="results.report_markdown">
               <div>
-                <h2>Judge Report</h2>
+                <div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:0.5rem;">
+                  <h2 style="margin:0;">Judge Report</h2>
+                  <div style="display:flex;gap:0.5rem;">
+                    <button class="btn btn-sm btn-secondary" @click="copyReportMarkdown()" x-text="reportCopied ? 'Copied!' : 'Copy Markdown'"></button>
+                    <button class="btn btn-sm btn-secondary" @click="window.print()">Print</button>
+                  </div>
+                </div>
                 <div class="card" style="line-height:1.7;" x-html="renderMarkdown(results.report_markdown)"></div>
               </div>
             </template>
@@ -1770,6 +1776,15 @@ Do not wrap the JSON in markdown fences.`;
           const a = document.createElement('a');
           a.href = url; a.download = 'battle-results-' + (this.runId || 'export') + '.md'; a.click();
           URL.revokeObjectURL(url);
+        },
+
+        reportCopied: false,
+        copyReportMarkdown() {
+          if (!this.results || !this.results.report_markdown) return;
+          navigator.clipboard.writeText(this.results.report_markdown).then(() => {
+            this.reportCopied = true;
+            setTimeout(() => { this.reportCopied = false; }, 2000);
+          });
         }
       };
     }


### PR DESCRIPTION
Closes #186

Implements FR-13 — Markdown Report functionality.

After a run completes and the report is displayed, users can now:
1. Copy raw markdown to clipboard via "Copy Markdown" button
2. Print the report via "Print" button (triggers browser print dialog)

## Changes
- Added Copy Markdown button with clipboard feedback ("Copied!" for 2s)
- Added Print button that triggers `window.print()`
- Both buttons positioned in header next to "Judge Report" title
- Uses existing clipboard API and Alpine.js reactivity