### PR TITLE
fix: move system_prompt from agent.run() to Agent() constructor

### DIFF
--- a/t01_llm_battle/providers/anthropic.py
+++ b/t01_llm_battle/providers/anthropic.py
@@ -34,7 +34,7 @@ class AnthropicProvider(BaseProvider):
 
         provider = PAIAnthropicProvider(api_key=api_key)
         model = AnthropicModel(request.model, provider=provider)
-        agent = Agent(model)
+        agent = Agent(model, system_prompt=request.system_prompt or "")
 
         model_settings: dict = {
             "temperature": request.temperature,
@@ -45,7 +45,6 @@ class AnthropicProvider(BaseProvider):
 
         result = await agent.run(
             request.user_prompt,
-            system_prompt=request.system_prompt or "",
             model_settings=model_settings,
         )
 

--- a/t01_llm_battle/providers/google.py
+++ b/t01_llm_battle/providers/google.py
@@ -34,7 +34,7 @@ class GoogleProvider(BaseProvider):
         api_key = os.environ.get("GOOGLE_API_KEY", "")
         provider = GoogleGLAProvider(api_key=api_key)
         model = GeminiModel(request.model, provider=provider)
-        agent = Agent(model)
+        agent = Agent(model, system_prompt=request.system_prompt or "")
 
         model_settings: dict = {
             "temperature": request.temperature,
@@ -45,7 +45,6 @@ class GoogleProvider(BaseProvider):
 
         result = await agent.run(
             request.user_prompt,
-            system_prompt=request.system_prompt or "",
             model_settings=model_settings,
         )
 

--- a/t01_llm_battle/providers/groq.py
+++ b/t01_llm_battle/providers/groq.py
@@ -37,7 +37,7 @@ class GroqProvider(BaseProvider):
         api_key = os.environ.get("GROQ_API_KEY", "")
         provider = PAIGroqProvider(api_key=api_key)
         model = GroqModel(request.model, provider=provider)
-        agent = Agent(model)
+        agent = Agent(model, system_prompt=request.system_prompt or "")
 
         model_settings: dict = {
             "temperature": request.temperature,
@@ -48,7 +48,6 @@ class GroqProvider(BaseProvider):
 
         result = await agent.run(
             request.user_prompt,
-            system_prompt=request.system_prompt or "",
             model_settings=model_settings,
         )
 

--- a/t01_llm_battle/providers/lmstudio.py
+++ b/t01_llm_battle/providers/lmstudio.py
@@ -33,7 +33,7 @@ class LMStudioProvider(BaseProvider):
             api_key="lm-studio",  # LM Studio doesn't need a real key
         )
         model = OpenAIChatModel(request.model, provider=provider)
-        agent = Agent(model)
+        agent = Agent(model, system_prompt=request.system_prompt or "")
 
         model_settings: dict = {
             "temperature": request.temperature,
@@ -44,7 +44,6 @@ class LMStudioProvider(BaseProvider):
 
         result = await agent.run(
             request.user_prompt,
-            system_prompt=request.system_prompt or "",
             model_settings=model_settings,
         )
 

--- a/t01_llm_battle/providers/ollama.py
+++ b/t01_llm_battle/providers/ollama.py
@@ -40,7 +40,7 @@ class OllamaProvider(BaseProvider):
             api_key="ollama",  # Ollama doesn't need a real key
         )
         model = OpenAIChatModel(request.model, provider=provider)
-        agent = Agent(model)
+        agent = Agent(model, system_prompt=request.system_prompt or "")
 
         model_settings: dict = {
             "temperature": request.temperature,
@@ -51,7 +51,6 @@ class OllamaProvider(BaseProvider):
 
         result = await agent.run(
             request.user_prompt,
-            system_prompt=request.system_prompt or "",
             model_settings=model_settings,
         )
 

--- a/t01_llm_battle/providers/openai.py
+++ b/t01_llm_battle/providers/openai.py
@@ -33,7 +33,7 @@ class OpenAIProvider(BaseProvider):
         api_key = os.environ.get("OPENAI_API_KEY", "")
         provider = PAIOpenAIProvider(api_key=api_key)
         model = OpenAIChatModel(request.model, provider=provider)
-        agent = Agent(model)
+        agent = Agent(model, system_prompt=request.system_prompt or "")
 
         # Build model_settings from known extra keys; unknown keys are ignored (forward-compat)
         model_settings: dict = {
@@ -45,7 +45,6 @@ class OpenAIProvider(BaseProvider):
 
         result = await agent.run(
             request.user_prompt,
-            system_prompt=request.system_prompt or "",
             model_settings=model_settings,
         )
 

--- a/t01_llm_battle/providers/openrouter.py
+++ b/t01_llm_battle/providers/openrouter.py
@@ -30,7 +30,7 @@ class OpenRouterProvider(BaseProvider):
             base_url="https://openrouter.ai/api/v1",
         )
         model = OpenAIChatModel(request.model, provider=provider)
-        agent = Agent(model)
+        agent = Agent(model, system_prompt=request.system_prompt or "")
 
         model_settings: dict = {
             "temperature": request.temperature,
@@ -41,7 +41,6 @@ class OpenRouterProvider(BaseProvider):
 
         result = await agent.run(
             request.user_prompt,
-            system_prompt=request.system_prompt or "",
             model_settings=model_settings,
         )
 


### PR DESCRIPTION
Closes #193

pydantic-ai's `AbstractAgent.run()` does not accept `system_prompt` as a keyword argument.

**Changes:**
- Moved `system_prompt` from `agent.run(..., system_prompt=...)` to `Agent(model, system_prompt=...)` constructor
- Fixed all 7 LLM provider adapters: openai, anthropic, google, groq, openrouter, ollama, lmstudio
- judge.py uses `provider.run(ProviderRequest(...))` which goes through the same code path and is fixed by these changes

**Testing:**
- Tests pass
- All acceptance criteria met