### PR TITLE
fix: step edit form shows correct provider

### DIFF
--- a/t01_llm_battle/static/index.html
+++ b/t01_llm_battle/static/index.html
@@ -1488,9 +1488,9 @@ Do not wrap the JSON in markdown fences.`;
         },
 
         startEditStep(step) {
-          this.activeEditStepId = step.id;
           this.editStep = { system_prompt: step.system_prompt || '', provider: step.provider, model_id: step.model_id, provider_config: step.provider_config || '{}' };
           this.editStepError = null;
+          this.$nextTick(() => { this.activeEditStepId = step.id; });
         },
 
         cancelEditStep() { this.activeEditStepId = null; this.editStepError = null; },


### PR DESCRIPTION
Closes #189

**Root cause**: Alpine.js `x-model` on `<select>` with `x-for` options — when the `x-if` template activates, the select renders and syncs to the first available option before the correct value can be applied.

**Fix**: In `startEditStep()`, populate `editStep` and `editStepError` first, then use `$nextTick` to defer `activeEditStepId`. This ensures x-model syncs to the correct value before the select renders.

**Acceptance criteria**:
- ✓ Opening step edit form shows the correct provider in the dropdown  
- ✓ Provider value matches what is displayed in the step list view
- ✓ Saving without changes does not alter the provider