### PR TITLE
fix: use result.output instead of result.data for pydantic-ai compat

### DIFF
--- a/t01_llm_battle/providers/anthropic.py
+++ b/t01_llm_battle/providers/anthropic.py
@@ -54,7 +54,7 @@ class AnthropicProvider(BaseProvider):
         cost_usd = self._calc_cost(input_tokens, output_tokens, request.model)
 
         return ProviderResult(
-            content=result.data,
+            content=result.output,
             input_tokens=input_tokens,
             output_tokens=output_tokens,
             credits_used=None,

--- a/t01_llm_battle/providers/google.py
+++ b/t01_llm_battle/providers/google.py
@@ -54,7 +54,7 @@ class GoogleProvider(BaseProvider):
         cost_usd = self._calc_cost(input_tokens, output_tokens, request.model)
 
         return ProviderResult(
-            content=result.data,
+            content=result.output,
             input_tokens=input_tokens,
             output_tokens=output_tokens,
             credits_used=None,

--- a/t01_llm_battle/providers/groq.py
+++ b/t01_llm_battle/providers/groq.py
@@ -57,7 +57,7 @@ class GroqProvider(BaseProvider):
         cost_usd = self._calc_cost(input_tokens, output_tokens, request.model)
 
         return ProviderResult(
-            content=result.data,
+            content=result.output,
             input_tokens=input_tokens,
             output_tokens=output_tokens,
             credits_used=None,

--- a/t01_llm_battle/providers/lmstudio.py
+++ b/t01_llm_battle/providers/lmstudio.py
@@ -52,7 +52,7 @@ class LMStudioProvider(BaseProvider):
         output_tokens = usage.response_tokens or 0
 
         return ProviderResult(
-            content=result.data,
+            content=result.output,
             input_tokens=input_tokens,
             output_tokens=output_tokens,
             credits_used=None,

--- a/t01_llm_battle/providers/ollama.py
+++ b/t01_llm_battle/providers/ollama.py
@@ -59,7 +59,7 @@ class OllamaProvider(BaseProvider):
         output_tokens = usage.response_tokens or 0
 
         return ProviderResult(
-            content=result.data,
+            content=result.output,
             input_tokens=input_tokens,
             output_tokens=output_tokens,
             credits_used=None,

--- a/t01_llm_battle/providers/openai.py
+++ b/t01_llm_battle/providers/openai.py
@@ -54,7 +54,7 @@ class OpenAIProvider(BaseProvider):
         cost_usd = self._calc_cost(input_tokens, output_tokens, request.model)
 
         return ProviderResult(
-            content=result.data,
+            content=result.output,
             input_tokens=input_tokens,
             output_tokens=output_tokens,
             credits_used=None,

--- a/t01_llm_battle/providers/openrouter.py
+++ b/t01_llm_battle/providers/openrouter.py
@@ -49,7 +49,7 @@ class OpenRouterProvider(BaseProvider):
         output_tokens = usage.response_tokens or 0
 
         return ProviderResult(
-            content=result.data,
+            content=result.output,
             input_tokens=input_tokens,
             output_tokens=output_tokens,
             credits_used=None,

--- a/tests/test_openai_adapter.py
+++ b/tests/test_openai_adapter.py
@@ -15,7 +15,7 @@ async def test_run_returns_result():
     mock_usage.response_tokens = 5
 
     mock_result = MagicMock()
-    mock_result.data = "Hello!"
+    mock_result.output = "Hello!"
     mock_result.usage.return_value = mock_usage
 
     with patch("t01_llm_battle.providers.openai.Agent") as MockAgent:

--- a/tests/test_provider_config_passthrough.py
+++ b/tests/test_provider_config_passthrough.py
@@ -15,7 +15,7 @@ def _mock_agent_run(content="response"):
     mock_usage.response_tokens = 5
 
     mock_result = MagicMock()
-    mock_result.data = content
+    mock_result.output = content
     mock_result.usage.return_value = mock_usage
     return mock_result
 


### PR DESCRIPTION
## Summary
- pydantic-ai renamed `AgentRunResult.data` to `.output` — all 7 LLM provider adapters updated
- This was a **blocker**: every battle run failed with `'AgentRunResult' object has no attribute 'data'`

## Test plan
- [ ] Run a battle with OpenAI fighter — step completes without error
- [ ] Run a battle with Anthropic fighter — step completes without error
- [ ] Verify results show fighter output content correctly

Closes #193

🤖 Generated with [Claude Code](https://claude.com/claude-code)