### PR TITLE
feat: add judge config UI, make judge optional

### DIFF
--- a/t01_llm_battle/db.py
+++ b/t01_llm_battle/db.py
@@ -14,9 +14,9 @@ _SCHEMA_SQL = """
 CREATE TABLE IF NOT EXISTS battle (
     id            TEXT PRIMARY KEY,
     name          TEXT NOT NULL,
-    judge_provider TEXT NOT NULL,
-    judge_model   TEXT NOT NULL,
-    judge_rubric  TEXT NOT NULL,
+    judge_provider TEXT,
+    judge_model   TEXT,
+    judge_rubric  TEXT,
     created_at    TEXT NOT NULL
 );
 
@@ -107,6 +107,18 @@ CREATE TABLE IF NOT EXISTS provider_config (
 # Migrations for existing DBs
 _MIGRATIONS_SQL = [
     "ALTER TABLE provider_config ADD COLUMN display_name TEXT",
+    # SQLite cannot drop NOT NULL via ALTER TABLE; recreate battle table without NOT NULL on judge fields.
+    "ALTER TABLE battle RENAME TO battle_old",
+    """CREATE TABLE IF NOT EXISTS battle (
+    id            TEXT PRIMARY KEY,
+    name          TEXT NOT NULL,
+    judge_provider TEXT,
+    judge_model   TEXT,
+    judge_rubric  TEXT,
+    created_at    TEXT NOT NULL
+)""",
+    "INSERT INTO battle SELECT id, name, judge_provider, judge_model, judge_rubric, created_at FROM battle_old",
+    "DROP TABLE battle_old",
 ]
 
 

--- a/t01_llm_battle/routers/battles.py
+++ b/t01_llm_battle/routers/battles.py
@@ -36,9 +36,9 @@ class FighterBatch(BaseModel):
 
 class BattleCreate(BaseModel):
     name: str = Field(min_length=1)
-    judge_provider: str
-    judge_model: str
-    judge_rubric: str
+    judge_provider: Optional[str] = None
+    judge_model: Optional[str] = None
+    judge_rubric: Optional[str] = None
     fighters: list[FighterBatch] = []
 
     @field_validator("name")
@@ -59,17 +59,24 @@ class BattleSummary(BaseModel):
 class BattleDetail(BaseModel):
     id: str
     name: str
-    judge_provider: str
-    judge_model: str
-    judge_rubric: str
+    judge_provider: Optional[str] = None
+    judge_model: Optional[str] = None
+    judge_rubric: Optional[str] = None
     created_at: str
 
 
+_UNSET = object()
+
+
 class BattleUpdate(BaseModel):
+    model_config = {"arbitrary_types_allowed": True}
+
     name: Optional[str] = None
     judge_provider: Optional[str] = None
     judge_model: Optional[str] = None
     judge_rubric: Optional[str] = None
+    # When True, clear judge fields to NULL (disable judge)
+    judge_enabled: Optional[bool] = None
 
     @field_validator("name")
     @classmethod
@@ -180,9 +187,14 @@ async def update_battle(battle_id: str, body: BattleUpdate) -> BattleDetail:
             raise HTTPException(status_code=404, detail="Battle not found")
 
         new_name = body.name if body.name is not None else row["name"]
-        new_provider = body.judge_provider if body.judge_provider is not None else row["judge_provider"]
-        new_model = body.judge_model if body.judge_model is not None else row["judge_model"]
-        new_rubric = body.judge_rubric if body.judge_rubric is not None else row["judge_rubric"]
+        if body.judge_enabled is False:
+            new_provider = None
+            new_model = None
+            new_rubric = None
+        else:
+            new_provider = body.judge_provider if body.judge_provider is not None else row["judge_provider"]
+            new_model = body.judge_model if body.judge_model is not None else row["judge_model"]
+            new_rubric = body.judge_rubric if body.judge_rubric is not None else row["judge_rubric"]
 
         await db.execute(
             "UPDATE battle SET name = ?, judge_provider = ?, judge_model = ?, judge_rubric = ? WHERE id = ?",

--- a/t01_llm_battle/static/index.html
+++ b/t01_llm_battle/static/index.html
@@ -835,6 +835,56 @@
           </template>
         </div>
 
+        <!-- Judge card -->
+        <div class="card">
+          <div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:0.75rem;">
+            <h2 style="margin:0;">Judge <span class="badge-muted" style="font-size:0.72rem;font-weight:400;">optional</span></h2>
+            <label style="display:flex;align-items:center;gap:6px;cursor:pointer;margin:0;">
+              <input type="checkbox" x-model="judgeEnabled" @change="onJudgeToggle()" style="width:16px;height:16px;cursor:pointer;">
+              <span style="font-size:0.84rem;" x-text="judgeEnabled ? 'Enabled' : 'Disabled'"></span>
+            </label>
+          </div>
+          <template x-if="!judgeEnabled">
+            <p class="text-muted" style="font-size:0.84rem;margin:0;">Judge disabled — results will show outputs side-by-side without scores.</p>
+          </template>
+          <template x-if="judgeEnabled">
+            <div style="display:flex;flex-direction:column;gap:0.75rem;">
+              <div class="form-grid-2">
+                <div>
+                  <label style="font-size:0.84rem;">Provider</label>
+                  <select x-model="judgeProvider" @change="onJudgeProviderChange()" style="font-size:0.84rem;">
+                    <template x-for="p in llmProviders()" :key="p.name">
+                      <option :value="p.name" x-text="p.display_name"></option>
+                    </template>
+                    <template x-if="llmProviders().length === 0">
+                      <option value="openai">openai</option>
+                    </template>
+                  </select>
+                </div>
+                <div>
+                  <label style="font-size:0.84rem;">Model</label>
+                  <input type="text" x-model="judgeModel" style="font-size:0.84rem;" placeholder="e.g. gpt-4o">
+                </div>
+              </div>
+              <div>
+                <label style="font-size:0.84rem;">Rubric</label>
+                <textarea x-model="judgeRubric" rows="6" style="resize:vertical;font-size:0.83rem;font-family:inherit;" placeholder="Score the output on a scale of 0-10..."></textarea>
+              </div>
+              <div style="display:flex;gap:0.75rem;align-items:center;">
+                <button @click="saveJudge()" class="btn-primary" :disabled="judgeSaving" style="padding:5px 14px;font-size:0.83rem;">
+                  <span x-text="judgeSaving ? 'Saving...' : 'Save Judge'"></span>
+                </button>
+                <template x-if="judgeSaved">
+                  <span style="font-size:0.82rem;color:var(--gold);">Saved</span>
+                </template>
+                <template x-if="judgeError">
+                  <span class="text-danger" style="font-size:0.82rem;" x-text="judgeError"></span>
+                </template>
+              </div>
+            </div>
+          </template>
+        </div>
+
         <!-- Run Battle -->
         <div style="display:flex;align-items:center;gap:1rem;"
              @fighters-updated.window="fighterCount = $event.detail.count">
@@ -1279,7 +1329,7 @@
           try {
             const resp = await fetch('/battles', {
               method: 'POST', headers: {'Content-Type': 'application/json'},
-              body: JSON.stringify({ name, judge_provider: 'openai', judge_model: 'gpt-4o', judge_rubric: DEFAULT_RUBRIC })
+              body: JSON.stringify({ name, judge_provider: null, judge_model: null, judge_rubric: null })
             });
             if (!resp.ok) throw new Error(await resp.text());
             const battle = await resp.json();
@@ -1358,6 +1408,55 @@ Do not wrap the JSON in markdown fences.`;
         running: false, fighterCount: 0, runError: null, currentBattleId: null,
         battleName: '', nameInput: '', nameSaving: false,
         showTextForm: false, textItems: [{ content: '', label: '' }], addingText: false,
+        // Judge state
+        judgeEnabled: false, judgeProvider: 'openai', judgeModel: 'gpt-4o',
+        judgeRubric: DEFAULT_RUBRIC, judgeSaving: false, judgeSaved: false, judgeError: null,
+
+        llmProviders() {
+          const pi = window._providerInfoList || [];
+          return pi.filter(p => p.provider_type === 'llm' && p.enabled);
+        },
+
+        onJudgeProviderChange() {
+          const p = this.judgeProvider;
+          this.judgeModel = DEFAULT_MODELS[p] || 'gpt-4o';
+        },
+
+        onJudgeToggle() {
+          if (!this.judgeEnabled) {
+            // Disable: clear judge on server
+            this.saveJudgeDisabled();
+          }
+        },
+
+        async saveJudgeDisabled() {
+          if (!this.currentBattleId) return;
+          try {
+            await fetch(`/battles/${this.currentBattleId}`, {
+              method: 'PUT', headers: {'Content-Type': 'application/json'},
+              body: JSON.stringify({ judge_enabled: false })
+            });
+          } catch(_) {}
+        },
+
+        async saveJudge() {
+          if (!this.currentBattleId) return;
+          this.judgeSaving = true; this.judgeError = null; this.judgeSaved = false;
+          try {
+            const resp = await fetch(`/battles/${this.currentBattleId}`, {
+              method: 'PUT', headers: {'Content-Type': 'application/json'},
+              body: JSON.stringify({
+                judge_provider: this.judgeProvider,
+                judge_model: this.judgeModel,
+                judge_rubric: this.judgeRubric
+              })
+            });
+            if (!resp.ok) throw new Error(await resp.text());
+            this.judgeSaved = true;
+            setTimeout(() => { this.judgeSaved = false; }, 2000);
+          } catch(e) { this.judgeError = e.message; }
+          finally { this.judgeSaving = false; }
+        },
 
         async load(battleId) {
           if (!battleId) return;
@@ -1374,6 +1473,13 @@ Do not wrap the JSON in markdown fences.`;
               const b = await bResp.json();
               this.battleName = b.name || '';
               this.nameInput = this.battleName;
+              // Restore judge state
+              this.judgeEnabled = !!(b.judge_provider && b.judge_model);
+              if (this.judgeEnabled) {
+                this.judgeProvider = b.judge_provider;
+                this.judgeModel = b.judge_model;
+                this.judgeRubric = b.judge_rubric || DEFAULT_RUBRIC;
+              }
             }
           } catch(e) { this.error = e.message; }
         },
@@ -1592,6 +1698,7 @@ Do not wrap the JSON in markdown fences.`;
             const fighters = await fightersResp.json();
             if (provResp.ok) {
               this.providerInfoList = await provResp.json();
+              window._providerInfoList = this.providerInfoList;
               this.providers = this.providerInfoList.filter(p => p.enabled).map(p => p.name);
             }
             const firstLlm = this.providerInfoList.find(p => p.provider_type === 'llm' && p.enabled);


### PR DESCRIPTION
## Summary

Adds judge configuration UI to battle detail page and makes judge optional.

- BattleCreate/BattleDetail judge fields now Optional (null = disabled)
- Battle detail page shows Judge card with enable/disable toggle
- Judge can be configured with provider, model, and custom rubric
- New battles create with judge disabled by default
- Runs without judge skip scoring phase and show results side-by-side
- Engine already guards with `if judge_provider and judge_model:`

Closes #207

## Acceptance Criteria

- [x] Battle detail page has a Judge section with provider/model/rubric fields
- [x] Judge can be toggled on/off
- [x] New battles default to judge disabled
- [x] Runs without judge show results side-by-side
- [x] Runs with judge show scores as before
- [x] Judge config persists via PUT /battles/{id}

🤖 Generated with [Claude Code](https://claude.com/claude-code)