### PR TITLE
feat: auto-navigate to results when run completes

### DIFF
--- a/t01_llm_battle/static/index.html
+++ b/t01_llm_battle/static/index.html
@@ -1890,7 +1890,12 @@ Do not wrap the JSON in markdown fences.`;
             const resp = await fetch('/runs/' + this.runId + '/status');
             if (!resp.ok) throw new Error(await resp.text());
             this.run = await resp.json();
-            if (this.run.status === 'complete' || this.run.status === 'error') this.stopPolling();
+            if (this.run.status === 'complete' || this.run.status === 'error') {
+              this.stopPolling();
+              if (this.run.status === 'complete') {
+                setTimeout(() => { location.hash = '#/results/' + this.runId; }, 500);
+              }
+            }
           } catch(e) { this.error = e.message; this.stopPolling(); }
         },
 


### PR DESCRIPTION
Closes #213

## Summary
- When polling detects `run.status === 'complete'`, auto-navigates to `#/results/{runId}` after 500ms delay
- Error status still requires manual navigation so user can see error details
- "View Results →" button retained as fallback

## Tests
- All 69 pytest tests pass
- No debug statements found