### PR TITLE
fix: make live run cell status reactive via Alpine getter

### DIFF
--- a/t01_llm_battle/static/index.html
+++ b/t01_llm_battle/static/index.html
@@ -964,7 +964,7 @@
                         <template x-for="fighter in fighters()" :key="fighter.fighter_id">
                           <td style="vertical-align:top;">
                             <template x-if="getCellResult(fighter.fighter_id, source.source_id)">
-                              <div x-data="{ cell: getCellResult(fighter.fighter_id, source.source_id), submitContent: '', submitting: false, submitError: null }">
+                              <div x-data="{ _fid: fighter.fighter_id, _sid: source.source_id, get cell() { return getCellResult(this._fid, this._sid); }, submitContent: '', submitting: false, submitError: null }">
                                 <div style="display:flex;flex-wrap:wrap;gap:4px;margin-bottom:6px;">
                                   <template x-for="(step, idx) in (cell.steps || [])" :key="idx">
                                     <span


### PR DESCRIPTION
Closes #212

## Summary
- Root cause: `x-data="{ cell: getCellResult(...) }"` evaluates once on init — cell is frozen and never re-evaluated when polling updates `this.run`
- Fix: replace with `get cell()` getter so Alpine.js re-evaluates `getCellResult()` on every render cycle
- Stores fighter/source IDs in `_fid`/`_sid` so the getter can reference them from `this`

## Tests
- All 69 pytest tests pass
- No debug statements found