### PR TITLE
feat: Create llm_pricing.json and tool_pricing.json data files

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,8 @@ packages = ["t01_llm_battle"]
 
 [tool.hatch.build.targets.wheel.force-include]
 "t01_llm_battle/static" = "t01_llm_battle/static"
+"t01_llm_battle/llm_pricing.json" = "t01_llm_battle/llm_pricing.json"
+"t01_llm_battle/tool_pricing.json" = "t01_llm_battle/tool_pricing.json"
 
 [project.optional-dependencies]
 dev = [

--- a/t01_llm_battle/llm_pricing.json
+++ b/t01_llm_battle/llm_pricing.json
@@ -1,0 +1,31 @@
+{
+  "openai": {
+    "gpt-4o": {"input_per_million": 2.50, "output_per_million": 10.00},
+    "gpt-4o-mini": {"input_per_million": 0.15, "output_per_million": 0.60},
+    "gpt-4-turbo": {"input_per_million": 10.00, "output_per_million": 30.00},
+    "gpt-3.5-turbo": {"input_per_million": 0.50, "output_per_million": 1.50}
+  },
+  "anthropic": {
+    "claude-opus-4-6": {"input_per_million": 15.00, "output_per_million": 75.00},
+    "claude-sonnet-4-6": {"input_per_million": 3.00, "output_per_million": 15.00},
+    "claude-haiku-4-5-20251001": {"input_per_million": 0.80, "output_per_million": 4.00}
+  },
+  "google": {
+    "gemini-2.0-flash": {"input_per_million": 0.10, "output_per_million": 0.40},
+    "gemini-1.5-pro": {"input_per_million": 1.25, "output_per_million": 5.00},
+    "gemini-1.5-flash": {"input_per_million": 0.075, "output_per_million": 0.30}
+  },
+  "groq": {
+    "llama-3.3-70b-versatile": {"input_per_million": 0.59, "output_per_million": 0.79},
+    "llama-3.1-8b-instant": {"input_per_million": 0.05, "output_per_million": 0.08},
+    "mixtral-8x7b-32768": {"input_per_million": 0.24, "output_per_million": 0.24},
+    "gemma2-9b-it": {"input_per_million": 0.10, "output_per_million": 0.10}
+  },
+  "openrouter": {
+    "openai/gpt-4o": {"input_per_million": 0.0, "output_per_million": 0.0},
+    "anthropic/claude-sonnet-4-6": {"input_per_million": 0.0, "output_per_million": 0.0},
+    "google/gemini-2.0-flash": {"input_per_million": 0.0, "output_per_million": 0.0},
+    "meta-llama/llama-3.3-70b-instruct": {"input_per_million": 0.0, "output_per_million": 0.0},
+    "mistralai/mistral-7b-instruct": {"input_per_million": 0.0, "output_per_million": 0.0}
+  }
+}

--- a/t01_llm_battle/tool_pricing.json
+++ b/t01_llm_battle/tool_pricing.json
@@ -1,0 +1,17 @@
+{
+  "serper": {
+    "functions": ["search", "news"],
+    "credits_per_call": 1.0,
+    "usd_per_credit": 0.001
+  },
+  "tavily": {
+    "functions": ["search"],
+    "credits_per_call": 1.0,
+    "usd_per_credit": 0.002
+  },
+  "firecrawl": {
+    "functions": ["scrape", "crawl"],
+    "credits_per_call": 1.0,
+    "usd_per_credit": 0.001
+  }
+}


### PR DESCRIPTION
Closes #216

## Summary
- Adds `t01_llm_battle/llm_pricing.json` with all current hardcoded LLM pricing seeded from provider files (openai, anthropic, google, groq, openrouter)
- Adds `t01_llm_battle/tool_pricing.json` with all current tool CreditPricing values (serper, tavily, firecrawl)
- Updates `pyproject.toml` `force-include` to bundle both JSON files in the wheel build

## Tests
- All 69 pytest tests pass
- No debug statements introduced