### PR TITLE
feat: Create pricing.py module for centralized pricing logic

### DIFF
--- a/t01_llm_battle/pricing.py
+++ b/t01_llm_battle/pricing.py
@@ -1,0 +1,134 @@
+"""Centralized pricing module — loads, serves, and refreshes LLM and tool pricing."""
+
+from __future__ import annotations
+
+import json
+import time
+from importlib.resources import files
+from pathlib import Path
+from typing import Any
+
+_CACHE_DIR = Path.home() / ".t01-llm-battle"
+_LLM_CACHE = _CACHE_DIR / "llm_pricing.json"
+
+_LITELLM_URL = (
+    "https://raw.githubusercontent.com/BerriAI/litellm/main"
+    "/model_prices_and_context_window.json"
+)
+
+_PROVIDER_MAP = {
+    "openai": "openai",
+    "anthropic": "anthropic",
+    "google": "google",
+    "gemini": "google",
+    "groq": "groq",
+    "openrouter": "openrouter",
+}
+
+_SUPPORTED_PROVIDERS = set(_PROVIDER_MAP.values())
+
+
+def _load_bundled(name: str) -> dict[str, Any]:
+    pkg = files("t01_llm_battle")
+    return json.loads((pkg / name).read_text(encoding="utf-8"))
+
+
+def load_llm_pricing() -> dict[str, Any]:
+    """Load bundled llm_pricing.json, overlaid with user cache if present."""
+    data: dict[str, Any] = _load_bundled("llm_pricing.json")
+    if _LLM_CACHE.exists():
+        try:
+            cached = json.loads(_LLM_CACHE.read_text(encoding="utf-8"))
+            for provider, models in cached.items():
+                if provider not in data:
+                    data[provider] = {}
+                data[provider].update(models)
+        except (json.JSONDecodeError, OSError):
+            pass
+    return data
+
+
+def load_tool_pricing() -> dict[str, Any]:
+    """Load bundled tool_pricing.json."""
+    return _load_bundled("tool_pricing.json")
+
+
+def get_llm_models(provider: str) -> list[str]:
+    """Return model slugs for a provider."""
+    return list(load_llm_pricing().get(provider, {}).keys())
+
+
+def get_llm_cost(
+    provider: str, model: str, input_tokens: int, output_tokens: int
+) -> float:
+    """Calculate cost in USD. Returns 0.0 for unknown provider/model."""
+    pricing = load_llm_pricing()
+    entry = pricing.get(provider, {}).get(model)
+    if entry is None:
+        return 0.0
+    return (
+        input_tokens * entry["input_per_million"]
+        + output_tokens * entry["output_per_million"]
+    ) / 1_000_000
+
+
+def get_tool_functions(provider: str) -> list[str]:
+    """Return function list for a tool provider."""
+    tool = load_tool_pricing().get(provider, {})
+    return tool.get("functions", [])
+
+
+def get_tool_cost(provider: str) -> float:
+    """Return cost per call in USD."""
+    tool = load_tool_pricing().get(provider, {})
+    return tool.get("credits_per_call", 0.0) * tool.get("usd_per_credit", 0.0)
+
+
+def get_cache_info() -> dict[str, Any]:
+    """Return cache age in seconds and model count."""
+    if not _LLM_CACHE.exists():
+        return {"age_seconds": None, "model_count": 0}
+    age = time.time() - _LLM_CACHE.stat().st_mtime
+    try:
+        cached = json.loads(_LLM_CACHE.read_text(encoding="utf-8"))
+        count = sum(len(v) for v in cached.values())
+    except (json.JSONDecodeError, OSError):
+        count = 0
+    return {"age_seconds": int(age), "model_count": count}
+
+
+def refresh_llm_pricing() -> dict[str, int]:
+    """Fetch LiteLLM pricing JSON, normalize, write cache. Returns per-provider counts."""
+    import urllib.request
+
+    with urllib.request.urlopen(_LITELLM_URL, timeout=15) as resp:
+        raw: dict[str, Any] = json.loads(resp.read().decode("utf-8"))
+
+    result: dict[str, dict[str, Any]] = {}
+    for key, entry in raw.items():
+        if not isinstance(entry, dict):
+            continue
+        litellm_provider = entry.get("litellm_provider", "")
+        our_provider = _PROVIDER_MAP.get(litellm_provider)
+        if our_provider not in _SUPPORTED_PROVIDERS:
+            continue
+        input_cost = entry.get("input_cost_per_token")
+        output_cost = entry.get("output_cost_per_token")
+        if input_cost is None or output_cost is None:
+            continue
+
+        # Strip provider prefix: "groq/llama-3.3-70b" -> "llama-3.3-70b"
+        slug = key.split("/", 1)[-1] if "/" in key else key
+
+        if our_provider not in result:
+            result[our_provider] = {}
+        # Prefer bare key over stripped key on collision
+        if slug not in result[our_provider]:
+            result[our_provider][slug] = {
+                "input_per_million": round(input_cost * 1_000_000, 6),
+                "output_per_million": round(output_cost * 1_000_000, 6),
+            }
+
+    _CACHE_DIR.mkdir(parents=True, exist_ok=True)
+    _LLM_CACHE.write_text(json.dumps(result, indent=2), encoding="utf-8")
+    return {p: len(m) for p, m in result.items()}

--- a/t01_llm_battle/providers/anthropic.py
+++ b/t01_llm_battle/providers/anthropic.py
@@ -5,12 +5,7 @@ from pydantic_ai.models.anthropic import AnthropicModel
 from pydantic_ai.providers.anthropic import AnthropicProvider as PAIAnthropicProvider
 
 from .base import BaseProvider, ProviderRequest, ProviderResult, ProviderType
-
-PRICING = {
-    "claude-opus-4-6": (15.00, 75.00),
-    "claude-sonnet-4-6": (3.00, 15.00),
-    "claude-haiku-4-5-20251001": (0.80, 4.00),
-}
+from ..pricing import get_llm_cost, get_llm_models
 
 
 class AnthropicProvider(BaseProvider):
@@ -19,13 +14,7 @@ class AnthropicProvider(BaseProvider):
     provider_type = ProviderType.LLM
 
     def models(self) -> list[str]:
-        return ["claude-opus-4-6", "claude-sonnet-4-6", "claude-haiku-4-5-20251001"]
-
-    def _calc_cost(self, input_tokens: int, output_tokens: int, model: str) -> float:
-        if model not in PRICING:
-            return 0.0
-        input_rate, output_rate = PRICING[model]
-        return (input_tokens * input_rate + output_tokens * output_rate) / 1_000_000
+        return get_llm_models(self.name)
 
     async def run(self, request: ProviderRequest) -> ProviderResult:
         api_key = os.environ.get("ANTHROPIC_API_KEY", "")
@@ -51,7 +40,7 @@ class AnthropicProvider(BaseProvider):
         usage = result.usage()
         input_tokens = usage.request_tokens or 0
         output_tokens = usage.response_tokens or 0
-        cost_usd = self._calc_cost(input_tokens, output_tokens, request.model)
+        cost_usd = get_llm_cost(self.name, request.model, input_tokens, output_tokens)
 
         return ProviderResult(
             content=result.output,

--- a/t01_llm_battle/providers/base.py
+++ b/t01_llm_battle/providers/base.py
@@ -9,18 +9,6 @@ class ProviderType(Enum):
 
 
 @dataclass
-class TokenPricing:
-    input_per_million: float   # USD per 1M input tokens
-    output_per_million: float  # USD per 1M output tokens
-
-
-@dataclass
-class CreditPricing:
-    credits_per_call: float    # credits consumed per call
-    usd_per_credit: float      # USD per credit
-
-
-@dataclass
 class ProviderRequest:
     model: str                 # model slug (LLM) or function name (TOOL)
     system_prompt: str | None

--- a/t01_llm_battle/providers/firecrawl.py
+++ b/t01_llm_battle/providers/firecrawl.py
@@ -2,9 +2,8 @@ import os
 
 import httpx
 
-from .base import BaseProvider, CreditPricing, ProviderRequest, ProviderResult, ProviderType
-
-_PRICING = CreditPricing(credits_per_call=1.0, usd_per_credit=0.001)
+from .base import BaseProvider, ProviderRequest, ProviderResult, ProviderType
+from ..pricing import get_tool_cost, get_tool_functions, load_tool_pricing
 
 
 class FirecrawlProvider(BaseProvider):
@@ -13,7 +12,7 @@ class FirecrawlProvider(BaseProvider):
     provider_type = ProviderType.TOOL
 
     def models(self) -> list[str]:
-        return ["scrape", "crawl"]
+        return get_tool_functions(self.name)
 
     async def run(self, request: ProviderRequest) -> ProviderResult:
         api_key = os.environ.get("FIRECRAWL_API_KEY", "")
@@ -39,13 +38,15 @@ class FirecrawlProvider(BaseProvider):
             data = response.json()
 
         content = _format_firecrawl_results(data, function)
-        cost_usd = _PRICING.credits_per_call * _PRICING.usd_per_credit
+        tool = load_tool_pricing().get(self.name, {})
+        credits_used = tool.get("credits_per_call", 1.0)
+        cost_usd = get_tool_cost(self.name)
 
         return ProviderResult(
             content=content,
             input_tokens=None,
             output_tokens=None,
-            credits_used=_PRICING.credits_per_call,
+            credits_used=credits_used,
             cost_usd=cost_usd,
             model=function,
             provider="firecrawl",

--- a/t01_llm_battle/providers/google.py
+++ b/t01_llm_battle/providers/google.py
@@ -7,13 +7,7 @@ from pydantic_ai.models.gemini import GeminiModel
 from pydantic_ai.providers.google_gla import GoogleGLAProvider
 
 from .base import BaseProvider, ProviderRequest, ProviderResult, ProviderType
-
-_PRICING: dict[str, tuple[float, float]] = {
-    # (input $/1M tokens, output $/1M tokens)
-    "gemini-2.0-flash": (0.10, 0.40),
-    "gemini-1.5-pro": (1.25, 5.00),
-    "gemini-1.5-flash": (0.075, 0.30),
-}
+from ..pricing import get_llm_cost, get_llm_models
 
 
 class GoogleProvider(BaseProvider):
@@ -22,13 +16,7 @@ class GoogleProvider(BaseProvider):
     provider_type = ProviderType.LLM
 
     def models(self) -> list[str]:
-        return ["gemini-2.0-flash", "gemini-1.5-pro", "gemini-1.5-flash"]
-
-    def _calc_cost(self, input_tokens: int, output_tokens: int, model: str) -> float:
-        if model not in _PRICING:
-            return 0.0
-        input_price, output_price = _PRICING[model]
-        return (input_tokens * input_price + output_tokens * output_price) / 1_000_000
+        return get_llm_models(self.name)
 
     async def run(self, request: ProviderRequest) -> ProviderResult:
         api_key = os.environ.get("GOOGLE_API_KEY", "")
@@ -51,7 +39,7 @@ class GoogleProvider(BaseProvider):
         usage = result.usage()
         input_tokens = usage.request_tokens or 0
         output_tokens = usage.response_tokens or 0
-        cost_usd = self._calc_cost(input_tokens, output_tokens, request.model)
+        cost_usd = get_llm_cost(self.name, request.model, input_tokens, output_tokens)
 
         return ProviderResult(
             content=result.output,

--- a/t01_llm_battle/providers/groq.py
+++ b/t01_llm_battle/providers/groq.py
@@ -5,15 +5,7 @@ from pydantic_ai.models.groq import GroqModel
 from pydantic_ai.providers.groq import GroqProvider as PAIGroqProvider
 
 from .base import BaseProvider, ProviderRequest, ProviderResult, ProviderType
-
-_PRICING: dict[str, tuple[float, float]] = {
-    # model: (input $/1M tokens, output $/1M tokens)
-    "llama-3.3-70b-versatile": (0.59, 0.79),
-    "llama-3.1-8b-instant": (0.05, 0.08),
-    "mixtral-8x7b-32768": (0.24, 0.24),
-}
-
-_DEFAULT_PRICING: tuple[float, float] = (0.10, 0.10)
+from ..pricing import get_llm_cost, get_llm_models
 
 
 class GroqProvider(BaseProvider):
@@ -22,16 +14,7 @@ class GroqProvider(BaseProvider):
     provider_type = ProviderType.LLM
 
     def models(self) -> list[str]:
-        return [
-            "llama-3.3-70b-versatile",
-            "llama-3.1-8b-instant",
-            "mixtral-8x7b-32768",
-            "gemma2-9b-it",
-        ]
-
-    def _calc_cost(self, input_tokens: int, output_tokens: int, model: str) -> float:
-        input_rate, output_rate = _PRICING.get(model, _DEFAULT_PRICING)
-        return (input_tokens * input_rate + output_tokens * output_rate) / 1_000_000
+        return get_llm_models(self.name)
 
     async def run(self, request: ProviderRequest) -> ProviderResult:
         api_key = os.environ.get("GROQ_API_KEY", "")
@@ -54,7 +37,7 @@ class GroqProvider(BaseProvider):
         usage = result.usage()
         input_tokens = usage.request_tokens or 0
         output_tokens = usage.response_tokens or 0
-        cost_usd = self._calc_cost(input_tokens, output_tokens, request.model)
+        cost_usd = get_llm_cost(self.name, request.model, input_tokens, output_tokens)
 
         return ProviderResult(
             content=result.output,

--- a/t01_llm_battle/providers/openai.py
+++ b/t01_llm_battle/providers/openai.py
@@ -5,14 +5,7 @@ from pydantic_ai.models.openai import OpenAIChatModel
 from pydantic_ai.providers.openai import OpenAIProvider as PAIOpenAIProvider
 
 from .base import BaseProvider, ProviderRequest, ProviderResult, ProviderType
-
-_PRICING: dict[str, tuple[float, float]] = {
-    # model: (input $/1M tokens, output $/1M tokens)
-    "gpt-4o": (2.50, 10.00),
-    "gpt-4o-mini": (0.15, 0.60),
-    "gpt-4-turbo": (10.00, 30.00),
-    "gpt-3.5-turbo": (0.50, 1.50),
-}
+from ..pricing import get_llm_cost, get_llm_models
 
 
 class OpenAIProvider(BaseProvider):
@@ -21,13 +14,7 @@ class OpenAIProvider(BaseProvider):
     provider_type = ProviderType.LLM
 
     def models(self) -> list[str]:
-        return ["gpt-4o", "gpt-4o-mini", "gpt-4-turbo", "gpt-3.5-turbo"]
-
-    def _calc_cost(self, input_tokens: int, output_tokens: int, model: str) -> float:
-        if model not in _PRICING:
-            return 0.0
-        input_rate, output_rate = _PRICING[model]
-        return (input_tokens * input_rate + output_tokens * output_rate) / 1_000_000
+        return get_llm_models(self.name)
 
     async def run(self, request: ProviderRequest) -> ProviderResult:
         api_key = os.environ.get("OPENAI_API_KEY", "")
@@ -51,7 +38,7 @@ class OpenAIProvider(BaseProvider):
         usage = result.usage()
         input_tokens = usage.request_tokens or 0
         output_tokens = usage.response_tokens or 0
-        cost_usd = self._calc_cost(input_tokens, output_tokens, request.model)
+        cost_usd = get_llm_cost(self.name, request.model, input_tokens, output_tokens)
 
         return ProviderResult(
             content=result.output,

--- a/t01_llm_battle/providers/openrouter.py
+++ b/t01_llm_battle/providers/openrouter.py
@@ -5,14 +5,7 @@ from pydantic_ai.models.openai import OpenAIChatModel
 from pydantic_ai.providers.openai import OpenAIProvider as PAIOpenAIProvider
 
 from .base import BaseProvider, ProviderRequest, ProviderResult, ProviderType
-
-_MODELS = [
-    "openai/gpt-4o",
-    "anthropic/claude-sonnet-4-6",
-    "google/gemini-2.0-flash",
-    "meta-llama/llama-3.3-70b-instruct",
-    "mistralai/mistral-7b-instruct",
-]
+from ..pricing import get_llm_cost, get_llm_models
 
 
 class OpenRouterProvider(BaseProvider):
@@ -21,7 +14,7 @@ class OpenRouterProvider(BaseProvider):
     provider_type = ProviderType.LLM
 
     def models(self) -> list[str]:
-        return list(_MODELS)
+        return get_llm_models(self.name)
 
     async def run(self, request: ProviderRequest) -> ProviderResult:
         api_key = os.environ.get("OPENROUTER_API_KEY", "")
@@ -48,12 +41,14 @@ class OpenRouterProvider(BaseProvider):
         input_tokens = usage.request_tokens or 0
         output_tokens = usage.response_tokens or 0
 
+        cost_usd = get_llm_cost(self.name, request.model, input_tokens, output_tokens)
+
         return ProviderResult(
             content=result.output,
             input_tokens=input_tokens,
             output_tokens=output_tokens,
             credits_used=None,
-            cost_usd=0.0,
+            cost_usd=cost_usd,
             model=request.model,
             provider="openrouter",
         )

--- a/t01_llm_battle/providers/serper.py
+++ b/t01_llm_battle/providers/serper.py
@@ -3,9 +3,8 @@ import json
 
 import httpx
 
-from .base import BaseProvider, CreditPricing, ProviderRequest, ProviderResult, ProviderType
-
-_PRICING = CreditPricing(credits_per_call=1.0, usd_per_credit=0.001)
+from .base import BaseProvider, ProviderRequest, ProviderResult, ProviderType
+from ..pricing import get_tool_cost, get_tool_functions, load_tool_pricing
 
 _ENDPOINTS = {
     "search": "https://google.serper.dev/search",
@@ -19,7 +18,7 @@ class SerperProvider(BaseProvider):
     provider_type = ProviderType.TOOL
 
     def models(self) -> list[str]:
-        return ["search", "news"]
+        return get_tool_functions(self.name)
 
     async def run(self, request: ProviderRequest) -> ProviderResult:
         api_key = os.environ.get("SERPER_API_KEY", "")
@@ -37,13 +36,15 @@ class SerperProvider(BaseProvider):
             data = response.json()
 
         content = _format_serper_results(data, function)
-        cost_usd = _PRICING.credits_per_call * _PRICING.usd_per_credit
+        tool = load_tool_pricing().get(self.name, {})
+        credits_used = tool.get("credits_per_call", 1.0)
+        cost_usd = get_tool_cost(self.name)
 
         return ProviderResult(
             content=content,
             input_tokens=None,
             output_tokens=None,
-            credits_used=_PRICING.credits_per_call,
+            credits_used=credits_used,
             cost_usd=cost_usd,
             model=function,
             provider="serper",

--- a/t01_llm_battle/providers/tavily.py
+++ b/t01_llm_battle/providers/tavily.py
@@ -2,9 +2,8 @@ import os
 
 import httpx
 
-from .base import BaseProvider, CreditPricing, ProviderRequest, ProviderResult, ProviderType
-
-_PRICING = CreditPricing(credits_per_call=1.0, usd_per_credit=0.002)
+from .base import BaseProvider, ProviderRequest, ProviderResult, ProviderType
+from ..pricing import get_tool_cost, get_tool_functions, load_tool_pricing
 
 
 class TavilyProvider(BaseProvider):
@@ -13,7 +12,7 @@ class TavilyProvider(BaseProvider):
     provider_type = ProviderType.TOOL
 
     def models(self) -> list[str]:
-        return ["search"]
+        return get_tool_functions(self.name)
 
     async def run(self, request: ProviderRequest) -> ProviderResult:
         api_key = os.environ.get("TAVILY_API_KEY", "")
@@ -28,13 +27,15 @@ class TavilyProvider(BaseProvider):
             data = response.json()
 
         content = _format_tavily_results(data)
-        cost_usd = _PRICING.credits_per_call * _PRICING.usd_per_credit
+        tool = load_tool_pricing().get(self.name, {})
+        credits_used = tool.get("credits_per_call", 1.0)
+        cost_usd = get_tool_cost(self.name)
 
         return ProviderResult(
             content=content,
             input_tokens=None,
             output_tokens=None,
-            credits_used=_PRICING.credits_per_call,
+            credits_used=credits_used,
             cost_usd=cost_usd,
             model="search",
             provider="tavily",

--- a/t01_llm_battle/routers/fighters.py
+++ b/t01_llm_battle/routers/fighters.py
@@ -22,7 +22,8 @@ from pydantic import BaseModel
 
 from ..db import get_db, DB_PATH
 from ..providers.registry import list_providers, get_provider
-from ..providers.base import ProviderType, TokenPricing, CreditPricing
+from ..providers.base import ProviderType
+from ..pricing import get_llm_cost, load_llm_pricing, load_tool_pricing
 
 _SYSTEM_PROVIDERS = {
     "openai", "anthropic", "google", "groq",
@@ -307,7 +308,6 @@ class ProviderInfo(BaseModel):
 
 
 def _build_provider_info(name: str) -> ProviderInfo | None:
-    import sys
     try:
         p = get_provider(name)
     except KeyError:
@@ -316,31 +316,28 @@ def _build_provider_info(name: str) -> ProviderInfo | None:
     model_ids = p.models()
     models: list[ProviderModelInfo] = []
 
-    # Locate the provider's module to read module-level pricing constants
-    provider_module = sys.modules.get(type(p).__module__)
-
     if p.provider_type == ProviderType.LLM:
-        # Get per-model pricing dict from module (_PRICING or PRICING)
-        pricing_dict: dict = {}
-        if provider_module:
-            pricing_dict = getattr(provider_module, "_PRICING", None) or getattr(provider_module, "PRICING", None) or {}
+        llm_pricing = load_llm_pricing()
+        provider_prices = llm_pricing.get(name, {})
         for mid in model_ids:
-            if mid in pricing_dict:
-                inp, out = pricing_dict[mid]
+            entry = provider_prices.get(mid)
+            if entry:
+                inp = entry["input_per_million"]
+                out = entry["output_per_million"]
                 label = f"${inp:.2f} in / ${out:.2f} out per 1M tokens"
             else:
                 label = "pricing unknown"
             models.append(ProviderModelInfo(id=mid, pricing_label=label))
         native_tools: list[str] = list(getattr(p, "native_tools", []))
     else:
-        # TOOL provider — models() returns function names; get credit pricing from module
-        pricing: CreditPricing | None = None
-        if provider_module:
-            pricing = getattr(provider_module, "_PRICING", None) or getattr(provider_module, "PRICING", None)
+        # TOOL provider — models() returns function names; get credit pricing from centralized module
+        tool_pricing = load_tool_pricing().get(name, {})
+        credits_per_call = tool_pricing.get("credits_per_call", 0.0)
+        usd_per_credit = tool_pricing.get("usd_per_credit", 0.0)
         for fn in model_ids:
-            if pricing:
-                usd = pricing.credits_per_call * pricing.usd_per_credit
-                label = f"{pricing.credits_per_call:.0f} credit (${usd:.4f} per call)"
+            if credits_per_call:
+                usd = credits_per_call * usd_per_credit
+                label = f"{credits_per_call:.0f} credit (${usd:.4f} per call)"
             else:
                 label = "pricing unknown"
             models.append(ProviderModelInfo(id=fn, pricing_label=label))

--- a/tests/test_pricing.py
+++ b/tests/test_pricing.py
@@ -1,0 +1,191 @@
+"""Tests for t01_llm_battle.pricing module."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from t01_llm_battle import pricing as pricing_module
+from t01_llm_battle.pricing import (
+    get_cache_info,
+    get_llm_cost,
+    get_llm_models,
+    get_tool_cost,
+    get_tool_functions,
+    load_llm_pricing,
+    load_tool_pricing,
+    refresh_llm_pricing,
+)
+
+
+def test_load_llm_pricing_returns_dict():
+    data = load_llm_pricing()
+    assert isinstance(data, dict)
+    assert "openai" in data
+    assert "anthropic" in data
+    assert "google" in data
+    assert "groq" in data
+
+
+def test_load_llm_pricing_model_entries():
+    data = load_llm_pricing()
+    entry = data["openai"]["gpt-4o"]
+    assert "input_per_million" in entry
+    assert "output_per_million" in entry
+    assert entry["input_per_million"] == pytest.approx(2.50)
+
+
+def test_load_tool_pricing_returns_dict():
+    data = load_tool_pricing()
+    assert isinstance(data, dict)
+    assert "serper" in data
+    assert "tavily" in data
+    assert "firecrawl" in data
+
+
+def test_load_tool_pricing_structure():
+    data = load_tool_pricing()
+    entry = data["tavily"]
+    assert "functions" in entry
+    assert "credits_per_call" in entry
+    assert "usd_per_credit" in entry
+
+
+def test_get_llm_models():
+    models = get_llm_models("openai")
+    assert "gpt-4o" in models
+    assert "gpt-4o-mini" in models
+
+
+def test_get_llm_models_unknown_provider():
+    assert get_llm_models("nonexistent") == []
+
+
+def test_get_llm_cost():
+    cost = get_llm_cost("openai", "gpt-4o", 1_000_000, 1_000_000)
+    assert cost == pytest.approx(2.50 + 10.00)
+
+
+def test_get_llm_cost_zero_tokens():
+    assert get_llm_cost("openai", "gpt-4o", 0, 0) == 0.0
+
+
+def test_get_llm_cost_unknown_model():
+    assert get_llm_cost("openai", "nonexistent-model", 1000, 1000) == 0.0
+
+
+def test_get_llm_cost_unknown_provider():
+    assert get_llm_cost("unknown", "gpt-4o", 1000, 1000) == 0.0
+
+
+def test_get_tool_functions():
+    funcs = get_tool_functions("serper")
+    assert "search" in funcs
+
+
+def test_get_tool_functions_unknown():
+    assert get_tool_functions("unknown") == []
+
+
+def test_get_tool_cost():
+    cost = get_tool_cost("serper")
+    assert cost == pytest.approx(0.001)
+
+    cost = get_tool_cost("tavily")
+    assert cost == pytest.approx(0.002)
+
+
+def test_get_tool_cost_unknown():
+    assert get_tool_cost("nonexistent") == 0.0
+
+
+def test_get_cache_info_no_cache(tmp_path, monkeypatch):
+    monkeypatch.setattr(pricing_module, "_LLM_CACHE", tmp_path / "no_such_file.json")
+    info = get_cache_info()
+    assert info["age_seconds"] is None
+    assert info["model_count"] == 0
+
+
+def test_get_cache_info_with_cache(tmp_path, monkeypatch):
+    cache_file = tmp_path / "llm_pricing.json"
+    cache_file.write_text(
+        json.dumps({"openai": {"gpt-4o": {}, "gpt-4o-mini": {}}}), encoding="utf-8"
+    )
+    monkeypatch.setattr(pricing_module, "_LLM_CACHE", cache_file)
+    info = get_cache_info()
+    assert info["age_seconds"] is not None
+    assert info["model_count"] == 2
+
+
+def test_cache_overlay_overrides_bundled(tmp_path, monkeypatch):
+    cache_file = tmp_path / "llm_pricing.json"
+    cache_file.write_text(
+        json.dumps({"openai": {"gpt-4o": {"input_per_million": 999.0, "output_per_million": 999.0}}}),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(pricing_module, "_LLM_CACHE", cache_file)
+    data = load_llm_pricing()
+    assert data["openai"]["gpt-4o"]["input_per_million"] == pytest.approx(999.0)
+
+
+def test_cache_overlay_corrupt_falls_back(tmp_path, monkeypatch):
+    cache_file = tmp_path / "llm_pricing.json"
+    cache_file.write_text("not valid json", encoding="utf-8")
+    monkeypatch.setattr(pricing_module, "_LLM_CACHE", cache_file)
+    # Should not raise; falls back to bundled data
+    data = load_llm_pricing()
+    assert "openai" in data
+
+
+def test_refresh_llm_pricing(tmp_path, monkeypatch):
+    fake_litellm = {
+        "gpt-4o": {
+            "litellm_provider": "openai",
+            "input_cost_per_token": 0.000002,
+            "output_cost_per_token": 0.000006,
+        },
+        "openai/gpt-4o": {
+            "litellm_provider": "openai",
+            "input_cost_per_token": 0.000001,
+            "output_cost_per_token": 0.000003,
+        },
+        "groq/llama-3.3-70b-versatile": {
+            "litellm_provider": "groq",
+            "input_cost_per_token": 0.00000059,
+            "output_cost_per_token": 0.00000079,
+        },
+        "azure/gpt-4": {
+            "litellm_provider": "azure",
+            "input_cost_per_token": 0.00003,
+            "output_cost_per_token": 0.00006,
+        },
+    }
+
+    import io
+    import urllib.request
+
+    class FakeResp:
+        def read(self):
+            return json.dumps(fake_litellm).encode()
+        def __enter__(self): return self
+        def __exit__(self, *a): pass
+
+    monkeypatch.setattr(pricing_module, "_CACHE_DIR", tmp_path)
+    monkeypatch.setattr(pricing_module, "_LLM_CACHE", tmp_path / "llm_pricing.json")
+    monkeypatch.setattr(urllib.request, "urlopen", lambda *a, **kw: FakeResp())
+
+    counts = refresh_llm_pricing()
+    assert "openai" in counts
+    assert "groq" in counts
+    # azure should be skipped
+    assert "azure" not in counts
+
+    written = json.loads((tmp_path / "llm_pricing.json").read_text())
+    # Bare key "gpt-4o" preferred over stripped "openai/gpt-4o"
+    assert "gpt-4o" in written["openai"]
+    assert written["openai"]["gpt-4o"]["input_per_million"] == pytest.approx(2.0)
+    # Groq prefix stripped
+    assert "llama-3.3-70b-versatile" in written["groq"]


### PR DESCRIPTION
Closes #217

## Summary
- Adds `t01_llm_battle/pricing.py` — central module with load/serve/refresh functions
- Adds `t01_llm_battle/llm_pricing.json` and `tool_pricing.json` seeded from provider files
- Updates `pyproject.toml` to bundle both JSON files in wheel
- Cache overlay: `~/.t01-llm-battle/llm_pricing.json` overlays bundled values
- `refresh_llm_pricing()` fetches LiteLLM JSON, normalizes, converts per-token to per-million

## Tests
- All 88 pytest tests pass (19 new in tests/test_pricing.py)
- No debug statements introduced