### PR TITLE
refactor: Migrate all providers to use centralized pricing module

### DIFF
--- a/t01_llm_battle/providers/anthropic.py
+++ b/t01_llm_battle/providers/anthropic.py
@@ -5,12 +5,7 @@ from pydantic_ai.models.anthropic import AnthropicModel
 from pydantic_ai.providers.anthropic import AnthropicProvider as PAIAnthropicProvider
 
 from .base import BaseProvider, ProviderRequest, ProviderResult, ProviderType
-
-PRICING = {
-    "claude-opus-4-6": (15.00, 75.00),
-    "claude-sonnet-4-6": (3.00, 15.00),
-    "claude-haiku-4-5-20251001": (0.80, 4.00),
-}
+from ..pricing import get_llm_cost, get_llm_models
 
 
 class AnthropicProvider(BaseProvider):
@@ -19,13 +14,7 @@ class AnthropicProvider(BaseProvider):
     provider_type = ProviderType.LLM
 
     def models(self) -> list[str]:
-        return ["claude-opus-4-6", "claude-sonnet-4-6", "claude-haiku-4-5-20251001"]
-
-    def _calc_cost(self, input_tokens: int, output_tokens: int, model: str) -> float:
-        if model not in PRICING:
-            return 0.0
-        input_rate, output_rate = PRICING[model]
-        return (input_tokens * input_rate + output_tokens * output_rate) / 1_000_000
+        return get_llm_models(self.name)
 
     async def run(self, request: ProviderRequest) -> ProviderResult:
         api_key = os.environ.get("ANTHROPIC_API_KEY", "")
@@ -51,7 +40,7 @@ class AnthropicProvider(BaseProvider):
         usage = result.usage()
         input_tokens = usage.request_tokens or 0
         output_tokens = usage.response_tokens or 0
-        cost_usd = self._calc_cost(input_tokens, output_tokens, request.model)
+        cost_usd = get_llm_cost(self.name, request.model, input_tokens, output_tokens)
 
         return ProviderResult(
             content=result.output,

--- a/t01_llm_battle/providers/base.py
+++ b/t01_llm_battle/providers/base.py
@@ -9,18 +9,6 @@ class ProviderType(Enum):
 
 
 @dataclass
-class TokenPricing:
-    input_per_million: float   # USD per 1M input tokens
-    output_per_million: float  # USD per 1M output tokens
-
-
-@dataclass
-class CreditPricing:
-    credits_per_call: float    # credits consumed per call
-    usd_per_credit: float      # USD per credit
-
-
-@dataclass
 class ProviderRequest:
     model: str                 # model slug (LLM) or function name (TOOL)
     system_prompt: str | None

--- a/t01_llm_battle/providers/firecrawl.py
+++ b/t01_llm_battle/providers/firecrawl.py
@@ -2,9 +2,8 @@ import os
 
 import httpx
 
-from .base import BaseProvider, CreditPricing, ProviderRequest, ProviderResult, ProviderType
-
-_PRICING = CreditPricing(credits_per_call=1.0, usd_per_credit=0.001)
+from .base import BaseProvider, ProviderRequest, ProviderResult, ProviderType
+from ..pricing import get_tool_cost, get_tool_functions, load_tool_pricing
 
 
 class FirecrawlProvider(BaseProvider):
@@ -13,7 +12,7 @@ class FirecrawlProvider(BaseProvider):
     provider_type = ProviderType.TOOL
 
     def models(self) -> list[str]:
-        return ["scrape", "crawl"]
+        return get_tool_functions(self.name)
 
     async def run(self, request: ProviderRequest) -> ProviderResult:
         api_key = os.environ.get("FIRECRAWL_API_KEY", "")
@@ -39,13 +38,15 @@ class FirecrawlProvider(BaseProvider):
             data = response.json()
 
         content = _format_firecrawl_results(data, function)
-        cost_usd = _PRICING.credits_per_call * _PRICING.usd_per_credit
+        tool = load_tool_pricing().get(self.name, {})
+        credits_used = tool.get("credits_per_call", 1.0)
+        cost_usd = get_tool_cost(self.name)
 
         return ProviderResult(
             content=content,
             input_tokens=None,
             output_tokens=None,
-            credits_used=_PRICING.credits_per_call,
+            credits_used=credits_used,
             cost_usd=cost_usd,
             model=function,
             provider="firecrawl",

--- a/t01_llm_battle/providers/google.py
+++ b/t01_llm_battle/providers/google.py
@@ -7,13 +7,7 @@ from pydantic_ai.models.gemini import GeminiModel
 from pydantic_ai.providers.google_gla import GoogleGLAProvider
 
 from .base import BaseProvider, ProviderRequest, ProviderResult, ProviderType
-
-_PRICING: dict[str, tuple[float, float]] = {
-    # (input $/1M tokens, output $/1M tokens)
-    "gemini-2.0-flash": (0.10, 0.40),
-    "gemini-1.5-pro": (1.25, 5.00),
-    "gemini-1.5-flash": (0.075, 0.30),
-}
+from ..pricing import get_llm_cost, get_llm_models
 
 
 class GoogleProvider(BaseProvider):
@@ -22,13 +16,7 @@ class GoogleProvider(BaseProvider):
     provider_type = ProviderType.LLM
 
     def models(self) -> list[str]:
-        return ["gemini-2.0-flash", "gemini-1.5-pro", "gemini-1.5-flash"]
-
-    def _calc_cost(self, input_tokens: int, output_tokens: int, model: str) -> float:
-        if model not in _PRICING:
-            return 0.0
-        input_price, output_price = _PRICING[model]
-        return (input_tokens * input_price + output_tokens * output_price) / 1_000_000
+        return get_llm_models(self.name)
 
     async def run(self, request: ProviderRequest) -> ProviderResult:
         api_key = os.environ.get("GOOGLE_API_KEY", "")
@@ -51,7 +39,7 @@ class GoogleProvider(BaseProvider):
         usage = result.usage()
         input_tokens = usage.request_tokens or 0
         output_tokens = usage.response_tokens or 0
-        cost_usd = self._calc_cost(input_tokens, output_tokens, request.model)
+        cost_usd = get_llm_cost(self.name, request.model, input_tokens, output_tokens)
 
         return ProviderResult(
             content=result.output,

--- a/t01_llm_battle/providers/groq.py
+++ b/t01_llm_battle/providers/groq.py
@@ -5,15 +5,7 @@ from pydantic_ai.models.groq import GroqModel
 from pydantic_ai.providers.groq import GroqProvider as PAIGroqProvider
 
 from .base import BaseProvider, ProviderRequest, ProviderResult, ProviderType
-
-_PRICING: dict[str, tuple[float, float]] = {
-    # model: (input $/1M tokens, output $/1M tokens)
-    "llama-3.3-70b-versatile": (0.59, 0.79),
-    "llama-3.1-8b-instant": (0.05, 0.08),
-    "mixtral-8x7b-32768": (0.24, 0.24),
-}
-
-_DEFAULT_PRICING: tuple[float, float] = (0.10, 0.10)
+from ..pricing import get_llm_cost, get_llm_models
 
 
 class GroqProvider(BaseProvider):
@@ -22,16 +14,7 @@ class GroqProvider(BaseProvider):
     provider_type = ProviderType.LLM
 
     def models(self) -> list[str]:
-        return [
-            "llama-3.3-70b-versatile",
-            "llama-3.1-8b-instant",
-            "mixtral-8x7b-32768",
-            "gemma2-9b-it",
-        ]
-
-    def _calc_cost(self, input_tokens: int, output_tokens: int, model: str) -> float:
-        input_rate, output_rate = _PRICING.get(model, _DEFAULT_PRICING)
-        return (input_tokens * input_rate + output_tokens * output_rate) / 1_000_000
+        return get_llm_models(self.name)
 
     async def run(self, request: ProviderRequest) -> ProviderResult:
         api_key = os.environ.get("GROQ_API_KEY", "")
@@ -54,7 +37,7 @@ class GroqProvider(BaseProvider):
         usage = result.usage()
         input_tokens = usage.request_tokens or 0
         output_tokens = usage.response_tokens or 0
-        cost_usd = self._calc_cost(input_tokens, output_tokens, request.model)
+        cost_usd = get_llm_cost(self.name, request.model, input_tokens, output_tokens)
 
         return ProviderResult(
             content=result.output,

--- a/t01_llm_battle/providers/openai.py
+++ b/t01_llm_battle/providers/openai.py
@@ -5,14 +5,7 @@ from pydantic_ai.models.openai import OpenAIChatModel
 from pydantic_ai.providers.openai import OpenAIProvider as PAIOpenAIProvider
 
 from .base import BaseProvider, ProviderRequest, ProviderResult, ProviderType
-
-_PRICING: dict[str, tuple[float, float]] = {
-    # model: (input $/1M tokens, output $/1M tokens)
-    "gpt-4o": (2.50, 10.00),
-    "gpt-4o-mini": (0.15, 0.60),
-    "gpt-4-turbo": (10.00, 30.00),
-    "gpt-3.5-turbo": (0.50, 1.50),
-}
+from ..pricing import get_llm_cost, get_llm_models
 
 
 class OpenAIProvider(BaseProvider):
@@ -21,13 +14,7 @@ class OpenAIProvider(BaseProvider):
     provider_type = ProviderType.LLM
 
     def models(self) -> list[str]:
-        return ["gpt-4o", "gpt-4o-mini", "gpt-4-turbo", "gpt-3.5-turbo"]
-
-    def _calc_cost(self, input_tokens: int, output_tokens: int, model: str) -> float:
-        if model not in _PRICING:
-            return 0.0
-        input_rate, output_rate = _PRICING[model]
-        return (input_tokens * input_rate + output_tokens * output_rate) / 1_000_000
+        return get_llm_models(self.name)
 
     async def run(self, request: ProviderRequest) -> ProviderResult:
         api_key = os.environ.get("OPENAI_API_KEY", "")
@@ -51,7 +38,7 @@ class OpenAIProvider(BaseProvider):
         usage = result.usage()
         input_tokens = usage.request_tokens or 0
         output_tokens = usage.response_tokens or 0
-        cost_usd = self._calc_cost(input_tokens, output_tokens, request.model)
+        cost_usd = get_llm_cost(self.name, request.model, input_tokens, output_tokens)
 
         return ProviderResult(
             content=result.output,

--- a/t01_llm_battle/providers/openrouter.py
+++ b/t01_llm_battle/providers/openrouter.py
@@ -5,14 +5,7 @@ from pydantic_ai.models.openai import OpenAIChatModel
 from pydantic_ai.providers.openai import OpenAIProvider as PAIOpenAIProvider
 
 from .base import BaseProvider, ProviderRequest, ProviderResult, ProviderType
-
-_MODELS = [
-    "openai/gpt-4o",
-    "anthropic/claude-sonnet-4-6",
-    "google/gemini-2.0-flash",
-    "meta-llama/llama-3.3-70b-instruct",
-    "mistralai/mistral-7b-instruct",
-]
+from ..pricing import get_llm_cost, get_llm_models
 
 
 class OpenRouterProvider(BaseProvider):
@@ -21,7 +14,7 @@ class OpenRouterProvider(BaseProvider):
     provider_type = ProviderType.LLM
 
     def models(self) -> list[str]:
-        return list(_MODELS)
+        return get_llm_models(self.name)
 
     async def run(self, request: ProviderRequest) -> ProviderResult:
         api_key = os.environ.get("OPENROUTER_API_KEY", "")
@@ -48,12 +41,14 @@ class OpenRouterProvider(BaseProvider):
         input_tokens = usage.request_tokens or 0
         output_tokens = usage.response_tokens or 0
 
+        cost_usd = get_llm_cost(self.name, request.model, input_tokens, output_tokens)
+
         return ProviderResult(
             content=result.output,
             input_tokens=input_tokens,
             output_tokens=output_tokens,
             credits_used=None,
-            cost_usd=0.0,
+            cost_usd=cost_usd,
             model=request.model,
             provider="openrouter",
         )

--- a/t01_llm_battle/providers/serper.py
+++ b/t01_llm_battle/providers/serper.py
@@ -3,9 +3,8 @@ import json
 
 import httpx
 
-from .base import BaseProvider, CreditPricing, ProviderRequest, ProviderResult, ProviderType
-
-_PRICING = CreditPricing(credits_per_call=1.0, usd_per_credit=0.001)
+from .base import BaseProvider, ProviderRequest, ProviderResult, ProviderType
+from ..pricing import get_tool_cost, get_tool_functions, load_tool_pricing
 
 _ENDPOINTS = {
     "search": "https://google.serper.dev/search",
@@ -19,7 +18,7 @@ class SerperProvider(BaseProvider):
     provider_type = ProviderType.TOOL
 
     def models(self) -> list[str]:
-        return ["search", "news"]
+        return get_tool_functions(self.name)
 
     async def run(self, request: ProviderRequest) -> ProviderResult:
         api_key = os.environ.get("SERPER_API_KEY", "")
@@ -37,13 +36,15 @@ class SerperProvider(BaseProvider):
             data = response.json()
 
         content = _format_serper_results(data, function)
-        cost_usd = _PRICING.credits_per_call * _PRICING.usd_per_credit
+        tool = load_tool_pricing().get(self.name, {})
+        credits_used = tool.get("credits_per_call", 1.0)
+        cost_usd = get_tool_cost(self.name)
 
         return ProviderResult(
             content=content,
             input_tokens=None,
             output_tokens=None,
-            credits_used=_PRICING.credits_per_call,
+            credits_used=credits_used,
             cost_usd=cost_usd,
             model=function,
             provider="serper",

--- a/t01_llm_battle/providers/tavily.py
+++ b/t01_llm_battle/providers/tavily.py
@@ -2,9 +2,8 @@ import os
 
 import httpx
 
-from .base import BaseProvider, CreditPricing, ProviderRequest, ProviderResult, ProviderType
-
-_PRICING = CreditPricing(credits_per_call=1.0, usd_per_credit=0.002)
+from .base import BaseProvider, ProviderRequest, ProviderResult, ProviderType
+from ..pricing import get_tool_cost, get_tool_functions, load_tool_pricing
 
 
 class TavilyProvider(BaseProvider):
@@ -13,7 +12,7 @@ class TavilyProvider(BaseProvider):
     provider_type = ProviderType.TOOL
 
     def models(self) -> list[str]:
-        return ["search"]
+        return get_tool_functions(self.name)
 
     async def run(self, request: ProviderRequest) -> ProviderResult:
         api_key = os.environ.get("TAVILY_API_KEY", "")
@@ -28,13 +27,15 @@ class TavilyProvider(BaseProvider):
             data = response.json()
 
         content = _format_tavily_results(data)
-        cost_usd = _PRICING.credits_per_call * _PRICING.usd_per_credit
+        tool = load_tool_pricing().get(self.name, {})
+        credits_used = tool.get("credits_per_call", 1.0)
+        cost_usd = get_tool_cost(self.name)
 
         return ProviderResult(
             content=content,
             input_tokens=None,
             output_tokens=None,
-            credits_used=_PRICING.credits_per_call,
+            credits_used=credits_used,
             cost_usd=cost_usd,
             model="search",
             provider="tavily",

--- a/t01_llm_battle/routers/fighters.py
+++ b/t01_llm_battle/routers/fighters.py
@@ -22,7 +22,8 @@ from pydantic import BaseModel
 
 from ..db import get_db, DB_PATH
 from ..providers.registry import list_providers, get_provider
-from ..providers.base import ProviderType, TokenPricing, CreditPricing
+from ..providers.base import ProviderType
+from ..pricing import get_llm_cost, load_llm_pricing, load_tool_pricing
 
 _SYSTEM_PROVIDERS = {
     "openai", "anthropic", "google", "groq",
@@ -307,7 +308,6 @@ class ProviderInfo(BaseModel):
 
 
 def _build_provider_info(name: str) -> ProviderInfo | None:
-    import sys
     try:
         p = get_provider(name)
     except KeyError:
@@ -316,31 +316,28 @@ def _build_provider_info(name: str) -> ProviderInfo | None:
     model_ids = p.models()
     models: list[ProviderModelInfo] = []
 
-    # Locate the provider's module to read module-level pricing constants
-    provider_module = sys.modules.get(type(p).__module__)
-
     if p.provider_type == ProviderType.LLM:
-        # Get per-model pricing dict from module (_PRICING or PRICING)
-        pricing_dict: dict = {}
-        if provider_module:
-            pricing_dict = getattr(provider_module, "_PRICING", None) or getattr(provider_module, "PRICING", None) or {}
+        llm_pricing = load_llm_pricing()
+        provider_prices = llm_pricing.get(name, {})
         for mid in model_ids:
-            if mid in pricing_dict:
-                inp, out = pricing_dict[mid]
+            entry = provider_prices.get(mid)
+            if entry:
+                inp = entry["input_per_million"]
+                out = entry["output_per_million"]
                 label = f"${inp:.2f} in / ${out:.2f} out per 1M tokens"
             else:
                 label = "pricing unknown"
             models.append(ProviderModelInfo(id=mid, pricing_label=label))
         native_tools: list[str] = list(getattr(p, "native_tools", []))
     else:
-        # TOOL provider — models() returns function names; get credit pricing from module
-        pricing: CreditPricing | None = None
-        if provider_module:
-            pricing = getattr(provider_module, "_PRICING", None) or getattr(provider_module, "PRICING", None)
+        # TOOL provider — models() returns function names; get credit pricing from centralized module
+        tool_pricing = load_tool_pricing().get(name, {})
+        credits_per_call = tool_pricing.get("credits_per_call", 0.0)
+        usd_per_credit = tool_pricing.get("usd_per_credit", 0.0)
         for fn in model_ids:
-            if pricing:
-                usd = pricing.credits_per_call * pricing.usd_per_credit
-                label = f"{pricing.credits_per_call:.0f} credit (${usd:.4f} per call)"
+            if credits_per_call:
+                usd = credits_per_call * usd_per_credit
+                label = f"{credits_per_call:.0f} credit (${usd:.4f} per call)"
             else:
                 label = "pricing unknown"
             models.append(ProviderModelInfo(id=fn, pricing_label=label))


### PR DESCRIPTION
Closes #218

## Summary
- Removed hardcoded _PRICING dicts and _calc_cost methods from all LLM providers
- Removed _PRICING constants and hardcoded function lists from all tool providers
- Removed TokenPricing and CreditPricing dataclasses from base.py
- Updated fighters.py /providers endpoint to use centralized pricing.py

## Tests
- All 88 pytest tests pass