### PR TITLE
feat: Add pricing refresh API endpoint and UI button

### DIFF
--- a/t01_llm_battle/routers/providers.py
+++ b/t01_llm_battle/routers/providers.py
@@ -1,17 +1,34 @@
 """
 Provider management API.
 
+GET    /providers/pricing        — pricing cache info
+POST   /providers/pricing/refresh — fetch latest LLM pricing from LiteLLM
 PATCH  /providers/{name}        — toggle enabled/disabled
 PUT    /providers/{name}/config — update server_url or other config
 DELETE /providers/{name}        — uninstall non-system provider (403 for system)
 """
-from datetime import datetime, timezone
+import json
+import os
+from datetime import datetime, timezone, date
+from pathlib import Path
 
+import httpx
 from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel
 
 from ..db import get_db
 from ..providers.registry import list_providers, get_provider
+
+_CACHE_DIR = Path.home() / ".t01-llm-battle"
+_CACHE_FILE = _CACHE_DIR / "llm_pricing.json"
+_LITELLM_URL = "https://raw.githubusercontent.com/BerriAI/litellm/main/model_prices_and_context_window.json"
+_PROVIDER_MAP = {
+    "openai": "openai",
+    "anthropic": "anthropic",
+    "google": "google",
+    "groq": "groq",
+    "openrouter": "openrouter",
+}
 
 router = APIRouter(prefix="/providers", tags=["providers"])
 
@@ -79,6 +96,56 @@ async def update_provider_config(name: str, body: ProviderConfigUpdate):
         )
         await db.commit()
     return {"provider": name, "server_url": server_url}
+
+
+@router.get("/pricing")
+async def get_pricing_cache():
+    """Return pricing cache info: {models, updated_at, age_days} or null if no cache."""
+    if not _CACHE_FILE.exists():
+        return None
+    try:
+        mtime = _CACHE_FILE.stat().st_mtime
+        updated_at = datetime.fromtimestamp(mtime, tz=timezone.utc).isoformat()
+        age_days = (datetime.now(timezone.utc).timestamp() - mtime) / 86400
+        data = json.loads(_CACHE_FILE.read_text())
+        return {"models": len(data), "updated_at": updated_at, "age_days": round(age_days, 1)}
+    except Exception:
+        return None
+
+
+@router.post("/pricing/refresh")
+async def refresh_pricing():
+    """Fetch latest LLM pricing from LiteLLM, normalize, and save to cache."""
+    try:
+        async with httpx.AsyncClient(timeout=15) as client:
+            resp = await client.get(_LITELLM_URL)
+            resp.raise_for_status()
+            raw = resp.json()
+    except Exception as e:
+        raise HTTPException(status_code=502, detail=f"Failed to fetch LiteLLM pricing: {e}")
+
+    normalized: dict = {}
+    for key, val in raw.items():
+        if not isinstance(val, dict):
+            continue
+        litellm_provider = val.get("litellm_provider", "")
+        our_provider = _PROVIDER_MAP.get(litellm_provider)
+        if not our_provider:
+            continue
+        # Strip provider prefix from key
+        slug = key.split("/", 1)[-1] if "/" in key else key
+        inp = val.get("input_cost_per_token", 0) * 1_000_000
+        out = val.get("output_cost_per_token", 0) * 1_000_000
+        # Prefer bare key (no slash) over stripped key to avoid collisions
+        entry_key = f"{our_provider}/{slug}"
+        if entry_key not in normalized:
+            normalized[entry_key] = {"input_per_million": inp, "output_per_million": out}
+
+    _CACHE_DIR.mkdir(parents=True, exist_ok=True)
+    _CACHE_FILE.write_text(json.dumps(normalized, indent=2))
+
+    updated_at = datetime.now(timezone.utc).isoformat()
+    return {"models_updated": len(normalized), "updated_at": updated_at}
 
 
 @router.delete("/{name}", status_code=204, response_model=None)

--- a/t01_llm_battle/routers/providers.py
+++ b/t01_llm_battle/routers/providers.py
@@ -8,8 +8,7 @@ PUT    /providers/{name}/config — update server_url or other config
 DELETE /providers/{name}        — uninstall non-system provider (403 for system)
 """
 import json
-import os
-from datetime import datetime, timezone, date
+from datetime import datetime, timezone
 from pathlib import Path
 
 import httpx

--- a/t01_llm_battle/static/index.html
+++ b/t01_llm_battle/static/index.html
@@ -1179,7 +1179,19 @@
             <!-- LLM Providers -->
             <template x-if="llmKeys().length > 0">
               <div>
-                <h3 style="font-size:0.8rem;font-weight:700;text-transform:uppercase;letter-spacing:0.07em;color:var(--mid);margin:0 0 0.6rem;">LLM Providers</h3>
+                <div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:0.6rem;">
+                  <h3 style="font-size:0.8rem;font-weight:700;text-transform:uppercase;letter-spacing:0.07em;color:var(--mid);margin:0;">LLM Providers</h3>
+                  <div style="display:flex;align-items:center;gap:0.5rem;">
+                    <span style="font-size:0.78rem;color:var(--mid);"
+                          x-text="pricingCacheLabel"></span>
+                    <button class="btn-secondary" style="padding:3px 10px;font-size:0.78rem;"
+                            :disabled="pricingRefreshing"
+                            @click="refreshPricing()">
+                      <span x-show="!pricingRefreshing">Refresh Pricing</span>
+                      <span x-show="pricingRefreshing">Refreshing…</span>
+                    </button>
+                  </div>
+                </div>
                 <div style="display:flex;flex-direction:column;gap:0.75rem;">
                   <template x-for="k in llmKeys()" :key="k.provider">
                     <div class="card" style="padding:1rem 1.25rem;">
@@ -1822,13 +1834,18 @@ Do not wrap the JSON in markdown fences.`;
     function providersList() {
       return {
         keys: [], providerInfoList: [], loading: false, error: null, inputs: {}, displayNames: {}, baseUrls: {}, saved: {}, saveErrors: {},
+        pricingRefreshing: false, pricingCacheLabel: '',
 
         async load() {
           this.loading = true; this.error = null;
           try {
-            const [keysResp, infoResp] = await Promise.all([fetch('/keys'), fetch('/providers')]);
+            const [keysResp, infoResp, pricingResp] = await Promise.all([fetch('/keys'), fetch('/providers'), fetch('/providers/pricing')]);
             if (!keysResp.ok) throw new Error(await keysResp.text());
             this.keys = await keysResp.json();
+            if (pricingResp.ok) {
+              const pc = await pricingResp.json();
+              this.pricingCacheLabel = pc ? `Updated ${pc.age_days}d ago` : 'Using bundled defaults';
+            }
             if (infoResp.ok) this.providerInfoList = await infoResp.json();
             this.keys.forEach(k => {
               if (this.inputs[k.provider] === undefined) this.inputs[k.provider] = '';
@@ -1846,6 +1863,20 @@ Do not wrap the JSON in markdown fences.`;
 
         llmKeys() {
           return this.keys.filter(k => this.getProviderType(k.provider) === 'llm');
+        },
+
+        async refreshPricing() {
+          this.pricingRefreshing = true;
+          try {
+            const resp = await fetch('/providers/pricing/refresh', { method: 'POST' });
+            if (!resp.ok) throw new Error(await resp.text());
+            const data = await resp.json();
+            this.pricingCacheLabel = `Updated just now (${data.models_updated} models)`;
+          } catch(e) {
+            this.pricingCacheLabel = 'Refresh failed';
+          } finally {
+            this.pricingRefreshing = false;
+          }
         },
 
         toolKeys() {


### PR DESCRIPTION
Closes #219

## Summary
- Adds `GET /providers/pricing` — returns cache info: {models, updated_at, age_days} or null
- Adds `POST /providers/pricing/refresh` — fetches latest LLM pricing from LiteLLM, returns {models_updated, updated_at}
- Adds "Refresh Pricing" button in Providers section near "LLM Providers" header
- Shows cache age: "Updated 3d ago" or "Using bundled defaults"
- Button disabled during refresh; success/error feedback displayed

## Tests
- All 69 pytest tests pass
- No debug statements introduced