### PR TITLE
feat: Add missing test coverage for source deletion, manual submit flow, and mixed-fighter report

### DIFF
--- a/tests/test_e2e_complete_run.py
+++ b/tests/test_e2e_complete_run.py
@@ -1,0 +1,109 @@
+"""E2E test: upload source -> create run with manual fighter -> submit -> check status."""
+import io
+import uuid
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from t01_llm_battle.db import get_db
+
+
+async def _create_battle_and_fighter(db_path: str) -> tuple[str, str, str]:
+    """Seed battle + source + manual fighter. Returns (battle_id, source_id, fighter_id)."""
+    battle_id = str(uuid.uuid4())
+    source_id = str(uuid.uuid4())
+    fighter_id = str(uuid.uuid4())
+    now = datetime.now(timezone.utc).isoformat()
+
+    async with get_db(db_path) as db:
+        await db.execute(
+            "INSERT INTO battle (id, name, judge_provider, judge_model, judge_rubric, created_at) "
+            "VALUES (?, ?, ?, ?, ?, ?)",
+            (battle_id, "E2E Battle", "openai", "gpt-4o", "Be helpful.", now),
+        )
+        await db.execute(
+            "INSERT INTO battle_source (id, battle_id, label, content, position) VALUES (?, ?, ?, ?, ?)",
+            (source_id, battle_id, "Q1", "What is AI?", 1),
+        )
+        await db.execute(
+            "INSERT INTO fighter (id, battle_id, name, is_manual, position, created_at) "
+            "VALUES (?, ?, ?, ?, ?, ?)",
+            (fighter_id, battle_id, "HumanExpert", 1, 1, now),
+        )
+        await db.commit()
+
+    return battle_id, source_id, fighter_id
+
+
+@pytest.mark.asyncio
+async def test_e2e_complete_flow_source_to_results(client, db_path):
+    """E2E: upload source -> create run -> submit manual response -> check results."""
+    # Setup: create battle and manual fighter
+    battle_id, source_id, fighter_id = await _create_battle_and_fighter(db_path)
+
+    # 1. Create run
+    with patch("t01_llm_battle.engine.start_run_background"):
+        run_resp = await client.post(
+            "/runs",
+            json={"battle_id": battle_id},
+        )
+    assert run_resp.status_code == 200
+    run_id = run_resp.json()["run_id"]
+
+    # 2. Manually insert fighter_result (since background execution is patched)
+    fr_id = str(uuid.uuid4())
+    now = datetime.now(timezone.utc).isoformat()
+    async with get_db(db_path) as db:
+        await db.execute(
+            "INSERT INTO fighter_result "
+            "(id, run_id, fighter_id, source_id, status, created_at) "
+            "VALUES (?, ?, ?, ?, ?, ?)",
+            (fr_id, run_id, fighter_id, source_id, "awaiting_input", now),
+        )
+        await db.commit()
+
+    # 3. Check run status — should show awaiting_input for manual fighter
+    status_resp = await client.get(f"/runs/{run_id}/status")
+    assert status_resp.status_code == 200
+    status_data = status_resp.json()
+    assert status_data["status"] in ("pending", "running")
+    fighter_results = status_data["fighter_results"]
+    assert len(fighter_results) == 1
+    assert fighter_results[0]["status"] == "awaiting_input"
+
+    # 4. Submit manual answer (triggers scoring + report generation)
+    with patch("t01_llm_battle.routers.runs.score_response", new_callable=AsyncMock) as mock_score, \
+         patch("t01_llm_battle.routers.runs.generate_report", new_callable=AsyncMock) as mock_report:
+        mock_score.return_value = (9.5, "Excellent explanation.")
+        mock_report.return_value = None
+        submit_resp = await client.post(
+            f"/runs/{run_id}/steps/{fr_id}/submit",
+            json={"content": "AI is artificial intelligence — systems designed to perform tasks autonomously."},
+        )
+
+    assert submit_resp.status_code == 200
+    assert submit_resp.json()["status"] == "complete"
+
+    # 5. Verify DB: fighter_result now complete with score
+    async with get_db(db_path) as db:
+        cursor = await db.execute(
+            "SELECT status, judge_score, judge_reasoning, final_output FROM fighter_result WHERE id = ?",
+            (fr_id,),
+        )
+        row = await cursor.fetchone()
+
+    assert row["status"] == "complete"
+    assert row["judge_score"] == 9.5
+    assert row["judge_reasoning"] == "Excellent explanation."
+    assert row["final_output"] == "AI is artificial intelligence — systems designed to perform tasks autonomously."
+
+    # 6. Get final results via /results endpoint
+    results_resp = await client.get(f"/runs/{run_id}/results")
+    assert results_resp.status_code == 200
+    results_data = results_resp.json()
+    assert results_data["run_id"] == run_id
+    assert results_data["status"] == "complete"
+    summary = results_data["summary"]
+    assert len(summary) == 1
+    assert summary[0]["fighter_id"] == fighter_id
+    assert summary[0]["score"] == 9.5

--- a/tests/test_judge_generate_report.py
+++ b/tests/test_judge_generate_report.py
@@ -168,6 +168,84 @@ async def test_generate_report_provider_raises(tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_generate_report_mixed_manual_automated_fighters(tmp_path):
+    """generate_report works correctly when mix of manual (cost=0) and automated fighters."""
+    db_path = str(tmp_path / "test.db")
+    await init_db(db_path)
+
+    import uuid
+    from datetime import datetime, timezone
+
+    now = datetime.now(timezone.utc).isoformat()
+    battle_id = str(uuid.uuid4())
+    run_id = str(uuid.uuid4())
+    source_id = str(uuid.uuid4())
+
+    async with get_db(db_path) as db:
+        await db.execute(
+            "INSERT INTO battle (id, name, judge_provider, judge_model, judge_rubric, created_at) "
+            "VALUES (?, ?, ?, ?, ?, ?)",
+            (battle_id, "Mixed Battle", "openai", "gpt-4o", "Quality.", now),
+        )
+        await db.execute(
+            "INSERT INTO battle_source (id, battle_id, label, content, position) VALUES (?, ?, ?, ?, ?)",
+            (source_id, battle_id, "q1", "Explain AI.", 1),
+        )
+        await db.execute(
+            "INSERT INTO run (id, battle_id, status, started_at) VALUES (?, ?, ?, ?)",
+            (run_id, battle_id, "complete", now),
+        )
+        # Manual fighter (is_manual=1, cost=0)
+        manual_id = str(uuid.uuid4())
+        await db.execute(
+            "INSERT INTO fighter (id, battle_id, name, is_manual, position, created_at) "
+            "VALUES (?, ?, ?, ?, ?, ?)",
+            (manual_id, battle_id, "Human Expert", 1, 1, now),
+        )
+        await db.execute(
+            "INSERT INTO fighter_result "
+            "(id, run_id, fighter_id, source_id, final_output, total_cost_usd, "
+            "total_latency_ms, status, judge_score, judge_reasoning, created_at) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            (str(uuid.uuid4()), run_id, manual_id, source_id,
+             "AI is artificial intelligence.", 0.0, 0, "complete", 9.0,
+             "Excellent. SCORE: 9.0", now),
+        )
+        # Automated fighter
+        auto_id = str(uuid.uuid4())
+        await db.execute(
+            "INSERT INTO fighter (id, battle_id, name, is_manual, position, created_at) "
+            "VALUES (?, ?, ?, ?, ?, ?)",
+            (auto_id, battle_id, "GPT-4o", 0, 2, now),
+        )
+        await db.execute(
+            "INSERT INTO fighter_result "
+            "(id, run_id, fighter_id, source_id, final_output, total_cost_usd, "
+            "total_latency_ms, status, judge_score, judge_reasoning, created_at) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            (str(uuid.uuid4()), run_id, auto_id, source_id,
+             "AI means machines that mimic human intelligence.", 0.005, 1200,
+             "complete", 7.5, "Good answer. SCORE: 7.5", now),
+        )
+        await db.commit()
+
+    mock_provider = AsyncMock()
+    mock_provider.run.return_value = _mock_result(
+        "## Rankings\n1. Human Expert\n2. GPT-4o"
+    )
+
+    with patch("t01_llm_battle.judge.get_provider", return_value=mock_provider):
+        report = await generate_report(run_id, "openai", "gpt-4o", db_path)
+
+    assert "Human Expert" in report
+    assert "GPT-4o" in report
+    mock_provider.run.assert_awaited_once()
+    prompt = mock_provider.run.call_args[0][0].user_prompt
+    assert "Human Expert" in prompt
+    assert "GPT-4o" in prompt
+
+
+@pytest.mark.asyncio
 async def test_generate_report_prompt_includes_fighter_names(tmp_path):
     """The prompt sent to the judge includes fighter names and scores."""
     db_path = str(tmp_path / "test.db")

--- a/tests/test_judge_mixed_fighters.py
+++ b/tests/test_judge_mixed_fighters.py
@@ -1,0 +1,123 @@
+"""Tests for generate_report with mixed manual + automated fighters."""
+import uuid
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from t01_llm_battle.db import init_db, get_db
+from t01_llm_battle.judge import generate_report
+from t01_llm_battle.providers.base import ProviderResult
+
+
+def _mock_result(content: str) -> ProviderResult:
+    return ProviderResult(
+        content=content,
+        input_tokens=50,
+        output_tokens=100,
+        credits_used=None,
+        cost_usd=0.002,
+        model="gpt-4o",
+        provider="openai",
+    )
+
+
+async def _seed_mixed(db_path: str) -> str:
+    """Seed a run with one manual fighter (judge_score via submit) and one automated fighter."""
+    battle_id = str(uuid.uuid4())
+    run_id = str(uuid.uuid4())
+    source_id = str(uuid.uuid4())
+    auto_fighter_id = str(uuid.uuid4())
+    manual_fighter_id = str(uuid.uuid4())
+    now = datetime.now(timezone.utc).isoformat()
+
+    async with get_db(db_path) as db:
+        await db.execute(
+            "INSERT INTO battle (id, name, judge_provider, judge_model, judge_rubric, created_at) "
+            "VALUES (?, ?, ?, ?, ?, ?)",
+            (battle_id, "Mixed Battle", "openai", "gpt-4o", "Be concise.", now),
+        )
+        await db.execute(
+            "INSERT INTO battle_source (id, battle_id, label, content, position) VALUES (?, ?, ?, ?, ?)",
+            (source_id, battle_id, "Q1", "Explain gravity.", 1),
+        )
+        await db.execute(
+            "INSERT INTO run (id, battle_id, status, started_at) VALUES (?, ?, ?, ?)",
+            (run_id, battle_id, "complete", now),
+        )
+        # Automated fighter — has a judge_score
+        await db.execute(
+            "INSERT INTO fighter (id, battle_id, name, is_manual, position, created_at) VALUES (?, ?, ?, ?, ?, ?)",
+            (auto_fighter_id, battle_id, "AutoBot", 0, 1, now),
+        )
+        await db.execute(
+            "INSERT INTO fighter_result "
+            "(id, run_id, fighter_id, source_id, final_output, total_cost_usd, "
+            "total_latency_ms, status, judge_score, judge_reasoning, created_at) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            (
+                str(uuid.uuid4()), run_id, auto_fighter_id, source_id,
+                "Gravity is a force.", 0.001, 400, "complete",
+                8.0, "Good. SCORE: 8.0", now,
+            ),
+        )
+        # Manual fighter — also has a judge_score (set via submit endpoint)
+        await db.execute(
+            "INSERT INTO fighter (id, battle_id, name, is_manual, position, created_at) VALUES (?, ?, ?, ?, ?, ?)",
+            (manual_fighter_id, battle_id, "HumanFighter", 1, 2, now),
+        )
+        await db.execute(
+            "INSERT INTO fighter_result "
+            "(id, run_id, fighter_id, source_id, final_output, total_cost_usd, "
+            "total_latency_ms, status, judge_score, judge_reasoning, created_at) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            (
+                str(uuid.uuid4()), run_id, manual_fighter_id, source_id,
+                "Gravity pulls objects.", 0, 0, "complete",
+                6.5, "Decent. SCORE: 6.5", now,
+            ),
+        )
+        await db.commit()
+
+    return run_id
+
+
+@pytest.mark.asyncio
+async def test_generate_report_mixed_fighters_calls_judge(tmp_path):
+    """generate_report works when results include both manual and automated fighters."""
+    db_path = str(tmp_path / "test.db")
+    await init_db(db_path)
+    run_id = await _seed_mixed(db_path)
+
+    mock_provider = AsyncMock()
+    mock_provider.run.return_value = _mock_result("## Rankings\n1. AutoBot\n2. HumanFighter")
+
+    with patch("t01_llm_battle.judge.get_provider", return_value=mock_provider):
+        report = await generate_report(run_id, "openai", "gpt-4o", db_path)
+
+    assert "## Rankings" in report
+    mock_provider.run.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_generate_report_mixed_fighters_prompt_includes_both(tmp_path):
+    """The judge prompt includes both manual and automated fighter names."""
+    db_path = str(tmp_path / "test.db")
+    await init_db(db_path)
+    run_id = await _seed_mixed(db_path)
+
+    mock_provider = AsyncMock()
+    captured = []
+
+    async def capture(req):
+        captured.append(req)
+        return _mock_result("## Rankings\n...")
+
+    mock_provider.run.side_effect = capture
+
+    with patch("t01_llm_battle.judge.get_provider", return_value=mock_provider):
+        await generate_report(run_id, "openai", "gpt-4o", db_path)
+
+    assert len(captured) == 1
+    prompt = captured[0].user_prompt
+    assert "AutoBot" in prompt
+    assert "HumanFighter" in prompt

--- a/tests/test_manual_submit_flow.py
+++ b/tests/test_manual_submit_flow.py
@@ -1,0 +1,153 @@
+"""Integration tests for manual fighter submit flow.
+
+Covers POST /runs/{run_id}/steps/{step_result_id}/submit:
+- successful submission updates status to complete
+- run marked complete when all results are done
+- 404 for unknown step_result_id
+- 400 when status is not awaiting_input
+"""
+import uuid
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from t01_llm_battle.db import get_db
+
+
+async def _seed_manual_run(db_path: str) -> tuple[str, str, str]:
+    """Seed battle + manual fighter + source + run + awaiting_input fighter_result.
+
+    Returns (run_id, fighter_result_id, battle_id).
+    """
+    battle_id = str(uuid.uuid4())
+    fighter_id = str(uuid.uuid4())
+    source_id = str(uuid.uuid4())
+    run_id = str(uuid.uuid4())
+    fr_id = str(uuid.uuid4())
+    now = datetime.now(timezone.utc).isoformat()
+
+    async with get_db(db_path) as db:
+        await db.execute(
+            "INSERT INTO battle (id, name, judge_provider, judge_model, judge_rubric, created_at) "
+            "VALUES (?, ?, ?, ?, ?, ?)",
+            (battle_id, "Manual Battle", "openai", "gpt-4o", "Be helpful.", now),
+        )
+        await db.execute(
+            "INSERT INTO fighter (id, battle_id, name, is_manual, position, created_at) "
+            "VALUES (?, ?, ?, ?, ?, ?)",
+            (fighter_id, battle_id, "Human", 1, 1, now),
+        )
+        await db.execute(
+            "INSERT INTO battle_source (id, battle_id, label, content, position) "
+            "VALUES (?, ?, ?, ?, ?)",
+            (source_id, battle_id, "Q1", "What is 2+2?", 1),
+        )
+        await db.execute(
+            "INSERT INTO run (id, battle_id, status, started_at) VALUES (?, ?, ?, ?)",
+            (run_id, battle_id, "running", now),
+        )
+        await db.execute(
+            "INSERT INTO fighter_result "
+            "(id, run_id, fighter_id, source_id, status, created_at) "
+            "VALUES (?, ?, ?, ?, ?, ?)",
+            (fr_id, run_id, fighter_id, source_id, "awaiting_input", now),
+        )
+        await db.commit()
+
+    return run_id, fr_id, battle_id
+
+
+@pytest.mark.asyncio
+async def test_submit_manual_step_returns_complete(client, db_path):
+    """Submitting a valid manual answer returns status=complete."""
+    run_id, fr_id, _ = await _seed_manual_run(db_path)
+
+    with patch("t01_llm_battle.routers.runs.score_response", new_callable=AsyncMock) as mock_score, \
+         patch("t01_llm_battle.routers.runs.generate_report", new_callable=AsyncMock):
+        mock_score.return_value = (9.0, "Great answer.")
+        resp = await client.post(
+            f"/runs/{run_id}/steps/{fr_id}/submit",
+            json={"content": "4"},
+        )
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["status"] == "complete"
+    assert data["step_result_id"] == fr_id
+
+
+@pytest.mark.asyncio
+async def test_submit_manual_step_updates_db(client, db_path):
+    """After submit, fighter_result.final_output and status are updated in DB."""
+    run_id, fr_id, _ = await _seed_manual_run(db_path)
+
+    with patch("t01_llm_battle.routers.runs.score_response", new_callable=AsyncMock) as mock_score, \
+         patch("t01_llm_battle.routers.runs.generate_report", new_callable=AsyncMock):
+        mock_score.return_value = (8.0, "Good.")
+        await client.post(
+            f"/runs/{run_id}/steps/{fr_id}/submit",
+            json={"content": "The answer is 4"},
+        )
+
+    async with get_db(db_path) as db:
+        cursor = await db.execute(
+            "SELECT status, final_output FROM fighter_result WHERE id = ?", (fr_id,)
+        )
+        row = await cursor.fetchone()
+
+    assert row["status"] == "complete"
+    assert row["final_output"] == "The answer is 4"
+
+
+@pytest.mark.asyncio
+async def test_submit_marks_run_complete_when_all_done(client, db_path):
+    """When the last awaiting_input result is submitted, the run status becomes complete."""
+    run_id, fr_id, _ = await _seed_manual_run(db_path)
+
+    with patch("t01_llm_battle.routers.runs.score_response", new_callable=AsyncMock) as mock_score, \
+         patch("t01_llm_battle.routers.runs.generate_report", new_callable=AsyncMock):
+        mock_score.return_value = (7.0, "OK.")
+        await client.post(
+            f"/runs/{run_id}/steps/{fr_id}/submit",
+            json={"content": "4"},
+        )
+
+    async with get_db(db_path) as db:
+        cursor = await db.execute("SELECT status FROM run WHERE id = ?", (run_id,))
+        row = await cursor.fetchone()
+
+    assert row["status"] == "complete"
+
+
+@pytest.mark.asyncio
+async def test_submit_unknown_step_result_returns_404(client, db_path):
+    """Submitting to a nonexistent step_result_id returns 404."""
+    run_id, _, _ = await _seed_manual_run(db_path)
+
+    resp = await client.post(
+        f"/runs/{run_id}/steps/{uuid.uuid4()}/submit",
+        json={"content": "answer"},
+    )
+    assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_submit_wrong_status_returns_400(client, db_path):
+    """Submitting to a step_result that is not awaiting_input returns 400."""
+    run_id, fr_id, _ = await _seed_manual_run(db_path)
+
+    # First submit moves it to complete
+    with patch("t01_llm_battle.routers.runs.score_response", new_callable=AsyncMock) as mock_score, \
+         patch("t01_llm_battle.routers.runs.generate_report", new_callable=AsyncMock):
+        mock_score.return_value = (5.0, "Meh.")
+        await client.post(
+            f"/runs/{run_id}/steps/{fr_id}/submit",
+            json={"content": "first"},
+        )
+
+    # Second submit should fail with 400
+    resp = await client.post(
+        f"/runs/{run_id}/steps/{fr_id}/submit",
+        json={"content": "second"},
+    )
+    assert resp.status_code == 400

--- a/tests/test_routers_sources.py
+++ b/tests/test_routers_sources.py
@@ -119,3 +119,47 @@ async def test_list_sources_returns_items(client, db_path):
     assert len(sources) == 2
     labels = {s["label"] for s in sources}
     assert labels == {"a.txt", "b.txt"}
+
+
+@pytest.mark.asyncio
+async def test_delete_source_removes_item(client, db_path):
+    """DELETE /battles/{battle_id}/sources/{source_id} removes the source."""
+    battle_id = await _create_battle(db_path)
+
+    upload_resp = await client.post(
+        f"/battles/{battle_id}/sources",
+        files={"file": ("del.txt", io.BytesIO(b"to delete"), "text/plain")},
+    )
+    assert upload_resp.status_code == 201
+    source_id = upload_resp.json()["sources"][0]["id"]
+
+    del_resp = await client.delete(f"/battles/{battle_id}/sources/{source_id}")
+    assert del_resp.status_code == 204
+
+    list_resp = await client.get(f"/battles/{battle_id}/sources")
+    assert list_resp.status_code == 200
+    assert list_resp.json()["sources"] == []
+
+
+@pytest.mark.asyncio
+async def test_delete_source_not_found_returns_404(client, db_path):
+    """DELETE with a nonexistent source_id returns 404."""
+    battle_id = await _create_battle(db_path)
+    resp = await client.delete(f"/battles/{battle_id}/sources/{uuid.uuid4()}")
+    assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_delete_source_wrong_battle_returns_404(client, db_path):
+    """DELETE a source from a different battle returns 404 (not found for that battle)."""
+    battle_a = await _create_battle(db_path)
+    battle_b = await _create_battle(db_path)
+
+    upload_resp = await client.post(
+        f"/battles/{battle_a}/sources",
+        files={"file": ("x.txt", io.BytesIO(b"content"), "text/plain")},
+    )
+    source_id = upload_resp.json()["sources"][0]["id"]
+
+    resp = await client.delete(f"/battles/{battle_b}/sources/{source_id}")
+    assert resp.status_code == 404

--- a/tests/test_runs_router.py
+++ b/tests/test_runs_router.py
@@ -66,3 +66,155 @@ async def test_create_run_no_fighters(client, db_path):
     with patch("t01_llm_battle.engine.start_run_background"):
         resp = await client.post("/runs", json={"battle_id": battle_id})
     assert resp.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_manual_submit_completes_run(client, db_path):
+    """Manual submit marks fighter_result complete and, when sole result, marks run complete."""
+    now = datetime.now(timezone.utc).isoformat()
+    battle_id = str(uuid.uuid4())
+    run_id = str(uuid.uuid4())
+    fighter_id = str(uuid.uuid4())
+    source_id = str(uuid.uuid4())
+    fr_id = str(uuid.uuid4())
+
+    async with get_db(db_path) as db:
+        await db.execute(
+            "INSERT INTO battle (id, name, judge_provider, judge_model, judge_rubric, created_at) "
+            "VALUES (?, ?, ?, ?, ?, ?)",
+            (battle_id, "Manual Battle", "", "", "", now),
+        )
+        await db.execute(
+            "INSERT INTO battle_source (id, battle_id, label, content, position) VALUES (?, ?, ?, ?, ?)",
+            (source_id, battle_id, "q1", "What is 2+2?", 1),
+        )
+        await db.execute(
+            "INSERT INTO fighter (id, battle_id, name, is_manual, position, created_at) "
+            "VALUES (?, ?, ?, ?, ?, ?)",
+            (fighter_id, battle_id, "Human", 1, 1, now),
+        )
+        await db.execute(
+            "INSERT INTO run (id, battle_id, status, started_at) VALUES (?, ?, ?, ?)",
+            (run_id, battle_id, "running", now),
+        )
+        await db.execute(
+            "INSERT INTO fighter_result "
+            "(id, run_id, fighter_id, source_id, status, created_at) "
+            "VALUES (?, ?, ?, ?, ?, ?)",
+            (fr_id, run_id, fighter_id, source_id, "awaiting_input", now),
+        )
+        await db.commit()
+
+    with patch("t01_llm_battle.routers.runs.score_response", return_value=(None, None)), \
+         patch("t01_llm_battle.routers.runs.generate_report", return_value="report"):
+        resp = await client.post(
+            f"/runs/{run_id}/steps/{fr_id}/submit",
+            json={"content": "The answer is 4."},
+        )
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["step_result_id"] == fr_id
+    assert data["status"] == "complete"
+
+    async with get_db(db_path) as db:
+        cursor = await db.execute("SELECT status FROM fighter_result WHERE id = ?", (fr_id,))
+        row = await cursor.fetchone()
+        assert row["status"] == "complete"
+
+        cursor = await db.execute("SELECT status FROM run WHERE id = ?", (run_id,))
+        run_row = await cursor.fetchone()
+        assert run_row["status"] == "complete"
+
+
+@pytest.mark.asyncio
+async def test_manual_submit_wrong_run_returns_404(client, db_path):
+    """Submit with a run_id that doesn't match the fighter_result returns 404."""
+    now = datetime.now(timezone.utc).isoformat()
+    battle_id = str(uuid.uuid4())
+    run_id = str(uuid.uuid4())
+    other_run_id = str(uuid.uuid4())
+    fighter_id = str(uuid.uuid4())
+    source_id = str(uuid.uuid4())
+    fr_id = str(uuid.uuid4())
+
+    async with get_db(db_path) as db:
+        await db.execute(
+            "INSERT INTO battle (id, name, judge_provider, judge_model, judge_rubric, created_at) "
+            "VALUES (?, ?, ?, ?, ?, ?)",
+            (battle_id, "B", "", "", "", now),
+        )
+        await db.execute(
+            "INSERT INTO battle_source (id, battle_id, label, content, position) VALUES (?, ?, ?, ?, ?)",
+            (source_id, battle_id, "s", "q", 1),
+        )
+        await db.execute(
+            "INSERT INTO fighter (id, battle_id, name, is_manual, position, created_at) "
+            "VALUES (?, ?, ?, ?, ?, ?)",
+            (fighter_id, battle_id, "H", 1, 1, now),
+        )
+        await db.execute(
+            "INSERT INTO run (id, battle_id, status, started_at) VALUES (?, ?, ?, ?)",
+            (run_id, battle_id, "running", now),
+        )
+        await db.execute(
+            "INSERT INTO run (id, battle_id, status, started_at) VALUES (?, ?, ?, ?)",
+            (other_run_id, battle_id, "running", now),
+        )
+        await db.execute(
+            "INSERT INTO fighter_result "
+            "(id, run_id, fighter_id, source_id, status, created_at) "
+            "VALUES (?, ?, ?, ?, ?, ?)",
+            (fr_id, run_id, fighter_id, source_id, "awaiting_input", now),
+        )
+        await db.commit()
+
+    resp = await client.post(
+        f"/runs/{other_run_id}/steps/{fr_id}/submit",
+        json={"content": "answer"},
+    )
+    assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_manual_submit_non_awaiting_input_returns_400(client, db_path):
+    """Submit to a fighter_result not in awaiting_input status returns 400."""
+    now = datetime.now(timezone.utc).isoformat()
+    battle_id = str(uuid.uuid4())
+    run_id = str(uuid.uuid4())
+    fighter_id = str(uuid.uuid4())
+    source_id = str(uuid.uuid4())
+    fr_id = str(uuid.uuid4())
+
+    async with get_db(db_path) as db:
+        await db.execute(
+            "INSERT INTO battle (id, name, judge_provider, judge_model, judge_rubric, created_at) "
+            "VALUES (?, ?, ?, ?, ?, ?)",
+            (battle_id, "B2", "", "", "", now),
+        )
+        await db.execute(
+            "INSERT INTO battle_source (id, battle_id, label, content, position) VALUES (?, ?, ?, ?, ?)",
+            (source_id, battle_id, "s", "q", 1),
+        )
+        await db.execute(
+            "INSERT INTO fighter (id, battle_id, name, is_manual, position, created_at) "
+            "VALUES (?, ?, ?, ?, ?, ?)",
+            (fighter_id, battle_id, "H", 1, 1, now),
+        )
+        await db.execute(
+            "INSERT INTO run (id, battle_id, status, started_at) VALUES (?, ?, ?, ?)",
+            (run_id, battle_id, "running", now),
+        )
+        await db.execute(
+            "INSERT INTO fighter_result "
+            "(id, run_id, fighter_id, source_id, status, created_at) "
+            "VALUES (?, ?, ?, ?, ?, ?)",
+            (fr_id, run_id, fighter_id, source_id, "complete", now),
+        )
+        await db.commit()
+
+    resp = await client.post(
+        f"/runs/{run_id}/steps/{fr_id}/submit",
+        json={"content": "too late"},
+    )
+    assert resp.status_code == 400

--- a/tests/test_source_delete.py
+++ b/tests/test_source_delete.py
@@ -1,0 +1,78 @@
+"""Tests for DELETE /battles/{battle_id}/sources/{source_id}."""
+import io
+import uuid
+from datetime import datetime, timezone
+
+import pytest
+from t01_llm_battle.db import get_db
+
+
+async def _create_battle(db_path: str) -> str:
+    battle_id = str(uuid.uuid4())
+    now = datetime.now(timezone.utc).isoformat()
+    async with get_db(db_path) as db:
+        await db.execute(
+            "INSERT INTO battle (id, name, judge_provider, judge_model, judge_rubric, created_at) "
+            "VALUES (?, ?, ?, ?, ?, ?)",
+            (battle_id, "Delete Battle", "openai", "gpt-4o", "", now),
+        )
+        await db.commit()
+    return battle_id
+
+
+@pytest.mark.asyncio
+async def test_delete_source_returns_204(client, db_path):
+    """Delete an existing source returns 204."""
+    battle_id = await _create_battle(db_path)
+
+    upload = await client.post(
+        f"/battles/{battle_id}/sources",
+        files={"file": ("x.txt", io.BytesIO(b"hello"), "text/plain")},
+    )
+    assert upload.status_code == 201
+    source_id = upload.json()["sources"][0]["id"]
+
+    resp = await client.delete(f"/battles/{battle_id}/sources/{source_id}")
+    assert resp.status_code == 204
+
+
+@pytest.mark.asyncio
+async def test_delete_source_removes_from_db(client, db_path):
+    """After deletion, listing sources no longer returns the deleted item."""
+    battle_id = await _create_battle(db_path)
+
+    upload = await client.post(
+        f"/battles/{battle_id}/sources",
+        files={"file": ("y.txt", io.BytesIO(b"bye"), "text/plain")},
+    )
+    source_id = upload.json()["sources"][0]["id"]
+
+    await client.delete(f"/battles/{battle_id}/sources/{source_id}")
+
+    list_resp = await client.get(f"/battles/{battle_id}/sources")
+    ids = [s["id"] for s in list_resp.json()["sources"]]
+    assert source_id not in ids
+
+
+@pytest.mark.asyncio
+async def test_delete_nonexistent_source_returns_404(client, db_path):
+    """Deleting a source that doesn't exist returns 404."""
+    battle_id = await _create_battle(db_path)
+    resp = await client.delete(f"/battles/{battle_id}/sources/{uuid.uuid4()}")
+    assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_delete_source_wrong_battle_returns_404(client, db_path):
+    """Deleting a source that belongs to a different battle returns 404."""
+    battle_a = await _create_battle(db_path)
+    battle_b = await _create_battle(db_path)
+
+    upload = await client.post(
+        f"/battles/{battle_a}/sources",
+        files={"file": ("a.txt", io.BytesIO(b"a"), "text/plain")},
+    )
+    source_id = upload.json()["sources"][0]["id"]
+
+    resp = await client.delete(f"/battles/{battle_b}/sources/{source_id}")
+    assert resp.status_code == 404


### PR DESCRIPTION
Closes #234

## Changes

1. **test_source_delete.py** — DELETE endpoint tests
   - Successfully deletes source and removes from database
   - Returns 404 for nonexistent sources
   - Returns 404 for cross-battle deletion attempts

2. **test_manual_submit_flow.py** — POST /runs/{run_id}/steps/{step_result_id}/submit tests
   - Submits manual response and updates fighter_result status
   - Marks run as complete when all results are done
   - Handles 404 and 400 status errors correctly

3. **test_judge_mixed_fighters.py** — generate_report with mixed fighter types
   - Works with both manual and automated fighters scored
   - Judge prompt includes all fighter names regardless of type

4. **test_e2e_complete_run.py** — Full run cycle
   - Create run → insert awaiting_input result → submit → check status → verify results

All 107 tests pass locally.