### PR TITLE
fix: include judge_reasoning in results API response

### DIFF
--- a/t01_llm_battle/routers/runs.py
+++ b/t01_llm_battle/routers/runs.py
@@ -332,6 +332,7 @@ async def get_run_results(run_id: str):
                 fr.total_input_tokens,
                 fr.total_output_tokens,
                 fr.judge_score,
+                fr.judge_reasoning,
                 fr.status,
                 f.name           AS fighter_name,
                 bs.label         AS source_label
@@ -405,6 +406,7 @@ async def get_run_results(run_id: str):
                 "source_id": fr["source_id"],
                 "source_label": fr["source_label"],
                 "score": fr["judge_score"],
+                "reasoning": fr["judge_reasoning"],
                 "total_cost_usd": agg["agg_cost_usd"] if agg else fr["total_cost_usd"],
                 "total_latency_ms": agg["agg_latency_ms"] if agg else fr["total_latency_ms"],
                 "total_input_tokens": agg["agg_input_tokens"] if agg else fr["total_input_tokens"],


### PR DESCRIPTION
Closes #232

Adds `judge_reasoning` to the SELECT and response dict in `GET /runs/{run_id}/results`, enabling the frontend to display judge reasoning in the results view.