### PR TITLE
fix: enable SQLite foreign key enforcement via PRAGMA foreign_keys = ON

### DIFF
--- a/t01_llm_battle/db.py
+++ b/t01_llm_battle/db.py
@@ -166,6 +166,7 @@ async def get_db(
     """Async context manager that yields an aiosqlite.Connection with row_factory set."""
     async with aiosqlite.connect(db_path) as db:
         await db.execute("PRAGMA journal_mode=WAL")
+        await db.execute("PRAGMA foreign_keys = ON")
         db.row_factory = aiosqlite.Row
         yield db
 


### PR DESCRIPTION
Closes #231

Adds `PRAGMA foreign_keys = ON` to `get_db()` so all runtime queries enforce referential integrity. The `init_db` path intentionally omits it to avoid breaking the legacy migration that renames/drops `battle_old`.