### PR TITLE
fix: eliminate race condition in API key injection for concurrent provider calls

### DIFF
--- a/t01_llm_battle/engine.py
+++ b/t01_llm_battle/engine.py
@@ -9,31 +9,19 @@ import time
 import uuid
 from datetime import datetime, timezone
 
-from .db import DB_PATH, get_db, resolve_api_key, _PROVIDER_ENV_VARS
+from .db import DB_PATH, get_db, resolve_api_key
 from .judge import score_response, generate_report
 from .providers.base import ProviderRequest, ProviderResult
 from .providers.registry import get_provider
 from . import rate_limiter
 
 
-async def _inject_api_key(provider_name: str, db_path) -> str | None:
-    """If the env var for provider is not set, look up DB and set it temporarily.
+async def _resolve_api_key(provider_name: str, db_path) -> str | None:
+    """Return the API key for a provider without mutating os.environ.
 
-    Returns the env var name that was set (so the caller can restore it), or None.
+    Resolves from env var first, then DB.  Safe for concurrent coroutines.
     """
-    import os
-
-    env_var = _PROVIDER_ENV_VARS.get(provider_name)
-    if not env_var:
-        return None
-    if os.environ.get(env_var):
-        return None  # env already set; nothing to do
-
-    key = await resolve_api_key(provider_name, db_path)
-    if key:
-        os.environ[env_var] = key
-        return env_var
-    return None
+    return await resolve_api_key(provider_name, db_path)
 
 
 async def _execute_pair(
@@ -47,8 +35,6 @@ async def _execute_pair(
     db_path,
 ) -> bool:
     """Execute one fighter x source pair. Returns True if successful (not errored)."""
-    import os
-
     fighter_id = fighter["id"]
     is_manual = fighter["is_manual"]
     source_id = source["id"]
@@ -109,13 +95,13 @@ async def _execute_pair(
                 extra=extra,
             )
 
+            api_key = await _resolve_api_key(step["provider"], db_path)
+            if api_key:
+                request.api_key = api_key
             await rate_limiter.acquire(step["provider"])
-            injected_env_var = await _inject_api_key(step["provider"], db_path)
             t0 = time.monotonic()
             result: ProviderResult = await provider.run(request)
             latency_ms = int((time.monotonic() - t0) * 1000)
-            if injected_env_var:
-                os.environ.pop(injected_env_var, None)
 
             async with get_db(db_path) as db:
                 await db.execute(
@@ -183,16 +169,15 @@ async def _execute_pair(
 
     # Run judge scoring for completed results
     if not had_error and final_output and judge_provider and judge_model:
-        injected_judge_env_var = await _inject_api_key(judge_provider, db_path)
+        judge_api_key = await _resolve_api_key(judge_provider, db_path)
         judge_score, judge_reasoning = await score_response(
             judge_provider=judge_provider,
             judge_model=judge_model,
             judge_rubric=judge_rubric or "",
             source_content=source_content,
             response_content=final_output,
+            api_key=judge_api_key,
         )
-        if injected_judge_env_var:
-            os.environ.pop(injected_judge_env_var, None)
         async with get_db(db_path) as db:
             await db.execute(
                 "UPDATE fighter_result SET judge_score = ?, judge_reasoning = ? WHERE id = ?",
@@ -293,11 +278,8 @@ async def execute_run(run_id: str, db_path=DB_PATH) -> None:
 
     # Generate markdown report after all judging is complete
     if judge_provider and judge_model:
-        import os
-        injected_report_env_var = await _inject_api_key(judge_provider, db_path)
-        await generate_report(run_id, judge_provider, judge_model, db_path)
-        if injected_report_env_var:
-            os.environ.pop(injected_report_env_var, None)
+        report_api_key = await _resolve_api_key(judge_provider, db_path)
+        await generate_report(run_id, judge_provider, judge_model, db_path, api_key=report_api_key)
 
 
 def start_run_background(run_id: str, db_path=DB_PATH) -> None:

--- a/t01_llm_battle/judge.py
+++ b/t01_llm_battle/judge.py
@@ -30,6 +30,7 @@ async def score_response(
     judge_rubric: str,
     source_content: str,
     response_content: str,
+    api_key: str | None = None,
 ) -> tuple[float | None, str]:
     """
     Returns (score, explanation).
@@ -47,6 +48,7 @@ async def score_response(
                 model=judge_model,
                 system_prompt="You are an objective evaluator. Always end with 'SCORE: <0-10>'.",
                 user_prompt=prompt,
+                api_key=api_key,
             )
         )
         # Parse score from last line
@@ -66,6 +68,7 @@ async def generate_report(
     judge_provider: str,
     judge_model: str,
     db_path: str,
+    api_key: str | None = None,
 ) -> str:
     """Generate a markdown summary report for the run using the judge model.
 
@@ -160,6 +163,7 @@ async def generate_report(
                 model=judge_model,
                 system_prompt="You are an expert technical writer producing clear, insightful battle reports.",
                 user_prompt=report_prompt,
+                api_key=api_key,
             )
         )
         markdown = result.content

--- a/t01_llm_battle/providers/anthropic.py
+++ b/t01_llm_battle/providers/anthropic.py
@@ -17,7 +17,7 @@ class AnthropicProvider(BaseProvider):
         return get_llm_models(self.name)
 
     async def run(self, request: ProviderRequest) -> ProviderResult:
-        api_key = os.environ.get("ANTHROPIC_API_KEY", "")
+        api_key = request.api_key or os.environ.get("ANTHROPIC_API_KEY", "")
         if not api_key:
             raise ValueError("ANTHROPIC_API_KEY environment variable is not set")
 

--- a/t01_llm_battle/providers/base.py
+++ b/t01_llm_battle/providers/base.py
@@ -16,6 +16,7 @@ class ProviderRequest:
     temperature: float = 0.7
     max_tokens: int = 2048
     extra: dict = field(default_factory=dict)
+    api_key: str | None = None  # resolved key; avoids shared os.environ mutation
 
 
 @dataclass

--- a/t01_llm_battle/providers/firecrawl.py
+++ b/t01_llm_battle/providers/firecrawl.py
@@ -15,7 +15,7 @@ class FirecrawlProvider(BaseProvider):
         return get_tool_functions(self.name)
 
     async def run(self, request: ProviderRequest) -> ProviderResult:
-        api_key = os.environ.get("FIRECRAWL_API_KEY", "")
+        api_key = request.api_key or os.environ.get("FIRECRAWL_API_KEY", "")
         function = request.model  # "scrape" or "crawl"
         headers = {"Authorization": f"Bearer {api_key}", "Content-Type": "application/json"}
 

--- a/t01_llm_battle/providers/google.py
+++ b/t01_llm_battle/providers/google.py
@@ -19,7 +19,7 @@ class GoogleProvider(BaseProvider):
         return get_llm_models(self.name)
 
     async def run(self, request: ProviderRequest) -> ProviderResult:
-        api_key = os.environ.get("GOOGLE_API_KEY", "")
+        api_key = request.api_key or os.environ.get("GOOGLE_API_KEY", "")
         provider = GoogleGLAProvider(api_key=api_key)
         model = GeminiModel(request.model, provider=provider)
         agent = Agent(model, system_prompt=request.system_prompt or "")

--- a/t01_llm_battle/providers/groq.py
+++ b/t01_llm_battle/providers/groq.py
@@ -17,7 +17,7 @@ class GroqProvider(BaseProvider):
         return get_llm_models(self.name)
 
     async def run(self, request: ProviderRequest) -> ProviderResult:
-        api_key = os.environ.get("GROQ_API_KEY", "")
+        api_key = request.api_key or os.environ.get("GROQ_API_KEY", "")
         provider = PAIGroqProvider(api_key=api_key)
         model = GroqModel(request.model, provider=provider)
         agent = Agent(model, system_prompt=request.system_prompt or "")

--- a/t01_llm_battle/providers/openai.py
+++ b/t01_llm_battle/providers/openai.py
@@ -17,7 +17,7 @@ class OpenAIProvider(BaseProvider):
         return get_llm_models(self.name)
 
     async def run(self, request: ProviderRequest) -> ProviderResult:
-        api_key = os.environ.get("OPENAI_API_KEY", "")
+        api_key = request.api_key or os.environ.get("OPENAI_API_KEY", "")
         provider = PAIOpenAIProvider(api_key=api_key)
         model = OpenAIChatModel(request.model, provider=provider)
         agent = Agent(model, system_prompt=request.system_prompt or "")

--- a/t01_llm_battle/providers/openrouter.py
+++ b/t01_llm_battle/providers/openrouter.py
@@ -17,7 +17,7 @@ class OpenRouterProvider(BaseProvider):
         return get_llm_models(self.name)
 
     async def run(self, request: ProviderRequest) -> ProviderResult:
-        api_key = os.environ.get("OPENROUTER_API_KEY", "")
+        api_key = request.api_key or os.environ.get("OPENROUTER_API_KEY", "")
         provider = PAIOpenAIProvider(
             api_key=api_key,
             base_url="https://openrouter.ai/api/v1",

--- a/t01_llm_battle/providers/serper.py
+++ b/t01_llm_battle/providers/serper.py
@@ -21,7 +21,7 @@ class SerperProvider(BaseProvider):
         return get_tool_functions(self.name)
 
     async def run(self, request: ProviderRequest) -> ProviderResult:
-        api_key = os.environ.get("SERPER_API_KEY", "")
+        api_key = request.api_key or os.environ.get("SERPER_API_KEY", "")
         function = request.model  # "search" or "news"
         endpoint = _ENDPOINTS.get(function, _ENDPOINTS["search"])
 

--- a/t01_llm_battle/providers/tavily.py
+++ b/t01_llm_battle/providers/tavily.py
@@ -15,7 +15,7 @@ class TavilyProvider(BaseProvider):
         return get_tool_functions(self.name)
 
     async def run(self, request: ProviderRequest) -> ProviderResult:
-        api_key = os.environ.get("TAVILY_API_KEY", "")
+        api_key = request.api_key or os.environ.get("TAVILY_API_KEY", "")
 
         async with httpx.AsyncClient() as client:
             response = await client.post(

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -117,7 +117,7 @@ async def test_sequential_steps_output_chaining(tmp_path):
         patch("t01_llm_battle.engine.rate_limiter.acquire", new=AsyncMock()),
         patch("t01_llm_battle.engine.score_response", new=AsyncMock(return_value=(8.0, "good"))),
         patch("t01_llm_battle.engine.generate_report", new=AsyncMock(return_value="report")),
-        patch("t01_llm_battle.engine._inject_api_key", new=AsyncMock(return_value=None)),
+        patch("t01_llm_battle.engine._resolve_api_key", new=AsyncMock(return_value=None)),
     ):
         await execute_run(run_id, db_path)
 
@@ -153,7 +153,7 @@ async def test_step_error_stops_subsequent_steps(tmp_path):
         patch("t01_llm_battle.engine.rate_limiter.acquire", new=AsyncMock()),
         patch("t01_llm_battle.engine.score_response", new=AsyncMock(return_value=(None, "err"))),
         patch("t01_llm_battle.engine.generate_report", new=AsyncMock(return_value="report")),
-        patch("t01_llm_battle.engine._inject_api_key", new=AsyncMock(return_value=None)),
+        patch("t01_llm_battle.engine._resolve_api_key", new=AsyncMock(return_value=None)),
     ):
         await execute_run(run_id, db_path)
 
@@ -184,7 +184,7 @@ async def test_manual_fighter_awaiting_input(tmp_path):
         patch("t01_llm_battle.engine.rate_limiter.acquire", new=AsyncMock()),
         patch("t01_llm_battle.engine.score_response", new=AsyncMock(return_value=(None, ""))),
         patch("t01_llm_battle.engine.generate_report", new=AsyncMock(return_value="")),
-        patch("t01_llm_battle.engine._inject_api_key", new=AsyncMock(return_value=None)),
+        patch("t01_llm_battle.engine._resolve_api_key", new=AsyncMock(return_value=None)),
     ):
         await execute_run(run_id, db_path)
 


### PR DESCRIPTION
Closes #229

Replace os.environ mutation with per-request api_key field on ProviderRequest. Each concurrent coroutine receives its own resolved key without touching shared process state. All 8 providers updated to prefer request.api_key over os.environ fallback.

## Acceptance Criteria
- [x] No more os.environ mutations during provider calls
- [x] Concurrent provider calls safe from race conditions
- [x] All tests pass (107 passed)
- [x] Backward compatible (env var fallback still works)