### PR TITLE
fix: update bundled LLM pricing (301 models) + auto-refresh on first start

### DIFF
--- a/t01_llm_battle/llm_pricing.json
+++ b/t01_llm_battle/llm_pricing.json
@@ -1,31 +1,1216 @@
 {
   "openai": {
-    "gpt-4o": {"input_per_million": 2.50, "output_per_million": 10.00},
-    "gpt-4o-mini": {"input_per_million": 0.15, "output_per_million": 0.60},
-    "gpt-4-turbo": {"input_per_million": 10.00, "output_per_million": 30.00},
-    "gpt-3.5-turbo": {"input_per_million": 0.50, "output_per_million": 1.50}
+    "chatgpt-4o-latest": {
+      "input_per_million": 5.0,
+      "output_per_million": 15.0
+    },
+    "gpt-4o-transcribe-diarize": {
+      "input_per_million": 2.5,
+      "output_per_million": 10.0
+    },
+    "codex-mini-latest": {
+      "input_per_million": 1.5,
+      "output_per_million": 6.0
+    },
+    "ft:gpt-3.5-turbo": {
+      "input_per_million": 3.0,
+      "output_per_million": 6.0
+    },
+    "ft:gpt-3.5-turbo-0125": {
+      "input_per_million": 3.0,
+      "output_per_million": 6.0
+    },
+    "ft:gpt-3.5-turbo-0613": {
+      "input_per_million": 3.0,
+      "output_per_million": 6.0
+    },
+    "ft:gpt-3.5-turbo-1106": {
+      "input_per_million": 3.0,
+      "output_per_million": 6.0
+    },
+    "ft:gpt-4-0613": {
+      "input_per_million": 30.0,
+      "output_per_million": 60.0
+    },
+    "ft:gpt-4o-2024-08-06": {
+      "input_per_million": 3.75,
+      "output_per_million": 15.0
+    },
+    "ft:gpt-4o-2024-11-20": {
+      "input_per_million": 3.75,
+      "output_per_million": 15.0
+    },
+    "ft:gpt-4o-mini-2024-07-18": {
+      "input_per_million": 0.3,
+      "output_per_million": 1.2
+    },
+    "ft:gpt-4.1-2025-04-14": {
+      "input_per_million": 3.0,
+      "output_per_million": 12.0
+    },
+    "ft:gpt-4.1-mini-2025-04-14": {
+      "input_per_million": 0.8,
+      "output_per_million": 3.2
+    },
+    "ft:gpt-4.1-nano-2025-04-14": {
+      "input_per_million": 0.2,
+      "output_per_million": 0.8
+    },
+    "ft:o4-mini-2025-04-16": {
+      "input_per_million": 4.0,
+      "output_per_million": 16.0
+    },
+    "gpt-3.5-turbo": {
+      "input_per_million": 0.5,
+      "output_per_million": 1.5
+    },
+    "gpt-3.5-turbo-0125": {
+      "input_per_million": 0.5,
+      "output_per_million": 1.5
+    },
+    "gpt-3.5-turbo-1106": {
+      "input_per_million": 1.0,
+      "output_per_million": 2.0
+    },
+    "gpt-3.5-turbo-16k": {
+      "input_per_million": 3.0,
+      "output_per_million": 4.0
+    },
+    "gpt-4": {
+      "input_per_million": 30.0,
+      "output_per_million": 60.0
+    },
+    "gpt-4-0125-preview": {
+      "input_per_million": 10.0,
+      "output_per_million": 30.0
+    },
+    "gpt-4-0314": {
+      "input_per_million": 30.0,
+      "output_per_million": 60.0
+    },
+    "gpt-4-0613": {
+      "input_per_million": 30.0,
+      "output_per_million": 60.0
+    },
+    "gpt-4-1106-preview": {
+      "input_per_million": 10.0,
+      "output_per_million": 30.0
+    },
+    "gpt-4-turbo": {
+      "input_per_million": 10.0,
+      "output_per_million": 30.0
+    },
+    "gpt-4-turbo-2024-04-09": {
+      "input_per_million": 10.0,
+      "output_per_million": 30.0
+    },
+    "gpt-4-turbo-preview": {
+      "input_per_million": 10.0,
+      "output_per_million": 30.0
+    },
+    "gpt-4.1": {
+      "input_per_million": 2.0,
+      "output_per_million": 8.0
+    },
+    "gpt-4.1-2025-04-14": {
+      "input_per_million": 2.0,
+      "output_per_million": 8.0
+    },
+    "gpt-4.1-mini": {
+      "input_per_million": 0.4,
+      "output_per_million": 1.6
+    },
+    "gpt-4.1-mini-2025-04-14": {
+      "input_per_million": 0.4,
+      "output_per_million": 1.6
+    },
+    "gpt-4.1-nano": {
+      "input_per_million": 0.1,
+      "output_per_million": 0.4
+    },
+    "gpt-4.1-nano-2025-04-14": {
+      "input_per_million": 0.1,
+      "output_per_million": 0.4
+    },
+    "gpt-4o": {
+      "input_per_million": 2.5,
+      "output_per_million": 10.0
+    },
+    "gpt-4o-2024-05-13": {
+      "input_per_million": 5.0,
+      "output_per_million": 15.0
+    },
+    "gpt-4o-2024-08-06": {
+      "input_per_million": 2.5,
+      "output_per_million": 10.0
+    },
+    "gpt-4o-2024-11-20": {
+      "input_per_million": 2.5,
+      "output_per_million": 10.0
+    },
+    "gpt-4o-audio-preview": {
+      "input_per_million": 2.5,
+      "output_per_million": 10.0
+    },
+    "gpt-4o-audio-preview-2024-12-17": {
+      "input_per_million": 2.5,
+      "output_per_million": 10.0
+    },
+    "gpt-4o-audio-preview-2025-06-03": {
+      "input_per_million": 2.5,
+      "output_per_million": 10.0
+    },
+    "gpt-audio": {
+      "input_per_million": 2.5,
+      "output_per_million": 10.0
+    },
+    "gpt-audio-1.5": {
+      "input_per_million": 2.5,
+      "output_per_million": 10.0
+    },
+    "gpt-audio-2025-08-28": {
+      "input_per_million": 2.5,
+      "output_per_million": 10.0
+    },
+    "gpt-audio-mini": {
+      "input_per_million": 0.6,
+      "output_per_million": 2.4
+    },
+    "gpt-audio-mini-2025-10-06": {
+      "input_per_million": 0.6,
+      "output_per_million": 2.4
+    },
+    "gpt-audio-mini-2025-12-15": {
+      "input_per_million": 0.6,
+      "output_per_million": 2.4
+    },
+    "gpt-4o-mini": {
+      "input_per_million": 0.15,
+      "output_per_million": 0.6
+    },
+    "gpt-4o-mini-2024-07-18": {
+      "input_per_million": 0.15,
+      "output_per_million": 0.6
+    },
+    "gpt-4o-mini-audio-preview": {
+      "input_per_million": 0.15,
+      "output_per_million": 0.6
+    },
+    "gpt-4o-mini-audio-preview-2024-12-17": {
+      "input_per_million": 0.15,
+      "output_per_million": 0.6
+    },
+    "gpt-4o-mini-realtime-preview": {
+      "input_per_million": 0.6,
+      "output_per_million": 2.4
+    },
+    "gpt-4o-mini-realtime-preview-2024-12-17": {
+      "input_per_million": 0.6,
+      "output_per_million": 2.4
+    },
+    "gpt-4o-mini-search-preview": {
+      "input_per_million": 0.15,
+      "output_per_million": 0.6
+    },
+    "gpt-4o-mini-search-preview-2025-03-11": {
+      "input_per_million": 0.15,
+      "output_per_million": 0.6
+    },
+    "gpt-4o-mini-transcribe": {
+      "input_per_million": 1.25,
+      "output_per_million": 5.0
+    },
+    "gpt-4o-mini-tts": {
+      "input_per_million": 2.5,
+      "output_per_million": 10.0
+    },
+    "gpt-4o-realtime-preview": {
+      "input_per_million": 5.0,
+      "output_per_million": 20.0
+    },
+    "gpt-4o-realtime-preview-2024-12-17": {
+      "input_per_million": 5.0,
+      "output_per_million": 20.0
+    },
+    "gpt-4o-realtime-preview-2025-06-03": {
+      "input_per_million": 5.0,
+      "output_per_million": 20.0
+    },
+    "gpt-4o-search-preview": {
+      "input_per_million": 2.5,
+      "output_per_million": 10.0
+    },
+    "gpt-4o-search-preview-2025-03-11": {
+      "input_per_million": 2.5,
+      "output_per_million": 10.0
+    },
+    "gpt-4o-transcribe": {
+      "input_per_million": 2.5,
+      "output_per_million": 10.0
+    },
+    "gpt-image-1.5": {
+      "input_per_million": 5.0,
+      "output_per_million": 10.0
+    },
+    "gpt-image-1.5-2025-12-16": {
+      "input_per_million": 5.0,
+      "output_per_million": 10.0
+    },
+    "gpt-5": {
+      "input_per_million": 1.25,
+      "output_per_million": 10.0
+    },
+    "gpt-5.1": {
+      "input_per_million": 1.25,
+      "output_per_million": 10.0
+    },
+    "gpt-5.1-2025-11-13": {
+      "input_per_million": 1.25,
+      "output_per_million": 10.0
+    },
+    "gpt-5.1-chat-latest": {
+      "input_per_million": 1.25,
+      "output_per_million": 10.0
+    },
+    "gpt-5.2": {
+      "input_per_million": 1.75,
+      "output_per_million": 14.0
+    },
+    "gpt-5.2-2025-12-11": {
+      "input_per_million": 1.75,
+      "output_per_million": 14.0
+    },
+    "gpt-5.2-chat-latest": {
+      "input_per_million": 1.75,
+      "output_per_million": 14.0
+    },
+    "gpt-5.3-chat-latest": {
+      "input_per_million": 1.75,
+      "output_per_million": 14.0
+    },
+    "gpt-5.2-pro": {
+      "input_per_million": 21.0,
+      "output_per_million": 168.0
+    },
+    "gpt-5.2-pro-2025-12-11": {
+      "input_per_million": 21.0,
+      "output_per_million": 168.0
+    },
+    "gpt-5.5": {
+      "input_per_million": 5.0,
+      "output_per_million": 30.0
+    },
+    "gpt-5.5-2026-04-23": {
+      "input_per_million": 5.0,
+      "output_per_million": 30.0
+    },
+    "gpt-5.5-pro": {
+      "input_per_million": 60.0,
+      "output_per_million": 360.0
+    },
+    "gpt-5.5-pro-2026-04-23": {
+      "input_per_million": 60.0,
+      "output_per_million": 360.0
+    },
+    "gpt-5.4": {
+      "input_per_million": 2.5,
+      "output_per_million": 15.0
+    },
+    "gpt-5.4-2026-03-05": {
+      "input_per_million": 2.5,
+      "output_per_million": 15.0
+    },
+    "gpt-5.4-pro": {
+      "input_per_million": 30.0,
+      "output_per_million": 180.0
+    },
+    "gpt-5.4-pro-2026-03-05": {
+      "input_per_million": 30.0,
+      "output_per_million": 180.0
+    },
+    "gpt-5.4-mini": {
+      "input_per_million": 0.75,
+      "output_per_million": 4.5
+    },
+    "gpt-5.4-nano": {
+      "input_per_million": 0.2,
+      "output_per_million": 1.25
+    },
+    "gpt-5-pro": {
+      "input_per_million": 15.0,
+      "output_per_million": 120.0
+    },
+    "gpt-5-pro-2025-10-06": {
+      "input_per_million": 15.0,
+      "output_per_million": 120.0
+    },
+    "gpt-5-2025-08-07": {
+      "input_per_million": 1.25,
+      "output_per_million": 10.0
+    },
+    "gpt-5-chat": {
+      "input_per_million": 1.25,
+      "output_per_million": 10.0
+    },
+    "gpt-5-chat-latest": {
+      "input_per_million": 1.25,
+      "output_per_million": 10.0
+    },
+    "gpt-5-codex": {
+      "input_per_million": 1.25,
+      "output_per_million": 10.0
+    },
+    "gpt-5.1-codex": {
+      "input_per_million": 1.25,
+      "output_per_million": 10.0
+    },
+    "gpt-5.1-codex-max": {
+      "input_per_million": 1.25,
+      "output_per_million": 10.0
+    },
+    "gpt-5.1-codex-mini": {
+      "input_per_million": 0.25,
+      "output_per_million": 2.0
+    },
+    "gpt-5.2-codex": {
+      "input_per_million": 1.75,
+      "output_per_million": 14.0
+    },
+    "gpt-5.3-codex": {
+      "input_per_million": 1.75,
+      "output_per_million": 14.0
+    },
+    "gpt-5-mini": {
+      "input_per_million": 0.25,
+      "output_per_million": 2.0
+    },
+    "gpt-5-mini-2025-08-07": {
+      "input_per_million": 0.25,
+      "output_per_million": 2.0
+    },
+    "gpt-5-nano": {
+      "input_per_million": 0.05,
+      "output_per_million": 0.4
+    },
+    "gpt-5-nano-2025-08-07": {
+      "input_per_million": 0.05,
+      "output_per_million": 0.4
+    },
+    "gpt-realtime": {
+      "input_per_million": 4.0,
+      "output_per_million": 16.0
+    },
+    "gpt-realtime-1.5": {
+      "input_per_million": 4.0,
+      "output_per_million": 16.0
+    },
+    "gpt-realtime-mini": {
+      "input_per_million": 0.6,
+      "output_per_million": 2.4
+    },
+    "gpt-realtime-2025-08-28": {
+      "input_per_million": 4.0,
+      "output_per_million": 16.0
+    },
+    "o1": {
+      "input_per_million": 15.0,
+      "output_per_million": 60.0
+    },
+    "o1-2024-12-17": {
+      "input_per_million": 15.0,
+      "output_per_million": 60.0
+    },
+    "o1-pro": {
+      "input_per_million": 150.0,
+      "output_per_million": 600.0
+    },
+    "o1-pro-2025-03-19": {
+      "input_per_million": 150.0,
+      "output_per_million": 600.0
+    },
+    "o3": {
+      "input_per_million": 2.0,
+      "output_per_million": 8.0
+    },
+    "o3-2025-04-16": {
+      "input_per_million": 2.0,
+      "output_per_million": 8.0
+    },
+    "o3-deep-research": {
+      "input_per_million": 10.0,
+      "output_per_million": 40.0
+    },
+    "o3-deep-research-2025-06-26": {
+      "input_per_million": 10.0,
+      "output_per_million": 40.0
+    },
+    "o3-mini": {
+      "input_per_million": 1.1,
+      "output_per_million": 4.4
+    },
+    "o3-mini-2025-01-31": {
+      "input_per_million": 1.1,
+      "output_per_million": 4.4
+    },
+    "o3-pro": {
+      "input_per_million": 20.0,
+      "output_per_million": 80.0
+    },
+    "o3-pro-2025-06-10": {
+      "input_per_million": 20.0,
+      "output_per_million": 80.0
+    },
+    "o4-mini": {
+      "input_per_million": 1.1,
+      "output_per_million": 4.4
+    },
+    "o4-mini-2025-04-16": {
+      "input_per_million": 1.1,
+      "output_per_million": 4.4
+    },
+    "o4-mini-deep-research": {
+      "input_per_million": 2.0,
+      "output_per_million": 8.0
+    },
+    "o4-mini-deep-research-2025-06-26": {
+      "input_per_million": 2.0,
+      "output_per_million": 8.0
+    },
+    "omni-moderation-2024-09-26": {
+      "input_per_million": 0.0,
+      "output_per_million": 0.0
+    },
+    "omni-moderation-latest": {
+      "input_per_million": 0.0,
+      "output_per_million": 0.0
+    },
+    "text-embedding-3-large": {
+      "input_per_million": 0.13,
+      "output_per_million": 0.0
+    },
+    "text-embedding-3-small": {
+      "input_per_million": 0.02,
+      "output_per_million": 0.0
+    },
+    "text-embedding-ada-002": {
+      "input_per_million": 0.1,
+      "output_per_million": 0.0
+    },
+    "text-embedding-ada-002-v2": {
+      "input_per_million": 0.1,
+      "output_per_million": 0.0
+    },
+    "text-moderation-007": {
+      "input_per_million": 0.0,
+      "output_per_million": 0.0
+    },
+    "text-moderation-latest": {
+      "input_per_million": 0.0,
+      "output_per_million": 0.0
+    },
+    "text-moderation-stable": {
+      "input_per_million": 0.0,
+      "output_per_million": 0.0
+    },
+    "gpt-4o-mini-tts-2025-03-20": {
+      "input_per_million": 2.5,
+      "output_per_million": 10.0
+    },
+    "gpt-4o-mini-tts-2025-12-15": {
+      "input_per_million": 2.5,
+      "output_per_million": 10.0
+    },
+    "gpt-4o-mini-transcribe-2025-03-20": {
+      "input_per_million": 1.25,
+      "output_per_million": 5.0
+    },
+    "gpt-4o-mini-transcribe-2025-12-15": {
+      "input_per_million": 1.25,
+      "output_per_million": 5.0
+    },
+    "gpt-5-search-api": {
+      "input_per_million": 1.25,
+      "output_per_million": 10.0
+    },
+    "gpt-5-search-api-2025-10-14": {
+      "input_per_million": 1.25,
+      "output_per_million": 10.0
+    },
+    "gpt-realtime-mini-2025-10-06": {
+      "input_per_million": 0.6,
+      "output_per_million": 2.4
+    },
+    "gpt-realtime-mini-2025-12-15": {
+      "input_per_million": 0.6,
+      "output_per_million": 2.4
+    }
   },
   "anthropic": {
-    "claude-opus-4-6": {"input_per_million": 15.00, "output_per_million": 75.00},
-    "claude-sonnet-4-6": {"input_per_million": 3.00, "output_per_million": 15.00},
-    "claude-haiku-4-5-20251001": {"input_per_million": 0.80, "output_per_million": 4.00}
+    "claude-haiku-4-5-20251001": {
+      "input_per_million": 1.0,
+      "output_per_million": 5.0
+    },
+    "claude-haiku-4-5": {
+      "input_per_million": 1.0,
+      "output_per_million": 5.0
+    },
+    "claude-3-7-sonnet-20250219": {
+      "input_per_million": 3.0,
+      "output_per_million": 15.0
+    },
+    "claude-3-haiku-20240307": {
+      "input_per_million": 0.25,
+      "output_per_million": 1.25
+    },
+    "claude-3-opus-20240229": {
+      "input_per_million": 15.0,
+      "output_per_million": 75.0
+    },
+    "claude-4-opus-20250514": {
+      "input_per_million": 15.0,
+      "output_per_million": 75.0
+    },
+    "claude-4-sonnet-20250514": {
+      "input_per_million": 3.0,
+      "output_per_million": 15.0
+    },
+    "claude-sonnet-4-5": {
+      "input_per_million": 3.0,
+      "output_per_million": 15.0
+    },
+    "claude-sonnet-4-5-20250929": {
+      "input_per_million": 3.0,
+      "output_per_million": 15.0
+    },
+    "claude-sonnet-4-6": {
+      "input_per_million": 3.0,
+      "output_per_million": 15.0
+    },
+    "claude-opus-4-1": {
+      "input_per_million": 15.0,
+      "output_per_million": 75.0
+    },
+    "claude-opus-4-1-20250805": {
+      "input_per_million": 15.0,
+      "output_per_million": 75.0
+    },
+    "claude-opus-4-20250514": {
+      "input_per_million": 15.0,
+      "output_per_million": 75.0
+    },
+    "claude-opus-4-5-20251101": {
+      "input_per_million": 5.0,
+      "output_per_million": 25.0
+    },
+    "claude-opus-4-5": {
+      "input_per_million": 5.0,
+      "output_per_million": 25.0
+    },
+    "claude-opus-4-6": {
+      "input_per_million": 5.0,
+      "output_per_million": 25.0
+    },
+    "claude-opus-4-6-20260205": {
+      "input_per_million": 5.0,
+      "output_per_million": 25.0
+    },
+    "claude-opus-4-7": {
+      "input_per_million": 5.0,
+      "output_per_million": 25.0
+    },
+    "claude-opus-4-7-20260416": {
+      "input_per_million": 5.0,
+      "output_per_million": 25.0
+    },
+    "claude-sonnet-4-20250514": {
+      "input_per_million": 3.0,
+      "output_per_million": 15.0
+    }
   },
   "google": {
-    "gemini-2.0-flash": {"input_per_million": 0.10, "output_per_million": 0.40},
-    "gemini-1.5-pro": {"input_per_million": 1.25, "output_per_million": 5.00},
-    "gemini-1.5-flash": {"input_per_million": 0.075, "output_per_million": 0.30}
+    "gemini-live-2.5-flash-preview-native-audio-09-2025": {
+      "input_per_million": 0.3,
+      "output_per_million": 2.0
+    },
+    "gemini-robotics-er-1.5-preview": {
+      "input_per_million": 0.3,
+      "output_per_million": 2.5
+    },
+    "gemini-embedding-001": {
+      "input_per_million": 0.15,
+      "output_per_million": 0
+    },
+    "gemini-embedding-2-preview": {
+      "input_per_million": 0.2,
+      "output_per_million": 0
+    },
+    "gemini-1.5-flash": {
+      "input_per_million": 0.075,
+      "output_per_million": 0
+    },
+    "gemini-2.0-flash": {
+      "input_per_million": 0.1,
+      "output_per_million": 0.4
+    },
+    "gemini-2.0-flash-001": {
+      "input_per_million": 0.1,
+      "output_per_million": 0.4
+    },
+    "gemini-2.0-flash-lite": {
+      "input_per_million": 0.075,
+      "output_per_million": 0.3
+    },
+    "gemini-2.5-flash": {
+      "input_per_million": 0.3,
+      "output_per_million": 2.5
+    },
+    "gemini-2.5-flash-image": {
+      "input_per_million": 0.3,
+      "output_per_million": 2.5
+    },
+    "gemini-3-pro-image-preview": {
+      "input_per_million": 2.0,
+      "output_per_million": 12.0
+    },
+    "gemini-3.1-flash-image-preview": {
+      "input_per_million": 0.25,
+      "output_per_million": 1.5
+    },
+    "deep-research-pro-preview-12-2025": {
+      "input_per_million": 2.0,
+      "output_per_million": 12.0
+    },
+    "gemini-2.5-flash-lite": {
+      "input_per_million": 0.1,
+      "output_per_million": 0.4
+    },
+    "gemini-2.5-flash-lite-preview-09-2025": {
+      "input_per_million": 0.1,
+      "output_per_million": 0.4
+    },
+    "gemini-2.5-flash-preview-09-2025": {
+      "input_per_million": 0.3,
+      "output_per_million": 2.5
+    },
+    "gemini-flash-latest": {
+      "input_per_million": 0.3,
+      "output_per_million": 2.5
+    },
+    "gemini-flash-lite-latest": {
+      "input_per_million": 0.1,
+      "output_per_million": 0.4
+    },
+    "gemini-2.5-flash-lite-preview-06-17": {
+      "input_per_million": 0.1,
+      "output_per_million": 0.4
+    },
+    "gemini-2.5-flash-preview-tts": {
+      "input_per_million": 0.3,
+      "output_per_million": 2.5
+    },
+    "gemini-2.5-pro": {
+      "input_per_million": 1.25,
+      "output_per_million": 10.0
+    },
+    "gemini-2.5-computer-use-preview-10-2025": {
+      "input_per_million": 1.25,
+      "output_per_million": 10.0
+    },
+    "gemini-3-pro-preview": {
+      "input_per_million": 2.0,
+      "output_per_million": 12.0
+    },
+    "gemini-3.1-flash-lite-preview": {
+      "input_per_million": 0.25,
+      "output_per_million": 1.5
+    },
+    "gemini-3-flash-preview": {
+      "input_per_million": 0.5,
+      "output_per_million": 3.0
+    },
+    "gemini-3.1-pro-preview": {
+      "input_per_million": 2.0,
+      "output_per_million": 12.0
+    },
+    "gemini-3.1-pro-preview-customtools": {
+      "input_per_million": 2.0,
+      "output_per_million": 12.0
+    },
+    "gemini-2.5-pro-preview-tts": {
+      "input_per_million": 1.25,
+      "output_per_million": 10.0
+    },
+    "gemini-exp-1114": {
+      "input_per_million": 0,
+      "output_per_million": 0
+    },
+    "gemini-exp-1206": {
+      "input_per_million": 0,
+      "output_per_million": 0
+    },
+    "gemini-gemma-2-27b-it": {
+      "input_per_million": 0.35,
+      "output_per_million": 1.05
+    },
+    "gemini-gemma-2-9b-it": {
+      "input_per_million": 0.35,
+      "output_per_million": 1.05
+    },
+    "gemma-3-27b-it": {
+      "input_per_million": 0,
+      "output_per_million": 0
+    },
+    "learnlm-1.5-pro-experimental": {
+      "input_per_million": 0,
+      "output_per_million": 0
+    },
+    "lyria-3-clip-preview": {
+      "input_per_million": 0,
+      "output_per_million": 0
+    },
+    "lyria-3-pro-preview": {
+      "input_per_million": 0,
+      "output_per_million": 0
+    },
+    "gemini-2.0-flash-exp-image-generation": {
+      "input_per_million": 0.0,
+      "output_per_million": 0.0
+    },
+    "gemini-2.0-flash-lite-001": {
+      "input_per_million": 0.075,
+      "output_per_million": 0.3
+    },
+    "gemini-2.5-flash-native-audio-latest": {
+      "input_per_million": 0.3,
+      "output_per_million": 2.5
+    },
+    "gemini-2.5-flash-native-audio-preview-09-2025": {
+      "input_per_million": 0.3,
+      "output_per_million": 2.5
+    },
+    "gemini-2.5-flash-native-audio-preview-12-2025": {
+      "input_per_million": 0.3,
+      "output_per_million": 2.5
+    },
+    "gemini-3.1-flash-live-preview": {
+      "input_per_million": 0.75,
+      "output_per_million": 4.5
+    },
+    "gemini-pro-latest": {
+      "input_per_million": 1.25,
+      "output_per_million": 10.0
+    }
   },
   "groq": {
-    "llama-3.3-70b-versatile": {"input_per_million": 0.59, "output_per_million": 0.79},
-    "llama-3.1-8b-instant": {"input_per_million": 0.05, "output_per_million": 0.08},
-    "mixtral-8x7b-32768": {"input_per_million": 0.24, "output_per_million": 0.24},
-    "gemma2-9b-it": {"input_per_million": 0.10, "output_per_million": 0.10}
+    "llama-3.1-8b-instant": {
+      "input_per_million": 0.05,
+      "output_per_million": 0.08
+    },
+    "llama-3.3-70b-versatile": {
+      "input_per_million": 0.59,
+      "output_per_million": 0.79
+    },
+    "gemma-7b-it": {
+      "input_per_million": 0.05,
+      "output_per_million": 0.08
+    },
+    "meta-llama/llama-guard-4-12b": {
+      "input_per_million": 0.2,
+      "output_per_million": 0.2
+    },
+    "meta-llama/llama-4-maverick-17b-128e-instruct": {
+      "input_per_million": 0.2,
+      "output_per_million": 0.6
+    },
+    "meta-llama/llama-4-scout-17b-16e-instruct": {
+      "input_per_million": 0.11,
+      "output_per_million": 0.34
+    },
+    "moonshotai/kimi-k2-instruct-0905": {
+      "input_per_million": 1.0,
+      "output_per_million": 3.0
+    },
+    "openai/gpt-oss-120b": {
+      "input_per_million": 0.15,
+      "output_per_million": 0.6
+    },
+    "openai/gpt-oss-20b": {
+      "input_per_million": 0.075,
+      "output_per_million": 0.3
+    },
+    "openai/gpt-oss-safeguard-20b": {
+      "input_per_million": 0.075,
+      "output_per_million": 0.3
+    },
+    "qwen/qwen3-32b": {
+      "input_per_million": 0.29,
+      "output_per_million": 0.59
+    }
   },
   "openrouter": {
-    "openai/gpt-4o": {"input_per_million": 0.0, "output_per_million": 0.0},
-    "anthropic/claude-sonnet-4-6": {"input_per_million": 0.0, "output_per_million": 0.0},
-    "google/gemini-2.0-flash": {"input_per_million": 0.0, "output_per_million": 0.0},
-    "meta-llama/llama-3.3-70b-instruct": {"input_per_million": 0.0, "output_per_million": 0.0},
-    "mistralai/mistral-7b-instruct": {"input_per_million": 0.0, "output_per_million": 0.0}
+    "anthropic/claude-3-haiku": {
+      "input_per_million": 0.25,
+      "output_per_million": 1.25
+    },
+    "anthropic/claude-3.5-sonnet": {
+      "input_per_million": 3.0,
+      "output_per_million": 15.0
+    },
+    "anthropic/claude-3.7-sonnet": {
+      "input_per_million": 3.0,
+      "output_per_million": 15.0
+    },
+    "anthropic/claude-opus-4": {
+      "input_per_million": 15.0,
+      "output_per_million": 75.0
+    },
+    "anthropic/claude-opus-4.1": {
+      "input_per_million": 15.0,
+      "output_per_million": 75.0
+    },
+    "anthropic/claude-sonnet-4": {
+      "input_per_million": 3.0,
+      "output_per_million": 15.0
+    },
+    "anthropic/claude-sonnet-4.6": {
+      "input_per_million": 3.0,
+      "output_per_million": 15.0
+    },
+    "anthropic/claude-opus-4.5": {
+      "input_per_million": 5.0,
+      "output_per_million": 25.0
+    },
+    "anthropic/claude-opus-4.6": {
+      "input_per_million": 5.0,
+      "output_per_million": 25.0
+    },
+    "anthropic/claude-sonnet-4.5": {
+      "input_per_million": 3.0,
+      "output_per_million": 15.0
+    },
+    "anthropic/claude-haiku-4.5": {
+      "input_per_million": 1.0,
+      "output_per_million": 5.0
+    },
+    "anthropic/claude-opus-4.7": {
+      "input_per_million": 5.0,
+      "output_per_million": 25.0
+    },
+    "bytedance/ui-tars-1.5-7b": {
+      "input_per_million": 0.1,
+      "output_per_million": 0.2
+    },
+    "deepseek/deepseek-chat": {
+      "input_per_million": 0.14,
+      "output_per_million": 0.28
+    },
+    "deepseek/deepseek-chat-v3-0324": {
+      "input_per_million": 0.14,
+      "output_per_million": 0.28
+    },
+    "deepseek/deepseek-chat-v3.1": {
+      "input_per_million": 0.2,
+      "output_per_million": 0.8
+    },
+    "deepseek/deepseek-v3.2": {
+      "input_per_million": 0.28,
+      "output_per_million": 0.4
+    },
+    "deepseek/deepseek-v3.2-exp": {
+      "input_per_million": 0.2,
+      "output_per_million": 0.4
+    },
+    "deepseek/deepseek-r1": {
+      "input_per_million": 0.55,
+      "output_per_million": 2.19
+    },
+    "deepseek/deepseek-r1-0528": {
+      "input_per_million": 0.5,
+      "output_per_million": 2.15
+    },
+    "google/gemini-2.0-flash-001": {
+      "input_per_million": 0.1,
+      "output_per_million": 0.4
+    },
+    "google/gemini-2.5-flash": {
+      "input_per_million": 0.3,
+      "output_per_million": 2.5
+    },
+    "google/gemini-2.5-pro": {
+      "input_per_million": 1.25,
+      "output_per_million": 10.0
+    },
+    "google/gemini-3-pro-preview": {
+      "input_per_million": 2.0,
+      "output_per_million": 12.0
+    },
+    "google/gemini-3-flash-preview": {
+      "input_per_million": 0.5,
+      "output_per_million": 3.0
+    },
+    "google/gemini-3.1-flash-lite-preview": {
+      "input_per_million": 0.25,
+      "output_per_million": 1.5
+    },
+    "google/gemini-3.1-pro-preview": {
+      "input_per_million": 2.0,
+      "output_per_million": 12.0
+    },
+    "gryphe/mythomax-l2-13b": {
+      "input_per_million": 1.875,
+      "output_per_million": 1.875
+    },
+    "mancer/weaver": {
+      "input_per_million": 5.625,
+      "output_per_million": 5.625
+    },
+    "meta-llama/llama-3-70b-instruct": {
+      "input_per_million": 0.59,
+      "output_per_million": 0.79
+    },
+    "minimax/minimax-m2": {
+      "input_per_million": 0.255,
+      "output_per_million": 1.02
+    },
+    "mistralai/devstral-2512": {
+      "input_per_million": 0.15,
+      "output_per_million": 0.6
+    },
+    "mistralai/ministral-3b-2512": {
+      "input_per_million": 0.1,
+      "output_per_million": 0.1
+    },
+    "mistralai/ministral-8b-2512": {
+      "input_per_million": 0.15,
+      "output_per_million": 0.15
+    },
+    "mistralai/ministral-14b-2512": {
+      "input_per_million": 0.2,
+      "output_per_million": 0.2
+    },
+    "mistralai/mistral-large-2512": {
+      "input_per_million": 0.5,
+      "output_per_million": 1.5
+    },
+    "mistralai/mistral-7b-instruct": {
+      "input_per_million": 0.13,
+      "output_per_million": 0.13
+    },
+    "mistralai/mistral-large": {
+      "input_per_million": 8.0,
+      "output_per_million": 24.0
+    },
+    "mistralai/mistral-small-3.1-24b-instruct": {
+      "input_per_million": 0.1,
+      "output_per_million": 0.3
+    },
+    "mistralai/mistral-small-3.2-24b-instruct": {
+      "input_per_million": 0.1,
+      "output_per_million": 0.3
+    },
+    "mistralai/mixtral-8x22b-instruct": {
+      "input_per_million": 0.65,
+      "output_per_million": 0.65
+    },
+    "moonshotai/kimi-k2.5": {
+      "input_per_million": 0.6,
+      "output_per_million": 3.0
+    },
+    "openai/gpt-3.5-turbo": {
+      "input_per_million": 1.5,
+      "output_per_million": 2.0
+    },
+    "openai/gpt-3.5-turbo-16k": {
+      "input_per_million": 3.0,
+      "output_per_million": 4.0
+    },
+    "openai/gpt-4": {
+      "input_per_million": 30.0,
+      "output_per_million": 60.0
+    },
+    "openai/gpt-4.1": {
+      "input_per_million": 2.0,
+      "output_per_million": 8.0
+    },
+    "openai/gpt-4.1-mini": {
+      "input_per_million": 0.4,
+      "output_per_million": 1.6
+    },
+    "openai/gpt-4.1-nano": {
+      "input_per_million": 0.1,
+      "output_per_million": 0.4
+    },
+    "openai/gpt-4o": {
+      "input_per_million": 2.5,
+      "output_per_million": 10.0
+    },
+    "openai/gpt-4o-2024-05-13": {
+      "input_per_million": 5.0,
+      "output_per_million": 15.0
+    },
+    "openai/gpt-5-chat": {
+      "input_per_million": 1.25,
+      "output_per_million": 10.0
+    },
+    "openai/gpt-5-codex": {
+      "input_per_million": 1.25,
+      "output_per_million": 10.0
+    },
+    "openai/gpt-5.2-codex": {
+      "input_per_million": 1.75,
+      "output_per_million": 14.0
+    },
+    "openai/gpt-5": {
+      "input_per_million": 1.25,
+      "output_per_million": 10.0
+    },
+    "openai/gpt-5-mini": {
+      "input_per_million": 0.25,
+      "output_per_million": 2.0
+    },
+    "openai/gpt-5-nano": {
+      "input_per_million": 0.05,
+      "output_per_million": 0.4
+    },
+    "openai/gpt-5.1-codex-max": {
+      "input_per_million": 1.25,
+      "output_per_million": 10.0
+    },
+    "openai/gpt-5.2": {
+      "input_per_million": 1.75,
+      "output_per_million": 14.0
+    },
+    "openai/gpt-5.2-chat": {
+      "input_per_million": 1.75,
+      "output_per_million": 14.0
+    },
+    "openai/gpt-5.2-pro": {
+      "input_per_million": 21.0,
+      "output_per_million": 168.0
+    },
+    "openai/gpt-oss-120b": {
+      "input_per_million": 0.18,
+      "output_per_million": 0.8
+    },
+    "openai/gpt-oss-20b": {
+      "input_per_million": 0.02,
+      "output_per_million": 0.1
+    },
+    "openai/o1": {
+      "input_per_million": 15.0,
+      "output_per_million": 60.0
+    },
+    "openai/o3-mini": {
+      "input_per_million": 1.1,
+      "output_per_million": 4.4
+    },
+    "openai/o3-mini-high": {
+      "input_per_million": 1.1,
+      "output_per_million": 4.4
+    },
+    "qwen/qwen-2.5-coder-32b-instruct": {
+      "input_per_million": 0.18,
+      "output_per_million": 0.18
+    },
+    "qwen/qwen-vl-plus": {
+      "input_per_million": 0.21,
+      "output_per_million": 0.63
+    },
+    "qwen/qwen3-coder": {
+      "input_per_million": 0.22,
+      "output_per_million": 0.95
+    },
+    "qwen/qwen3-coder-plus": {
+      "input_per_million": 1.0,
+      "output_per_million": 5.0
+    },
+    "qwen/qwen3-235b-a22b-2507": {
+      "input_per_million": 0.071,
+      "output_per_million": 0.1
+    },
+    "qwen/qwen3-235b-a22b-thinking-2507": {
+      "input_per_million": 0.11,
+      "output_per_million": 0.6
+    },
+    "qwen/qwen3.5-35b-a3b": {
+      "input_per_million": 0.25,
+      "output_per_million": 2.0
+    },
+    "qwen/qwen3.5-27b": {
+      "input_per_million": 0.3,
+      "output_per_million": 2.4
+    },
+    "qwen/qwen3.5-122b-a10b": {
+      "input_per_million": 0.4,
+      "output_per_million": 2.0
+    },
+    "qwen/qwen3.5-flash-02-23": {
+      "input_per_million": 0.1,
+      "output_per_million": 0.4
+    },
+    "qwen/qwen3.5-plus-02-15": {
+      "input_per_million": 0.4,
+      "output_per_million": 2.4
+    },
+    "qwen/qwen3.5-397b-a17b": {
+      "input_per_million": 0.6,
+      "output_per_million": 3.6
+    },
+    "switchpoint/router": {
+      "input_per_million": 0.85,
+      "output_per_million": 3.4
+    },
+    "undi95/remm-slerp-l2-13b": {
+      "input_per_million": 1.875,
+      "output_per_million": 1.875
+    },
+    "x-ai/grok-4": {
+      "input_per_million": 3.0,
+      "output_per_million": 15.0
+    },
+    "z-ai/glm-4.6": {
+      "input_per_million": 0.4,
+      "output_per_million": 1.75
+    },
+    "z-ai/glm-4.6:exacto": {
+      "input_per_million": 0.45,
+      "output_per_million": 1.9
+    },
+    "xiaomi/mimo-v2-flash": {
+      "input_per_million": 0.09,
+      "output_per_million": 0.29
+    },
+    "z-ai/glm-4.7": {
+      "input_per_million": 0.4,
+      "output_per_million": 1.5
+    },
+    "z-ai/glm-4.7-flash": {
+      "input_per_million": 0.07,
+      "output_per_million": 0.4
+    },
+    "z-ai/glm-5": {
+      "input_per_million": 0.8,
+      "output_per_million": 2.56
+    },
+    "minimax/minimax-m2.1": {
+      "input_per_million": 0.27,
+      "output_per_million": 1.2
+    },
+    "minimax/minimax-m2.5": {
+      "input_per_million": 0.3,
+      "output_per_million": 1.1
+    },
+    "openrouter/auto": {
+      "input_per_million": 0,
+      "output_per_million": 0
+    },
+    "openrouter/free": {
+      "input_per_million": 0,
+      "output_per_million": 0
+    },
+    "openrouter/bodybuilder": {
+      "input_per_million": 0,
+      "output_per_million": 0
+    }
   }
 }

--- a/t01_llm_battle/server.py
+++ b/t01_llm_battle/server.py
@@ -1,3 +1,5 @@
+import asyncio
+import logging
 from contextlib import asynccontextmanager
 from pathlib import Path
 
@@ -5,6 +7,7 @@ from fastapi import FastAPI
 from fastapi.staticfiles import StaticFiles
 
 from .db import init_db, DB_PATH
+from .pricing import get_cache_info, refresh_llm_pricing
 from .routers.battles import router as battles_router
 from .routers.keys import router as keys_router
 from .routers.runs import router as runs_router
@@ -12,11 +15,26 @@ from .routers.sources import router as sources_router
 from .routers.fighters import router as fighters_router, providers_router
 from .routers.providers import router as provider_mgmt_router
 
+log = logging.getLogger(__name__)
+
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     await init_db()
+    # Auto-refresh LLM pricing if no user cache exists
+    cache = get_cache_info()
+    if cache["age_seconds"] is None:
+        asyncio.create_task(_background_pricing_refresh())
     yield
+
+
+async def _background_pricing_refresh():
+    try:
+        result = await asyncio.to_thread(refresh_llm_pricing)
+        total = sum(result.values())
+        log.info("Auto-refreshed LLM pricing: %d models", total)
+    except Exception as e:
+        log.warning("Failed to auto-refresh LLM pricing: %s", e)
 
 
 def create_app(db_path=DB_PATH) -> FastAPI:


### PR DESCRIPTION
## Summary

- Updated bundled `llm_pricing.json` from 16 models to 301 models via LiteLLM catalog
- Added auto-refresh on first server start when no user cache exists

Fixes $0.00 costs for newer models like `gpt-5-mini` and `gemini-2.5-flash-lite`.

## Test plan

- [ ] Run `pytest tests/test_pricing.py` — all 19 tests pass
- [ ] Start server, run a battle with `gpt-5-mini` — cost should be non-zero
- [ ] Delete `~/.t01-llm-battle/llm_pricing.json`, restart server — auto-refresh triggers

🤖 Generated with [Claude Code](https://claude.com/claude-code)