### PR TITLE
fix: enforce SQLite foreign keys via get_db()

### DIFF
--- a/t01_llm_battle/db.py
+++ b/t01_llm_battle/db.py
@@ -130,6 +130,9 @@ async def init_db(db_path: str | Path = DB_PATH) -> None:
 
     async with aiosqlite.connect(path) as db:
         await db.execute("PRAGMA journal_mode=WAL")
+        # Disable FK enforcement during schema creation and migrations to allow
+        # table renames and recreations without constraint violations.
+        # FK enforcement is enabled per-connection in get_db() for all runtime queries.
         await db.executescript(_SCHEMA_SQL)
         await db.commit()
         for sql in _MIGRATIONS_SQL:
@@ -137,7 +140,7 @@ async def init_db(db_path: str | Path = DB_PATH) -> None:
                 await db.execute(sql)
                 await db.commit()
             except Exception:
-                pass  # column already exists
+                pass  # migration already applied
 
     await _migrate_plaintext_keys(db_path)
 

--- a/t01_llm_battle/routers/battles.py
+++ b/t01_llm_battle/routers/battles.py
@@ -254,7 +254,7 @@ async def delete_battle(battle_id: str) -> None:
         if row is None:
             raise HTTPException(status_code=404, detail="Battle not found")
 
-        # Delete child records first (SQLite foreign keys may not be enforced by default)
+        # Delete child records first (schema uses REFERENCES without ON DELETE CASCADE)
         await db.execute(
             "DELETE FROM step_result WHERE run_id IN (SELECT id FROM run WHERE battle_id = ?)",
             (battle_id,),

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -1,4 +1,5 @@
 import pytest
+import aiosqlite
 from t01_llm_battle.db import init_db, get_db
 
 
@@ -12,3 +13,26 @@ async def test_init_db_creates_tables(tmp_path):
     assert "battle" in tables
     assert "fighter" in tables
     assert "run" in tables
+
+
+@pytest.mark.asyncio
+async def test_foreign_keys_enforced(tmp_path):
+    """PRAGMA foreign_keys = ON must be active — inserting a fighter with a bad battle_id must fail."""
+    import uuid
+    from datetime import datetime, timezone
+
+    db_path = str(tmp_path / "fk_test.db")
+    await init_db(db_path)
+    raised = False
+    async with get_db(db_path) as db:
+        try:
+            await db.execute(
+                "INSERT INTO fighter (id, battle_id, name, is_manual, position, created_at) "
+                "VALUES (?, ?, ?, ?, ?, ?)",
+                (str(uuid.uuid4()), "nonexistent-battle-id", "TestFighter", 0, 1,
+                 datetime.now(timezone.utc).isoformat()),
+            )
+            await db.commit()
+        except aiosqlite.IntegrityError:
+            raised = True
+    assert raised, "Expected IntegrityError for FK violation — foreign_keys pragma may be OFF"


### PR DESCRIPTION
Closes #252. get_db() already sets PRAGMA foreign_keys=ON for all runtime connections; init_db() intentionally keeps it off for schema migrations. Add clarifying comments and test confirming FK enforcement works.