### PR TITLE
feat: Display 'unknown' pricing label for custom model IDs

### DIFF
--- a/t01_llm_battle/engine.py
+++ b/t01_llm_battle/engine.py
@@ -68,6 +68,7 @@ async def _execute_pair(
     step_input = source_content
     had_error = False
     total_cost: float = 0.0
+    any_cost_known: bool = False
     total_latency: int = 0
     total_input_tokens: int = 0
     total_output_tokens: int = 0
@@ -123,7 +124,9 @@ async def _execute_pair(
                 had_error = True
                 break
 
-            total_cost += result.cost_usd or 0.0
+            if result.cost_usd is not None:
+                total_cost += result.cost_usd
+                any_cost_known = True
             total_latency += latency_ms
             total_input_tokens += result.input_tokens or 0
             total_output_tokens += result.output_tokens or 0
@@ -158,7 +161,7 @@ async def _execute_pair(
             "total_latency_ms = ?, total_input_tokens = ?, total_output_tokens = ? "
             "WHERE id = ?",
             (
-                fr_status, final_output, total_cost if total_cost else None,
+                fr_status, final_output, total_cost if any_cost_known else None,
                 total_latency if total_latency else None,
                 total_input_tokens if total_input_tokens else None,
                 total_output_tokens if total_output_tokens else None,

--- a/t01_llm_battle/pricing.py
+++ b/t01_llm_battle/pricing.py
@@ -60,12 +60,12 @@ def get_llm_models(provider: str) -> list[str]:
 
 def get_llm_cost(
     provider: str, model: str, input_tokens: int, output_tokens: int
-) -> float:
-    """Calculate cost in USD. Returns 0.0 for unknown provider/model."""
+) -> float | None:
+    """Calculate cost in USD. Returns None for unknown provider/model."""
     pricing = load_llm_pricing()
     entry = pricing.get(provider, {}).get(model)
     if entry is None:
-        return 0.0
+        return None
     return (
         input_tokens * entry["input_per_million"]
         + output_tokens * entry["output_per_million"]

--- a/t01_llm_battle/static/index.html
+++ b/t01_llm_battle/static/index.html
@@ -1153,7 +1153,7 @@
                       <td style="text-align:right;">
                         <span :style="f.avg_score !== null ? scoreColor(f.avg_score) : ''" x-text="f.avg_score !== null ? f.avg_score.toFixed(2) : '—'"></span>
                       </td>
-                      <td style="text-align:right;font-family:monospace;font-size:0.83rem;" x-text="'$' + f.total_cost.toFixed(4)"></td>
+                      <td style="text-align:right;font-family:monospace;font-size:0.83rem;" x-text="f.pricing_unknown ? 'unknown' : '$' + f.total_cost.toFixed(4)"></td>
                       <td style="text-align:right;font-family:monospace;font-size:0.83rem;color:var(--mid);" x-text="f.token_cost > 0 ? '$' + f.token_cost.toFixed(4) : '—'"></td>
                       <td style="text-align:right;font-family:monospace;font-size:0.83rem;color:var(--gold);" x-text="f.credit_cost > 0 ? '$' + f.credit_cost.toFixed(4) : '—'"></td>
                       <td style="text-align:right;font-family:monospace;font-size:0.83rem;" x-text="f.total_latency_ms > 0 ? (f.total_latency_ms / 1000).toFixed(1) + 's' : '—'"></td>
@@ -1192,7 +1192,7 @@
                         <div style="font-size:0.76rem;color:var(--mid);margin-top:6px;">
                           <span x-text="fighter.step_count + ' step(s)'"></span>
                           &nbsp;·&nbsp;
-                          <span style="font-family:monospace;" x-text="'$' + (fighter.total_cost_usd || 0).toFixed(4) + ' total'"></span>
+                          <span style="font-family:monospace;" x-text="fighter.total_cost_usd === null && (fighter.total_input_tokens || fighter.total_output_tokens) ? 'unknown pricing' : '$' + (fighter.total_cost_usd || 0).toFixed(4) + ' total'"></span>
                           <template x-if="fighter.total_input_tokens || fighter.total_output_tokens">
                             <span>&nbsp;·&nbsp;<span x-text="(fighter.total_input_tokens || 0) + ' in / ' + (fighter.total_output_tokens || 0) + ' out tokens'"></span></span>
                           </template>
@@ -2086,8 +2086,9 @@ Do not wrap the JSON in markdown fences.`;
           const map = {};
           for (const item of this.results.summary) {
             const name = item.fighter_name;
-            if (!map[name]) map[name] = { fighter_name: name, scores: [], total_cost: 0, token_cost: 0, credit_cost: 0, total_latency_ms: 0, success_count: 0, failed_count: 0 };
+            if (!map[name]) map[name] = { fighter_name: name, scores: [], total_cost: 0, token_cost: 0, credit_cost: 0, total_latency_ms: 0, success_count: 0, failed_count: 0, pricing_unknown: false };
             if (item.score !== null && item.score !== undefined) map[name].scores.push(item.score);
+            if (item.total_cost_usd === null && (item.total_input_tokens || item.total_output_tokens)) map[name].pricing_unknown = true;
             map[name].total_cost += item.total_cost_usd || 0;
             if (item.total_input_tokens || item.total_output_tokens) map[name].token_cost += item.total_cost_usd || 0;
             else if (item.total_cost_usd) map[name].credit_cost += item.total_cost_usd || 0;
@@ -2129,7 +2130,7 @@ Do not wrap the JSON in markdown fences.`;
           const lines = ['# LLM Battle Results', '', '**Run ID:** ' + (this.results.run_id || this.runId)];
           if (this.results.battle_id) lines.push('**Battle ID:** ' + this.results.battle_id);
           lines.push('', '## Fighter Summary', '', '| Fighter | Avg Score | Total Cost USD | Token Cost | Credit Cost | Time | Success | Failed |', '|---------|-----------|---------------|-----------|-------------|------|---------|--------|');
-          for (const f of summary) lines.push('| ' + f.fighter_name + ' | ' + (f.avg_score !== null ? f.avg_score.toFixed(2) : '—') + ' | $' + f.total_cost.toFixed(4) + ' | ' + (f.token_cost > 0 ? '$' + f.token_cost.toFixed(4) : '—') + ' | ' + (f.credit_cost > 0 ? '$' + f.credit_cost.toFixed(4) : '—') + ' | ' + (f.total_latency_ms > 0 ? (f.total_latency_ms / 1000).toFixed(1) + 's' : '—') + ' | ' + f.success_count + ' | ' + f.failed_count + ' |');
+          for (const f of summary) lines.push('| ' + f.fighter_name + ' | ' + (f.avg_score !== null ? f.avg_score.toFixed(2) : '—') + ' | ' + (f.pricing_unknown ? 'unknown' : '$' + f.total_cost.toFixed(4)) + ' | ' + (f.token_cost > 0 ? '$' + f.token_cost.toFixed(4) : '—') + ' | ' + (f.credit_cost > 0 ? '$' + f.credit_cost.toFixed(4) : '—') + ' | ' + (f.total_latency_ms > 0 ? (f.total_latency_ms / 1000).toFixed(1) + 's' : '—') + ' | ' + f.success_count + ' | ' + f.failed_count + ' |');
           lines.push('', '## Per-Source Breakdown', '');
           for (const source of this.sourceGroups()) {
             lines.push('### ' + source.label, '');

--- a/tests/test_pricing.py
+++ b/tests/test_pricing.py
@@ -74,11 +74,11 @@ def test_get_llm_cost_zero_tokens():
 
 
 def test_get_llm_cost_unknown_model():
-    assert get_llm_cost("openai", "nonexistent-model", 1000, 1000) == 0.0
+    assert get_llm_cost("openai", "nonexistent-model", 1000, 1000) is None
 
 
 def test_get_llm_cost_unknown_provider():
-    assert get_llm_cost("unknown", "gpt-4o", 1000, 1000) == 0.0
+    assert get_llm_cost("unknown", "gpt-4o", 1000, 1000) is None
 
 
 def test_get_tool_functions():


### PR DESCRIPTION
Closes #251

Implements FR-16: custom model IDs without pricing info now display 'unknown' instead of '$0.0000'.

## Changes
- `get_llm_cost()` returns `None` for unknown provider/model instead of `0.0`
- Engine tracks `any_cost_known` flag to store `NULL` total_cost_usd in DB
- Frontend shows 'unknown' in summary table, fighter detail, and markdown export
- Tests updated to match new None return value

## Spec Match
✓ Custom model IDs show 'unknown' pricing in UI
✓ Frontend distinguishes between 'free' (credit-based) and 'unknown pricing' (unknown LLM cost)