### PR TITLE
docs: News & Trending Boards PRD (v0.2)

### DIFF
--- a/prd/01-prd.md
+++ b/prd/01-prd.md
@@ -15,6 +15,8 @@ The user runs a CLI, opens a browser, defines a "battle" — a set of source inp
 
 After running, the final output of each fighter is judged side-by-side: quality score, cost, latency, token usage. No accounts, no cloud, no SaaS. Keys live on the developer's machine.
 
+Beyond battles, the tool also powers **personal news & trending boards** — scheduled pipelines that fetch content from live data sources (URLs, RSS feeds, APIs, social feeds), analyze and summarize it using fighter pipelines, and present curated, ranked news organized by topics. Results can be viewed locally or published to GitHub Pages.
+
 ### Positioning
 
 | Aspect | t01-llm-battle | Promptfoo (incumbent) |
@@ -25,6 +27,7 @@ After running, the final output of each fighter is judged side-by-side: quality 
 | Sharing | Markdown report (copy/print) | Local artifacts |
 | Cost model | Free forever (OSS) | OSS core + paid Enterprise tier |
 | Scope | Deliberately small, no teams/CI | Full eval platform, red team, SSO, teams |
+| News boards | Scheduled fighter pipelines fetch, analyze, and publish curated content | N/A |
 
 **We are not trying to beat Promptfoo.** We are taking one slice of its surface (pick-the-right-approach-now) and making it a dead-simple standalone tool.
 
@@ -35,6 +38,7 @@ After running, the final output of each fighter is judged side-by-side: quality 
 | Senior developer evaluating models for a new feature | "Is Haiku good enough or do I need Sonnet?" | Can decide in < 10 minutes with confidence |
 | AI engineer comparing pipelines vs single models | "Does my two-step extraction pipeline actually beat a single call?" | Sees cost × latency × quality on same axes |
 | LLM beginner learning the ecosystem | "What do different models actually do differently?" | Understands tradeoffs from one shareable report |
+| Developer wanting curated tech news | "I want an AI-powered news digest without yet another SaaS subscription" | Gets a personal, scheduled news board running locally in minutes |
 
 ## Document Index
 
@@ -47,6 +51,7 @@ After running, the final output of each fighter is judged side-by-side: quality 
 | [05-user-stories.md](./05-user-stories.md) | Key workflows |
 | [06-data-models.md](./06-data-models.md) | SQLite schema: battle / source / fighter / step / run / result / judgment / api_key |
 | [07-roadmap.md](./07-roadmap.md) | Phased delivery plan |
+| [08-news-boards.md](./08-news-boards.md) | News & trending boards — source pool, fighters, normalizer, topics, scheduling, publishing |
 
 ## v0.1 Scope
 
@@ -102,6 +107,7 @@ After running, the final output of each fighter is judged side-by-side: quality 
 | **Bring-your-own-keys, stored locally** | Env vars or SQLite. Keys never leave the user's machine. |
 | **Provider adapters use appropriate abstractions** | LLM providers use Pydantic AI as a unified abstraction layer (tool-calling, structured output, model switching). Tool providers (Serper, Tavily, Firecrawl) remain thin `httpx` clients — no SDK needed. Adding a provider is one file. |
 | **Custom model IDs always allowed** | Curated model catalog is a starting point; users can enter any model slug. Pricing is just "unknown" for custom models. Tool ages well when providers ship new models. |
+| **Boards reuse fighter pipelines** | No parallel abstraction for news processing. Boards reference existing fighters. Normalizer standardizes output like judge standardizes scoring. |
 | **No streaming in v0.1** | We need full responses to compare final token counts and latency apples-to-apples. Streaming adds complexity and asymmetric UX. |
 
 ## Non-Goals

--- a/prd/02-tech-stack.md
+++ b/prd/02-tech-stack.md
@@ -122,3 +122,10 @@ dependencies = [
 ```
 
 No `rich`, no `pydantic-settings` — intentionally minimal. `pydantic-ai` is the single LLM SDK dependency; tool providers use plain `httpx`.
+
+### v0.2 Additions
+
+| Dependency | Why | Size |
+|-----------|-----|------|
+| `feedparser` | RSS/Atom feed parsing for news board sources | ~0.1 MB |
+| `APScheduler>=4` | In-process async cron scheduler for board execution | ~0.3 MB |

--- a/prd/03-functional-requirements.md
+++ b/prd/03-functional-requirements.md
@@ -23,6 +23,24 @@
 | FR-19 | Provider Management UI | Sidebar footer link labelled "Providers"; lists providers with enable/disable toggle; edit popup for display name, API key, server URL (Ollama/LLM Studio/self-hosted); uninstall non-system providers |
 | FR-20 | Sidebar Layout | Single page: left sidebar (app name, battle list, "Providers" footer link) + main content area (selected battle or default empty battle with 2 fighters) |
 
+### v0.2 — News & Trending Boards
+
+| # | Area | Summary |
+|---|------|---------|
+| FR-21 | Source Pool | Global data source management: CRUD, types (URL/RSS/API/social), tags, priority, max items per source, fighter affinity, status |
+| FR-22 | News Fighters | Promote battle fighters to news fighters list; system prebuilts; fallback chain; priority for load balancing |
+| FR-23 | Load Balancing | Priority-ordered fetch, dedup by URL+title hash, cap at max_news_per_run (default 100), affinity-based assignment, fallback on failure |
+| FR-24 | Normalizer | Dedicated LLM step to convert raw fighter output to standard news item schema; classify, tag, and rank items (0–10) |
+| FR-25 | Topics | User-defined categories with tag filter rules; dynamic tag-based filtering; built-in "All" topic |
+| FR-26 | Board Creation | Source selection (by tags/IDs), fighter selection, normalizer config, topics, schedule, max news per run |
+| FR-27 | Scheduled Execution | In-process cron (APScheduler), dedup by URL+title hash, history retention with pruning |
+| FR-28 | Output & Templates | Standard JSON schema for news items; 2 bundled templates (card grid, news list); user-custom templates |
+| FR-29 | Publishing | GitHub Pages push (template HTML + data.json) + static HTML/JSON export to local directory |
+| FR-30 | Source Management UI | Dedicated section: CRUD, type-specific config forms, tags, priority, affinity, health status |
+| FR-31 | Topic Pages UI | Topic detail page with dynamic tag filters, pagination (default 20 items), ranked by relevance score |
+| FR-32 | System Defaults | Ship with 4 system sources, 3 system fighters, 1 default board with 3 topics — works immediately after adding API keys |
+| FR-33 | Fighter Promotion | "Add to News Fighters" action on battle fighter cards; copies fighter + steps independently |
+
 ---
 
 ## Detail: FR-8 Provider Management

--- a/prd/05-user-stories.md
+++ b/prd/05-user-stories.md
@@ -19,6 +19,19 @@
 | US-15 | Any user | Manage providers in the sidebar (enable/disable, edit API key, server URL) | I can configure my providers without touching env vars or config files |
 | US-16 | Any user | Navigate battles from a persistent sidebar | I can switch between battles without losing my place |
 
+### v0.2 — News & Trending Boards
+
+| ID | As a… | I want to… | So that… |
+|----|-------|-----------|----------|
+| US-17 | Developer | Install and see a working "Tech News Daily" board immediately | I get value without configuration beyond API keys |
+| US-18 | Developer | Add my own RSS feeds and URL sources to the source pool | I can monitor content specific to my interests |
+| US-19 | AI engineer | Promote a battle fighter I built to the news fighters list | I reuse my proven analysis pipeline for ongoing monitoring |
+| US-20 | Developer | Reserve YouTube sources for my "YouTube Analyzer" fighter | Only the right fighter processes video content |
+| US-21 | Developer | Publish my board results to GitHub Pages | My team sees curated news without running the tool |
+| US-22 | Any user | Browse the "AI & ML" topic page and filter by "llm" tag | I find relevant news quickly within a topic |
+| US-23 | Any user | View the "All" topic to see top-ranked news across all topics | I don't miss important items that span categories |
+| US-24 | Developer | Set max 5 items per source and 100 max per run | I control costs and processing time |
+
 ---
 
 ## Key Workflow: Multi-Step Pipeline Battle (US-1)

--- a/prd/06-data-models.md
+++ b/prd/06-data-models.md
@@ -135,7 +135,7 @@ One row per (run × fighter × source item). Aggregates step results and stores 
 
 ---
 
-## Entity Relationships
+## Entity Relationships (v0.1 — Battles)
 
 ```
 battle
@@ -145,4 +145,159 @@ battle
   └── run (1..N)
         └── fighter_result (fighter × source)
               └── step_result (step × source)  [empty if is_manual]
+```
+
+---
+
+## v0.2 — News & Trending Boards
+
+### `news_source`
+
+Global pool of data sources for news boards.
+
+| Column | Type | Notes |
+|--------|------|-------|
+| id | TEXT PK | UUID |
+| name | TEXT | Display name |
+| source_type | TEXT | `url` / `rss` / `api` / `social` |
+| config | TEXT | JSON: type-specific fetch config |
+| tags | TEXT | JSON array of tag strings |
+| priority | INTEGER | 1 = highest, controls fetch order |
+| max_items | INTEGER | Max items per fetch (default 5) |
+| fighter_affinity | TEXT | JSON array of news_fighter IDs (empty = any fighter) |
+| is_system | INTEGER | 1 = shipped with product, cannot be deleted |
+| status | TEXT | `active` / `paused` / `error` |
+| last_error | TEXT | Nullable — last fetch error message |
+| created_at | TEXT | ISO-8601 |
+
+---
+
+### `news_fighter`
+
+Fighters available for news processing. References existing fighter entities.
+
+| Column | Type | Notes |
+|--------|------|-------|
+| id | TEXT PK | UUID |
+| fighter_id | TEXT FK | → fighter.id (reuses existing fighter + steps) |
+| name | TEXT | Display name (may differ from source fighter) |
+| fallback_fighter_id | TEXT FK | → news_fighter.id, nullable — retry with this on failure |
+| priority | INTEGER | 1 = highest, for load balancing |
+| is_system | INTEGER | 1 = shipped with product |
+| created_at | TEXT | ISO-8601 |
+
+---
+
+### `board`
+
+A personal news/info dashboard.
+
+| Column | Type | Notes |
+|--------|------|-------|
+| id | TEXT PK | UUID |
+| name | TEXT | Board name |
+| description | TEXT | Optional |
+| source_filter | TEXT | JSON: `{"tags": ["ai"], "source_ids": ["..."]}` |
+| fighter_ids | TEXT | JSON array of news_fighter IDs |
+| normalizer_provider | TEXT | Provider slug for normalizer LLM |
+| normalizer_model | TEXT | Model slug for normalizer |
+| normalizer_instructions | TEXT | System prompt for normalizer (editable) |
+| schedule_cron | TEXT | Cron expression (e.g., `0 */6 * * *`) |
+| max_news_per_run | INTEGER | Default 100 |
+| max_history | INTEGER | Runs to keep (default 10), older pruned |
+| is_active | INTEGER | 1 = scheduler runs this board |
+| template_id | TEXT | Template filename |
+| publish_target | TEXT | `github_pages` / `static` / NULL |
+| publish_config | TEXT | JSON config for publish target |
+| is_system | INTEGER | 1 = shipped with product |
+| created_at | TEXT | ISO-8601 |
+
+---
+
+### `board_topic`
+
+User-defined categories for organizing news within a board.
+
+| Column | Type | Notes |
+|--------|------|-------|
+| id | TEXT PK | UUID |
+| board_id | TEXT FK | → board.id |
+| name | TEXT | Topic name (e.g., "AI & ML") |
+| description | TEXT | Optional |
+| tag_filter | TEXT | JSON: `{"include": ["ai", "ml"], "exclude": ["spam"]}` |
+| position | INTEGER | Display order |
+
+> The built-in "All" topic is not stored — it is implicit and always shows all items ranked by relevance.
+
+---
+
+### `board_run`
+
+One execution of a board's news pipeline.
+
+| Column | Type | Notes |
+|--------|------|-------|
+| id | TEXT PK | UUID |
+| board_id | TEXT FK | → board.id |
+| status | TEXT | `pending` / `running` / `complete` / `error` |
+| items_fetched | INTEGER | Raw items before dedup |
+| items_processed | INTEGER | After dedup + cap |
+| cost_usd | REAL | Total cost of this run |
+| started_at | TEXT | ISO-8601 |
+| finished_at | TEXT | ISO-8601, nullable |
+
+---
+
+### `board_news_item`
+
+Normalized news items, one row per item per run.
+
+| Column | Type | Notes |
+|--------|------|-------|
+| id | TEXT PK | UUID |
+| run_id | TEXT FK | → board_run.id |
+| board_id | TEXT FK | → board.id |
+| title | TEXT | Normalized title |
+| summary | TEXT | Normalized summary |
+| source_url | TEXT | Original URL |
+| source_name | TEXT | Source display name |
+| fighter_name | TEXT | Fighter that processed this item |
+| category | TEXT | Primary category |
+| tags | TEXT | JSON array of tag/label strings |
+| relevance_score | REAL | 0–10, assigned by normalizer |
+| published_at | TEXT | Original publish date |
+| created_at | TEXT | ISO-8601 |
+
+---
+
+### `board_seen_item`
+
+Deduplication tracking. Prevents re-processing items across runs.
+
+| Column | Type | Notes |
+|--------|------|-------|
+| board_id | TEXT | → board.id |
+| item_hash | TEXT | SHA-256 of URL + title |
+| first_seen_at | TEXT | ISO-8601 |
+| PK | | (board_id, item_hash) |
+
+---
+
+## Entity Relationships (v0.2 — Boards)
+
+```
+news_source (global pool)
+  └── fighter_affinity → news_fighter (optional, many-to-many via JSON)
+
+news_fighter
+  ├── fighter_id → fighter (reuses battle fighter + steps)
+  └── fallback_fighter_id → news_fighter (self-referential)
+
+board
+  ├── source_filter → news_source (by tags or IDs, via JSON)
+  ├── fighter_ids → news_fighter (multiple, via JSON)
+  ├── board_topic (1..N)
+  ├── board_run (0..N)
+  │     └── board_news_item (0..N)
+  └── board_seen_item (0..N)
 ```

--- a/prd/07-roadmap.md
+++ b/prd/07-roadmap.md
@@ -14,15 +14,35 @@
 | Distribution | `pipx install t01-llm-battle` on PyPI |
 | Docs | README with elevator pitch, install, quickstart, provider setup |
 
-## v0.2+ (future)
+## v0.2 — News & Trending Boards
 
-These are not committed. They exist to capture ideas without letting them bloat v0.1.
+**Goal**: personal news dashboards powered by fighter pipelines, with scheduled execution and publishing.
+
+| Area | Deliverable |
+|------|-------------|
+| Source Pool | Global source management: CRUD, types (URL/RSS/API/social), tags, priority, max items, fighter affinity |
+| News Fighters | Promote from battle, system prebuilts (General Summarizer, Tech Deep Dive, YouTube Analyzer), fallback chain |
+| Load Balancing | Priority-ordered fetch, dedup, cap at max_news_per_run, affinity-based assignment, fallback on failure |
+| Normalizer | Dedicated LLM step to standardize fighter output, classify, tag, and rank items (0–10) |
+| Topics | User-defined categories with tag filter rules, dynamic filtering, "All" topic |
+| Scheduler | In-process APScheduler, cron expressions, history retention with pruning |
+| UI | Source management section, board creation wizard, topic pages with dynamic filters and pagination |
+| Templates | 2 bundled (card grid, news feed list), user-custom support |
+| Publishing | GitHub Pages push + static HTML/JSON export |
+| System Defaults | 4 sources, 3 fighters, 1 board, 3 topics — works immediately after adding API keys |
+
+See [08-news-boards.md](./08-news-boards.md) for the full spec.
+
+## v0.3+ (future)
+
+These are not committed. They exist to capture ideas without letting them bloat v0.2.
 
 - Azure OpenAI + AWS Bedrock provider adapters
 - Shareable result URLs (requires tiny hosted snapshot service)
 - VS Code extension wrapper
-- Model catalog community PRs + pricing refresh automation
 - Multi-turn conversation support (system + user + assistant turns)
+- Board publishing to Slack webhook, email digest, Obsidian vault
+- Social media source providers (Twitter/X, Reddit, Bluesky)
 
 ## Explicit non-roadmap
 

--- a/prd/08-news-boards.md
+++ b/prd/08-news-boards.md
@@ -1,0 +1,272 @@
+# News & Trending Boards
+
+**Version**: 0.2 (planned)
+**Status**: Draft
+
+## Overview
+
+Boards extend t01-llm-battle from one-shot battle comparisons to **ongoing, scheduled news monitoring**. A board maintains a pool of data sources (URLs, RSS feeds, APIs, social feeds), runs prebuilt fighter pipelines to analyze and summarize content, then uses a **normalizer** (like the judge in battles) to convert raw output into a standard news item schema with tags, categories, and relevance scores. Items are organized into user-defined **topics** with dynamic filtering and pagination.
+
+| Concept | Battle (v0.1) | Board (v0.2) |
+|---------|---------------|--------------|
+| Purpose | One-time comparison | Ongoing monitoring |
+| Sources | Static files/CSV upload | Live feeds (URL, RSS, API, social) |
+| Execution | Manual trigger | Scheduled (cron) |
+| Fighters | Multiple competing | Prebuilt analysis pipeline(s) |
+| Result processing | Judge (score + reasoning) | Normalizer (standardize + classify + rank) |
+| Output | Markdown report | Structured JSON → topics → templates |
+| Publishing | None (local only) | Local templates + GitHub Pages + static export |
+
+---
+
+## Source Pool
+
+A global pool of data sources, managed independently from boards and fighters.
+
+### Source Types
+
+| Type | Example | Fetch Method | Config |
+|------|---------|-------------|--------|
+| URL | `https://news.ycombinator.com` | Firecrawl scrape | `{"url": "...", "selector": "..."}` |
+| RSS | `https://blog.example.com/feed.xml` | feedparser | `{"feed_url": "..."}` |
+| API | Serper news, Tavily search | Existing tool providers | `{"provider": "serper", "function": "news", "query": "..."}` |
+| Social | HackerNews top, Reddit subreddit | httpx + public API | `{"platform": "hackernews", "section": "top"}` |
+
+### Source Properties
+
+- **Tags**: user-defined labels for categorization (e.g., `["ai", "youtube", "crypto"]`)
+- **Priority**: configurable, 1 = highest. High-priority sources are fetched first during a run.
+- **Max items per source**: configurable, default 5. Limits items collected per source per run.
+- **Fighter affinity** (optional): list of news fighter IDs suitable for this source. If empty, any fighter can process it. Example: YouTube URL sources are reserved for a "YouTube Analyzer" fighter.
+- **Status**: `active` / `paused` / `error` (auto-set on fetch failure)
+- **System sources**: prebuilt, shipped with product, user can disable but not delete
+
+### System Sources (ship with product)
+
+| Name | Type | Config |
+|------|------|--------|
+| HackerNews Top Stories | social | `{"platform": "hackernews", "section": "top"}` |
+| TechCrunch | rss | `{"feed_url": "https://techcrunch.com/feed/"}` |
+| AI/ML News | api | `{"provider": "serper", "function": "news", "query": "artificial intelligence machine learning"}` |
+| GitHub Trending | url | `{"url": "https://github.com/trending"}` |
+
+### Source Management UI
+
+Dedicated section in the app:
+- CRUD: add, edit, delete sources
+- Config: type picker → type-specific form, tags, priority, max items, fighter affinity
+- Bulk operations: enable/disable by tag
+- Health: show last fetch status, error count, last successful fetch time
+
+---
+
+## News Fighters
+
+A news fighter is an existing fighter (from any battle) that has been **promoted** to the news fighters list, or a system-provided prebuilt fighter.
+
+### Promotion from Battle
+
+- "Add to News Fighters" button on battle fighter cards
+- Copies the fighter + all its steps to the news fighters list
+- The copy is independent — editing the original battle fighter does not affect the news fighter
+
+### System Fighters (ship with product)
+
+| Name | Description | Steps |
+|------|-------------|-------|
+| General News Summarizer | Summarize + categorize + score relevance | 1 step: LLM summarization |
+| Tech Deep Dive | Detailed analysis with key takeaways | 2 steps: extract facts → analyze |
+| YouTube Analyzer | Extract video metadata, summarize transcript | 1 step: specialized for video content |
+
+### Fallback Chain
+
+Each news fighter has an optional `fallback_fighter_id`. If a fighter fails (error, timeout) when processing a source item, the item is retried with the fallback fighter. Maximum 1 retry.
+
+### Priority
+
+Fighters have a configurable priority (1 = highest). Higher-priority fighters pick sources first during load balancing.
+
+---
+
+## Normalizer
+
+Like the **judge** in battles, the normalizer is a dedicated LLM step that runs after fighters produce raw output. It converts raw results into the **standard news item schema**.
+
+### Responsibilities
+
+1. Parse raw fighter output (may be markdown, free text, or partial JSON)
+2. Extract individual news items
+3. For each item: generate `title`, `summary`, `source_url`, `category`, `tags` (array), `relevance_score` (0–10), `published_at`
+4. Rank items by relevance
+5. Output valid JSON array conforming to the standard schema
+
+### Standard News Item Schema
+
+```json
+{
+  "title": "OpenAI releases GPT-5",
+  "summary": "OpenAI announced GPT-5 with improved reasoning capabilities...",
+  "source_url": "https://techcrunch.com/2026/04/25/openai-gpt-5",
+  "source_name": "TechCrunch",
+  "fighter_name": "General News Summarizer",
+  "category": "Product Launch",
+  "tags": ["ai", "openai", "gpt", "llm"],
+  "relevance_score": 9.2,
+  "published_at": "2026-04-25T10:00:00Z"
+}
+```
+
+### Normalizer Config (per board)
+
+- **Provider + model**: like judge config in battles (e.g., `google` / `gemini-2.0-flash`)
+- **Instructions**: editable system prompt (like judge rubric). Controls categorization, tagging strategy, and ranking criteria.
+- **Default**: use a fast, cheap model to minimize cost per run
+
+---
+
+## Topics
+
+User-defined categories for organizing news within a board.
+
+### Definition
+
+Each topic has:
+- **Name**: e.g., "AI Research", "Product Launches", "Open Source"
+- **Description**: optional context
+- **Tag filter**: JSON rule matching item tags. Example: `{"include": ["ai", "research"], "exclude": ["spam"]}`
+
+### Item → Topic Assignment
+
+After normalization, each news item's `tags` array is matched against topic filter rules. One item can appear in multiple topics.
+
+### "All" Topic
+
+Built-in, always present. Shows all news items ranked by `relevance_score` descending, no filter applied.
+
+### Topic Detail Page
+
+- Shows items matching the topic's tag filter
+- **Dynamic filters**: header chips showing all unique tags within the current topic. User clicks tags to further narrow results.
+- **Pagination**: configurable page size (default 20), sorted by `relevance_score` descending
+- **Each item shows**: title, summary, source name, relevance score, tags (as chips), published date, link to original source
+
+---
+
+## Load Balancing & Execution
+
+When a board run triggers (scheduled or manual):
+
+1. **Fetch sources**: ordered by priority (highest first). Each source returns max N items (per-source `max_items`, default 5).
+2. **Dedup**: hash items by URL + title (`SHA-256`), skip items already in `board_seen_item`.
+3. **Cap**: total items capped at board's `max_news_per_run` (default 100).
+4. **Assign to fighters**: respect fighter affinity on sources. For unaffiliated sources, round-robin by fighter priority.
+5. **Execute**: fighters process assigned items in parallel (bounded by provider RPM limits).
+6. **Fallback**: if a fighter fails on a source item, retry with its `fallback_fighter_id` (max 1 retry).
+7. **Normalize**: normalizer LLM converts all raw fighter outputs to standard news item schema. Classifies, tags, and ranks.
+8. **Assign to topics**: match each item's `tags` against board topic filters.
+9. **Store**: persist normalized items to `board_news_item` table, run metadata to `board_run`.
+10. **Publish**: if configured, push template HTML + `data.json` to GitHub Pages or export to local directory.
+
+---
+
+## Board
+
+A board ties together: sources (from pool), fighters, normalizer, topics, schedule, and publish config.
+
+### Properties
+
+- **Source selection**: by tags, individual source IDs, or "all active"
+- **Fighter selection**: pick from news fighters list (supports multiple fighters per board)
+- **Normalizer config**: provider + model + instructions
+- **Topics**: user-defined list with tag filter rules
+- **Schedule**: cron expression (e.g., `0 */6 * * *` = every 6 hours)
+- **Max news per run**: configurable, default 100
+- **Max history**: runs to keep, default 10 (older runs pruned)
+- **Template**: selected from bundled or user-custom templates
+- **Publish target**: GitHub Pages, static export, or none
+
+### Scheduling
+
+- In-process scheduler (APScheduler or asyncio-based) running inside FastAPI lifespan
+- Boards only run while the server is up
+- Manual "Run Now" button for immediate execution
+- Schedule toggle: active / paused
+
+---
+
+## Publishing
+
+### GitHub Pages
+
+- Push `index.html` (selected template) + `data.json` (latest board output) to a `gh-pages` branch of a configured GitHub repository
+- Config: `{"repo": "user/my-news", "branch": "gh-pages"}`
+- Requires `GH_TOKEN` with repo write access
+
+### Static Export
+
+- Generate `index.html` + `data.json` in a configurable local directory
+- Config: `{"output_dir": "/path/to/output"}`
+- Useful for serving via any static file server or embedding in other tools
+
+---
+
+## Templates
+
+### Bundled Templates
+
+Ship with 2 templates:
+1. **Card Grid** — responsive grid of news item cards with title, summary, score badge, and tags
+2. **News Feed List** — chronological feed with expandable summaries
+
+### User-Custom Templates
+
+- Drop HTML files in `~/.t01-llm-battle/templates/`
+- Template is a single HTML+Alpine.js file that loads `data.json` via fetch
+- Template receives the full board output JSON and renders it
+- Auto-discovered at startup, appears in template picker
+
+---
+
+## System Defaults ("Works Immediately")
+
+On first start, the system creates:
+
+- **4 system sources**: HN Top Stories, TechCrunch RSS, AI/ML News (Serper), GitHub Trending
+- **3 system fighters**: General News Summarizer, Tech Deep Dive, YouTube Analyzer
+- **1 default board** ("Tech News Daily"):
+  - All system sources
+  - General News Summarizer fighter
+  - Default normalizer (gemini-2.0-flash)
+  - 3 default topics: "AI & ML", "Developer Tools", "Industry News"
+  - Schedule: every 6 hours
+  - Not active by default (user activates after adding API keys)
+
+User workflow: add API keys → activate the default board → news starts flowing.
+
+---
+
+## Board UI
+
+### Sidebar
+
+New "Boards" section between Providers and Battles:
+- Board list with name + last run time
+- "+ New" button for board creation
+- Active/paused indicator per board
+
+### Board Creation Wizard
+
+1. **Name & description**
+2. **Select sources**: from pool by tags or individually
+3. **Select fighters**: from news fighters list
+4. **Configure normalizer**: provider + model + instructions (pre-filled default)
+5. **Define topics**: name + tag filter rules
+6. **Set schedule**: cron expression + max news per run
+7. **Configure publish** (optional): GitHub Pages or static export
+
+### Board View
+
+- **Topic tabs**: "All" + user-defined topics
+- **Topic page**: news items with dynamic tag filters, pagination, ranked by score
+- **Sidebar**: run history list, "Run Now" button, schedule toggle, settings
+- **Each item**: title, summary, source, score badge, tag chips, published date, source link


### PR DESCRIPTION
## Summary

- New `prd/08-news-boards.md` — full spec for News & Trending Boards feature
- Updated `01-prd.md` (vision, positioning, target users, architecture principles, doc index)
- Updated `02-tech-stack.md` (feedparser + APScheduler dependencies)
- Updated `03-functional-requirements.md` (FR-21 to FR-33)
- Updated `05-user-stories.md` (US-17 to US-24)
- Updated `06-data-models.md` (6 new tables: news_source, news_fighter, board, board_topic, board_run, board_news_item, board_seen_item)
- Updated `07-roadmap.md` (v0.2 scope + v0.3 future ideas)

## Test plan

- [ ] All PRD files are valid markdown
- [ ] New FR IDs (21-33) and US IDs (17-24) don't conflict with existing
- [ ] Data model FKs are valid (news_fighter.fighter_id → fighter.id)
- [ ] Cross-references between PRD files are consistent

🤖 Generated with [Claude Code](https://claude.com/claude-code)