### PR TITLE
fix: add rate limiter defaults for tool providers and lmstudio

### DIFF
--- a/t01_llm_battle/rate_limiter.py
+++ b/t01_llm_battle/rate_limiter.py
@@ -11,6 +11,10 @@ DEFAULT_RPM: dict[str, int] = {
     "groq": 30,
     "openrouter": 20,
     "ollama": 0,  # 0 = unlimited
+    "lmstudio": 0,  # local, unlimited
+    "serper": 10,   # free tier: ~600 req/month ≈ 10 RPM burst budget
+    "tavily": 10,   # free tier: ~1000 req/month ≈ 10 RPM burst budget
+    "firecrawl": 20,  # free tier: ~500 req/month ≈ 20 RPM burst budget
 }
 
 # Env var names for per-provider overrides
@@ -21,6 +25,10 @@ _ENV_VARS: dict[str, str] = {
     "groq": "T01_RPM_GROQ",
     "openrouter": "T01_RPM_OPENROUTER",
     "ollama": "T01_RPM_OLLAMA",
+    "lmstudio": "T01_RPM_LMSTUDIO",
+    "serper": "T01_RPM_SERPER",
+    "tavily": "T01_RPM_TAVILY",
+    "firecrawl": "T01_RPM_FIRECRAWL",
 }
 
 
@@ -43,7 +51,8 @@ class RateLimiter:
     Uses asyncio.sleep for backoff — never blocks the event loop.
     Limits are loaded from DEFAULT_RPM and can be overridden via env vars
     (T01_RPM_OPENAI, T01_RPM_ANTHROPIC, T01_RPM_GOOGLE, T01_RPM_GROQ,
-    T01_RPM_OPENROUTER, T01_RPM_OLLAMA).
+    T01_RPM_OPENROUTER, T01_RPM_OLLAMA, T01_RPM_LMSTUDIO,
+    T01_RPM_SERPER, T01_RPM_TAVILY, T01_RPM_FIRECRAWL).
     """
 
     def __init__(self, limits: dict[str, int] | None = None):

--- a/tests/test_rate_limiter.py
+++ b/tests/test_rate_limiter.py
@@ -26,6 +26,22 @@ def test_default_rpm_values():
     assert DEFAULT_RPM["groq"] == 30
     assert DEFAULT_RPM["openrouter"] == 20
     assert DEFAULT_RPM["ollama"] == 0  # unlimited
+    assert DEFAULT_RPM["lmstudio"] == 0  # local, unlimited
+    assert DEFAULT_RPM["serper"] == 10
+    assert DEFAULT_RPM["tavily"] == 10
+    assert DEFAULT_RPM["firecrawl"] == 20
+
+
+def test_tool_provider_env_var_overrides(monkeypatch):
+    monkeypatch.setenv("T01_RPM_SERPER", "5")
+    monkeypatch.setenv("T01_RPM_TAVILY", "3")
+    monkeypatch.setenv("T01_RPM_FIRECRAWL", "15")
+    monkeypatch.setenv("T01_RPM_LMSTUDIO", "0")
+    limits = _load_limits()
+    assert limits["serper"] == 5
+    assert limits["tavily"] == 3
+    assert limits["firecrawl"] == 15
+    assert limits["lmstudio"] == 0
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #250

Adds DEFAULT_RPM and _ENV_VARS entries for serper (10 RPM), tavily (10 RPM), firecrawl (20 RPM), and lmstudio (0/unlimited). Prevents quota exhaustion on free tiers.

## Changes
- rate_limiter.py: added tool providers and lmstudio to DEFAULT_RPM and _ENV_VARS
- test_rate_limiter.py: added test_tool_provider_env_var_overrides() and updated test_default_rpm_values()

## Acceptance Criteria
✓ serper has explicit RPM limit (10)
✓ tavily has explicit RPM limit (10)
✓ firecrawl has explicit RPM limit (20)
✓ lmstudio set to unlimited (0)
✓ env var overrides for all new providers
✓ all tests pass (108)