### PR TITLE
fix: Ollama models() uses DB-configured server_url

### DIFF
--- a/t01_llm_battle/providers/ollama.py
+++ b/t01_llm_battle/providers/ollama.py
@@ -1,9 +1,12 @@
+import sqlite3
+from pathlib import Path
+
 import httpx
 from pydantic_ai import Agent
 from pydantic_ai.models.openai import OpenAIChatModel
 from pydantic_ai.providers.openai import OpenAIProvider as PAIOpenAIProvider
 
-from ..db import resolve_base_url
+from ..db import DB_PATH, resolve_base_url
 from .base import BaseProvider, ProviderRequest, ProviderResult, ProviderType
 
 _DEFAULT_BASE_URL = "http://localhost:11434"
@@ -17,15 +20,32 @@ class OllamaProvider(BaseProvider):
     def __init__(self, base_url: str = _DEFAULT_BASE_URL) -> None:
         self.base_url = base_url.rstrip("/")
 
+    def _sync_base_url(self) -> str:
+        """Read DB-configured server_url synchronously; fall back to instance default."""
+        try:
+            db_path = Path(DB_PATH)
+            if db_path.exists():
+                con = sqlite3.connect(str(db_path))
+                row = con.execute(
+                    "SELECT server_url FROM provider_config WHERE provider = 'ollama'"
+                ).fetchone()
+                con.close()
+                if row and row[0]:
+                    return row[0].rstrip("/")
+        except Exception:
+            pass
+        return self.base_url
+
     async def _effective_base_url(self) -> str:
         """Return base_url from DB if configured, otherwise use instance default."""
         db_url = await resolve_base_url("ollama")
         return (db_url or self.base_url).rstrip("/")
 
     def models(self) -> list[str]:
-        """Query Ollama's /api/tags for installed models; return [] if not running."""
+        """Query Ollama's /api/tags for installed models using the DB-configured server URL."""
         try:
-            response = httpx.get(f"{self.base_url}/api/tags", timeout=5.0)
+            base_url = self._sync_base_url()
+            response = httpx.get(f"{base_url}/api/tags", timeout=5.0)
             if response.status_code != 200:
                 return []
             data = response.json()

--- a/tests/test_ollama_provider.py
+++ b/tests/test_ollama_provider.py
@@ -1,0 +1,73 @@
+"""Tests for OllamaProvider.models() using DB-configured server_url (FR-8)."""
+import sqlite3
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from t01_llm_battle.providers.ollama import OllamaProvider
+
+
+def test_models_uses_db_server_url(tmp_path):
+    """models() must query the DB-configured server_url, not the hardcoded default."""
+    db_path = tmp_path / "test.db"
+    con = sqlite3.connect(str(db_path))
+    con.execute(
+        "CREATE TABLE provider_config (provider TEXT PRIMARY KEY, server_url TEXT)"
+    )
+    con.execute(
+        "INSERT INTO provider_config (provider, server_url) VALUES ('ollama', 'http://custom-ollama:12345')"
+    )
+    con.commit()
+    con.close()
+
+    provider = OllamaProvider()
+
+    with patch("t01_llm_battle.providers.ollama.DB_PATH", db_path):
+        with patch("t01_llm_battle.providers.ollama.httpx.get") as mock_get:
+            mock_resp = MagicMock()
+            mock_resp.status_code = 200
+            mock_resp.json.return_value = {"models": [{"name": "llama3"}, {"name": "mistral"}]}
+            mock_get.return_value = mock_resp
+
+            result = provider.models()
+
+    # Verify custom URL was used
+    mock_get.assert_called_once_with("http://custom-ollama:12345/api/tags", timeout=5.0)
+    assert result == ["llama3", "mistral"]
+
+
+def test_models_falls_back_to_default_when_no_db_config(tmp_path):
+    """models() falls back to default URL when provider_config has no server_url."""
+    db_path = tmp_path / "test.db"
+    con = sqlite3.connect(str(db_path))
+    con.execute(
+        "CREATE TABLE provider_config (provider TEXT PRIMARY KEY, server_url TEXT)"
+    )
+    con.commit()
+    con.close()
+
+    provider = OllamaProvider(base_url="http://localhost:11434")
+
+    with patch("t01_llm_battle.providers.ollama.DB_PATH", db_path):
+        with patch("t01_llm_battle.providers.ollama.httpx.get") as mock_get:
+            mock_resp = MagicMock()
+            mock_resp.status_code = 200
+            mock_resp.json.return_value = {"models": []}
+            mock_get.return_value = mock_resp
+
+            result = provider.models()
+
+    mock_get.assert_called_once_with("http://localhost:11434/api/tags", timeout=5.0)
+    assert result == []
+
+
+def test_models_returns_empty_on_connection_error(tmp_path):
+    """models() returns [] if Ollama is not running."""
+    db_path = tmp_path / "empty.db"
+    provider = OllamaProvider()
+
+    with patch("t01_llm_battle.providers.ollama.DB_PATH", db_path):
+        with patch("t01_llm_battle.providers.ollama.httpx.get", side_effect=Exception("refused")):
+            result = provider.models()
+
+    assert result == []


### PR DESCRIPTION
Closes #249

OllamaProvider.models() was querying self.base_url (hardcoded default) instead of the DB-configured server URL set via the Providers UI.

Added _sync_base_url() that reads provider_config via sqlite3, so models() correctly reflects the user's configured Ollama endpoint.

## Test Coverage
- test_models_uses_db_server_url: verifies custom URL is used
- test_models_falls_back_to_default_when_no_db_config: fallback works
- test_models_returns_empty_on_connection_error: error handling

All 110 tests pass.