### PR TITLE
feat: Source pool — data source management for news boards

### DIFF
--- a/t01_llm_battle/db.py
+++ b/t01_llm_battle/db.py
@@ -102,6 +102,22 @@ CREATE TABLE IF NOT EXISTS provider_config (
     display_name TEXT,
     updated_at   TEXT NOT NULL
 );
+
+CREATE TABLE IF NOT EXISTS news_source (
+    id               TEXT PRIMARY KEY,
+    name             TEXT NOT NULL,
+    source_type      TEXT NOT NULL,
+    config           TEXT NOT NULL DEFAULT '{}',
+    tags             TEXT NOT NULL DEFAULT '[]',
+    priority         INTEGER NOT NULL DEFAULT 5,
+    max_items        INTEGER NOT NULL DEFAULT 20,
+    fighter_affinity TEXT,
+    is_system        INTEGER NOT NULL DEFAULT 0,
+    status           TEXT NOT NULL DEFAULT 'active',
+    last_error       TEXT,
+    created_at       TEXT NOT NULL,
+    updated_at       TEXT NOT NULL
+);
 """
 
 # Migrations for existing DBs
@@ -142,7 +158,73 @@ async def init_db(db_path: str | Path = DB_PATH) -> None:
             except Exception:
                 pass  # migration already applied
 
+    await _seed_system_news_sources(db_path)
     await _migrate_plaintext_keys(db_path)
+
+
+_SYSTEM_NEWS_SOURCES = [
+    {
+        "id": "sys-news-hn-top",
+        "name": "HN Top",
+        "source_type": "api",
+        "config": '{"url": "https://hacker-news.firebaseio.com/v0/topstories.json", "limit": 30}',
+        "tags": '["tech", "programming", "startups"]',
+        "priority": 8,
+        "max_items": 30,
+        "fighter_affinity": None,
+    },
+    {
+        "id": "sys-news-techcrunch-rss",
+        "name": "TechCrunch RSS",
+        "source_type": "rss",
+        "config": '{"url": "https://techcrunch.com/feed/"}',
+        "tags": '["tech", "startups", "vc"]',
+        "priority": 7,
+        "max_items": 20,
+        "fighter_affinity": None,
+    },
+    {
+        "id": "sys-news-ai-news-serper",
+        "name": "AI News (Serper)",
+        "source_type": "api",
+        "config": '{"query": "artificial intelligence news", "provider": "serper"}',
+        "tags": '["ai", "ml", "research"]',
+        "priority": 9,
+        "max_items": 20,
+        "fighter_affinity": None,
+    },
+    {
+        "id": "sys-news-github-trending",
+        "name": "GitHub Trending",
+        "source_type": "url",
+        "config": '{"url": "https://github.com/trending"}',
+        "tags": '["code", "opensource", "tech"]',
+        "priority": 6,
+        "max_items": 25,
+        "fighter_affinity": None,
+    },
+]
+
+
+async def _seed_system_news_sources(db_path: str | Path = DB_PATH) -> None:
+    """Insert system news sources if they don't exist yet."""
+    from datetime import datetime, timezone
+    now = datetime.now(timezone.utc).isoformat()
+
+    async with get_db(db_path) as db:
+        for src in _SYSTEM_NEWS_SOURCES:
+            cur = await db.execute("SELECT id FROM news_source WHERE id = ?", (src["id"],))
+            if await cur.fetchone() is None:
+                await db.execute(
+                    """INSERT INTO news_source
+                       (id, name, source_type, config, tags, priority, max_items,
+                        fighter_affinity, is_system, status, last_error, created_at, updated_at)
+                       VALUES (?, ?, ?, ?, ?, ?, ?, ?, 1, 'active', NULL, ?, ?)""",
+                    (src["id"], src["name"], src["source_type"], src["config"],
+                     src["tags"], src["priority"], src["max_items"],
+                     src["fighter_affinity"], now, now),
+                )
+        await db.commit()
 
 
 async def _migrate_plaintext_keys(db_path: str | Path = DB_PATH) -> None:

--- a/t01_llm_battle/routers/news_sources.py
+++ b/t01_llm_battle/routers/news_sources.py
@@ -1,0 +1,174 @@
+"""News Sources router — global source pool for news boards (FR-21, FR-30).
+
+GET    /news-sources               — list all sources
+POST   /news-sources               — create a source
+GET    /news-sources/{id}          — get one source
+PUT    /news-sources/{id}          — update a source
+DELETE /news-sources/{id}          — delete (system sources: 404)
+"""
+from __future__ import annotations
+
+import json
+import uuid
+from datetime import datetime, timezone
+from typing import Any
+
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel
+
+from ..db import get_db
+
+router = APIRouter(prefix="/news-sources", tags=["news-sources"])
+
+
+# ---------------------------------------------------------------------------
+# Pydantic models
+# ---------------------------------------------------------------------------
+
+class NewsSourceCreate(BaseModel):
+    name: str
+    source_type: str
+    config: dict[str, Any] = {}
+    tags: list[str] = []
+    priority: int = 5
+    max_items: int = 20
+    fighter_affinity: str | None = None
+
+
+class NewsSourceUpdate(BaseModel):
+    name: str | None = None
+    source_type: str | None = None
+    config: dict[str, Any] | None = None
+    tags: list[str] | None = None
+    priority: int | None = None
+    max_items: int | None = None
+    fighter_affinity: str | None = None
+    status: str | None = None
+
+
+class NewsSourceOut(BaseModel):
+    id: str
+    name: str
+    source_type: str
+    config: dict[str, Any]
+    tags: list[str]
+    priority: int
+    max_items: int
+    fighter_affinity: str | None
+    is_system: bool
+    status: str
+    last_error: str | None
+    created_at: str
+    updated_at: str
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _row_to_out(row) -> NewsSourceOut:
+    return NewsSourceOut(
+        id=row["id"],
+        name=row["name"],
+        source_type=row["source_type"],
+        config=json.loads(row["config"] or "{}"),
+        tags=json.loads(row["tags"] or "[]"),
+        priority=row["priority"],
+        max_items=row["max_items"],
+        fighter_affinity=row["fighter_affinity"],
+        is_system=bool(row["is_system"]),
+        status=row["status"],
+        last_error=row["last_error"],
+        created_at=row["created_at"],
+        updated_at=row["updated_at"],
+    )
+
+
+async def _get_or_404(source_id: str):
+    async with get_db() as db:
+        cur = await db.execute("SELECT * FROM news_source WHERE id = ?", (source_id,))
+        row = await cur.fetchone()
+    if row is None:
+        raise HTTPException(status_code=404, detail="News source not found")
+    return row
+
+
+# ---------------------------------------------------------------------------
+# Endpoints
+# ---------------------------------------------------------------------------
+
+@router.get("", response_model=list[NewsSourceOut])
+async def list_news_sources():
+    async with get_db() as db:
+        cur = await db.execute(
+            "SELECT * FROM news_source ORDER BY priority DESC, name ASC"
+        )
+        rows = await cur.fetchall()
+    return [_row_to_out(r) for r in rows]
+
+
+@router.post("", response_model=NewsSourceOut, status_code=201)
+async def create_news_source(body: NewsSourceCreate):
+    now = datetime.now(timezone.utc).isoformat()
+    src_id = str(uuid.uuid4())
+    async with get_db() as db:
+        await db.execute(
+            """INSERT INTO news_source
+               (id, name, source_type, config, tags, priority, max_items,
+                fighter_affinity, is_system, status, last_error, created_at, updated_at)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, 0, 'active', NULL, ?, ?)""",
+            (src_id, body.name, body.source_type,
+             json.dumps(body.config), json.dumps(body.tags),
+             body.priority, body.max_items, body.fighter_affinity, now, now),
+        )
+        await db.commit()
+        cur = await db.execute("SELECT * FROM news_source WHERE id = ?", (src_id,))
+        row = await cur.fetchone()
+    return _row_to_out(row)
+
+
+@router.get("/{source_id}", response_model=NewsSourceOut)
+async def get_news_source(source_id: str):
+    row = await _get_or_404(source_id)
+    return _row_to_out(row)
+
+
+@router.put("/{source_id}", response_model=NewsSourceOut)
+async def update_news_source(source_id: str, body: NewsSourceUpdate):
+    row = await _get_or_404(source_id)
+    now = datetime.now(timezone.utc).isoformat()
+
+    name = body.name if body.name is not None else row["name"]
+    source_type = body.source_type if body.source_type is not None else row["source_type"]
+    config = json.dumps(body.config) if body.config is not None else row["config"]
+    tags = json.dumps(body.tags) if body.tags is not None else row["tags"]
+    priority = body.priority if body.priority is not None else row["priority"]
+    max_items = body.max_items if body.max_items is not None else row["max_items"]
+    fighter_affinity = body.fighter_affinity if body.fighter_affinity is not None else row["fighter_affinity"]
+    status = body.status if body.status is not None else row["status"]
+
+    async with get_db() as db:
+        await db.execute(
+            """UPDATE news_source SET name=?, source_type=?, config=?, tags=?,
+               priority=?, max_items=?, fighter_affinity=?, status=?, updated_at=?
+               WHERE id=?""",
+            (name, source_type, config, tags, priority, max_items,
+             fighter_affinity, status, now, source_id),
+        )
+        await db.commit()
+        cur = await db.execute("SELECT * FROM news_source WHERE id = ?", (source_id,))
+        row = await cur.fetchone()
+    return _row_to_out(row)
+
+
+@router.delete("/{source_id}", status_code=204, response_model=None)
+async def delete_news_source(source_id: str):
+    row = await _get_or_404(source_id)
+    if row["is_system"]:
+        raise HTTPException(
+            status_code=403,
+            detail="System sources cannot be deleted. Set status='disabled' to deactivate.",
+        )
+    async with get_db() as db:
+        await db.execute("DELETE FROM news_source WHERE id = ?", (source_id,))
+        await db.commit()

--- a/t01_llm_battle/server.py
+++ b/t01_llm_battle/server.py
@@ -15,6 +15,7 @@ from .routers.sources import router as sources_router
 from .routers.fighters import router as fighters_router, providers_router
 from .routers.providers import router as provider_mgmt_router
 from .routers.templates import router as templates_router
+from .routers.news_sources import router as news_sources_router
 
 log = logging.getLogger(__name__)
 
@@ -49,6 +50,7 @@ def create_app(db_path=DB_PATH) -> FastAPI:
     app.include_router(providers_router)
     app.include_router(provider_mgmt_router)
     app.include_router(templates_router)
+    app.include_router(news_sources_router)
 
     # Health check
     @app.get("/healthz")

--- a/t01_llm_battle/static/index.html
+++ b/t01_llm_battle/static/index.html
@@ -499,6 +499,10 @@
           <span class="sidebar-section-title">Providers</span>
           <button class="btn-sidebar-new" @click="window.location.hash = '#/keys'">Manage</button>
         </div>
+        <div class="sidebar-section-header" style="margin-bottom:0;margin-top:0.4rem;">
+          <span class="sidebar-section-title">News Sources</span>
+          <button class="btn-sidebar-new" @click="window.location.hash = '#/news-sources'">Manage</button>
+        </div>
         <p class="text-muted" style="font-size:0.82rem;padding:2px 8px 4px;margin:0;"
            x-text="(function(){
              var active = providerInfoList.filter(function(p){ return p.has_key; });
@@ -1366,6 +1370,108 @@
         </template>
       </section>
 
+      <!-- ── News Sources ───────────────────────── -->
+      <section x-show="route === 'news-sources'" x-data="newsSources()" x-init="load()">
+        <div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:1.5rem;flex-wrap:wrap;gap:0.5rem;">
+          <h1 style="margin:0;">News Sources</h1>
+          <button class="btn-primary" @click="showAdd = true; resetForm()">+ Add Source</button>
+        </div>
+
+        <!-- Add source form -->
+        <template x-if="showAdd">
+          <div class="card" style="margin-bottom:1.5rem;">
+            <h3 style="margin:0 0 1rem;">New Source</h3>
+            <div class="form-grid-2">
+              <div>
+                <label class="form-label">Name *</label>
+                <input class="form-input" x-model="form.name" placeholder="My RSS Feed">
+              </div>
+              <div>
+                <label class="form-label">Type *</label>
+                <select class="form-input" x-model="form.source_type">
+                  <option value="url">URL</option>
+                  <option value="rss">RSS</option>
+                  <option value="api">API</option>
+                  <option value="social">Social</option>
+                </select>
+              </div>
+              <div>
+                <label class="form-label">Priority (1–10)</label>
+                <input class="form-input" type="number" min="1" max="10" x-model.number="form.priority">
+              </div>
+              <div>
+                <label class="form-label">Max Items</label>
+                <input class="form-input" type="number" min="1" x-model.number="form.max_items">
+              </div>
+              <div>
+                <label class="form-label">Tags (comma-separated)</label>
+                <input class="form-input" x-model="form.tags_input" placeholder="tech, ai, news">
+              </div>
+              <div>
+                <label class="form-label">Fighter Affinity (optional)</label>
+                <input class="form-input" x-model="form.fighter_affinity" placeholder="fighter-id">
+              </div>
+            </div>
+            <div style="margin-top:0.75rem;">
+              <label class="form-label">Config JSON</label>
+              <textarea class="form-input" rows="3" x-model="form.config_raw" placeholder='{"url": "https://example.com/feed"}'></textarea>
+            </div>
+            <div style="display:flex;gap:0.5rem;margin-top:1rem;">
+              <button class="btn-primary" @click="createSource()">Create</button>
+              <button class="btn-secondary" @click="showAdd = false">Cancel</button>
+            </div>
+            <template x-if="formError">
+              <p class="text-danger" style="margin-top:0.5rem;" x-text="formError"></p>
+            </template>
+          </div>
+        </template>
+
+        <template x-if="loading">
+          <p class="text-muted">Loading sources...</p>
+        </template>
+
+        <template x-if="!loading && sources.length === 0">
+          <p class="text-muted">No news sources yet.</p>
+        </template>
+
+        <!-- Sources table -->
+        <template x-if="sources.length > 0">
+          <div>
+            <template x-for="src in sources" :key="src.id">
+              <div class="card" style="margin-bottom:0.75rem;">
+                <div style="display:flex;align-items:flex-start;justify-content:space-between;gap:0.5rem;">
+                  <div style="flex:1;">
+                    <div style="display:flex;align-items:center;gap:0.5rem;flex-wrap:wrap;">
+                      <strong x-text="src.name"></strong>
+                      <span class="badge" x-text="src.source_type"></span>
+                      <span x-show="src.is_system" class="badge" style="background:var(--gold);color:#000;">system</span>
+                      <span x-show="src.status === 'disabled'" class="badge-muted">disabled</span>
+                      <span style="font-size:0.8rem;color:var(--mid);">priority: <span x-text="src.priority"></span></span>
+                      <span style="font-size:0.8rem;color:var(--mid);">max: <span x-text="src.max_items"></span></span>
+                    </div>
+                    <div style="margin-top:0.3rem;font-size:0.8rem;color:var(--mid);" x-show="src.tags && src.tags.length > 0">
+                      Tags: <span x-text="src.tags.join(', ')"></span>
+                    </div>
+                    <div style="margin-top:0.2rem;font-size:0.8rem;color:var(--mid);" x-show="src.fighter_affinity">
+                      Affinity: <span x-text="src.fighter_affinity"></span>
+                    </div>
+                    <div style="margin-top:0.3rem;font-size:0.75rem;color:var(--danger);" x-show="src.last_error" x-text="'Error: ' + src.last_error"></div>
+                  </div>
+                  <div style="display:flex;gap:0.4rem;flex-shrink:0;">
+                    <button class="btn-secondary" style="font-size:0.8rem;padding:3px 10px;"
+                            @click="toggleDisable(src)">
+                      <span x-text="src.status === 'disabled' ? 'Enable' : 'Disable'"></span>
+                    </button>
+                    <button x-show="!src.is_system" class="btn-secondary" style="font-size:0.8rem;padding:3px 10px;color:var(--danger);"
+                            @click="deleteSource(src.id)">Delete</button>
+                  </div>
+                </div>
+              </div>
+            </template>
+          </div>
+        </template>
+      </section>
+
       <!-- ── 404 ────────────────────────────────── -->
       <section x-show="route === 'not-found'">
         <h1>Page not found</h1>
@@ -2214,6 +2320,8 @@ Do not wrap the JSON in markdown fences.`;
             this.route = 'results/detail'; this.params = { id: parts[1] };
           } else if (parts[0] === 'keys') {
             this.route = 'keys'; this.params = {};
+          } else if (parts[0] === 'news-sources') {
+            this.route = 'news-sources'; this.params = {};
           } else {
             this.route = 'not-found'; this.params = {};
           }
@@ -2222,6 +2330,68 @@ Do not wrap the JSON in markdown fences.`;
         navigate(hash) {
           window.location.hash = hash;
         }
+      };
+    }
+
+    function newsSources() {
+      return {
+        sources: [],
+        loading: false,
+        showAdd: false,
+        formError: null,
+        form: { name: '', source_type: 'rss', priority: 5, max_items: 20, tags_input: '', fighter_affinity: '', config_raw: '{}' },
+
+        resetForm() {
+          this.form = { name: '', source_type: 'rss', priority: 5, max_items: 20, tags_input: '', fighter_affinity: '', config_raw: '{}' };
+          this.formError = null;
+        },
+
+        async load() {
+          this.loading = true;
+          try {
+            const resp = await fetch('/news-sources');
+            this.sources = await resp.json();
+          } finally {
+            this.loading = false;
+          }
+        },
+
+        async createSource() {
+          this.formError = null;
+          let config = {};
+          try { config = JSON.parse(this.form.config_raw || '{}'); } catch(e) { this.formError = 'Invalid JSON in Config'; return; }
+          const tags = this.form.tags_input.split(',').map(t => t.trim()).filter(Boolean);
+          const body = {
+            name: this.form.name,
+            source_type: this.form.source_type,
+            priority: this.form.priority,
+            max_items: this.form.max_items,
+            tags,
+            fighter_affinity: this.form.fighter_affinity || null,
+            config,
+          };
+          const resp = await fetch('/news-sources', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(body) });
+          if (resp.ok) {
+            this.showAdd = false;
+            this.resetForm();
+            await this.load();
+          } else {
+            const err = await resp.json();
+            this.formError = err.detail || 'Create failed';
+          }
+        },
+
+        async toggleDisable(src) {
+          const newStatus = src.status === 'disabled' ? 'active' : 'disabled';
+          await fetch('/news-sources/' + src.id, { method: 'PUT', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ status: newStatus }) });
+          await this.load();
+        },
+
+        async deleteSource(id) {
+          if (!confirm('Delete this source?')) return;
+          await fetch('/news-sources/' + id, { method: 'DELETE' });
+          await this.load();
+        },
       };
     }
   </script>

--- a/tests/test_news_sources_router.py
+++ b/tests/test_news_sources_router.py
@@ -1,0 +1,184 @@
+"""Tests for /news-sources CRUD router."""
+from __future__ import annotations
+
+import uuid
+from contextlib import asynccontextmanager
+
+import pytest
+import t01_llm_battle.db as db_module
+import t01_llm_battle.routers.news_sources as news_sources_module
+from httpx import AsyncClient, ASGITransport
+from t01_llm_battle.db import get_db, init_db
+from t01_llm_battle.server import create_app
+
+
+@pytest.fixture
+async def db_path(tmp_path):
+    path = str(tmp_path / "test.db")
+    await init_db(path)
+    return path
+
+
+@pytest.fixture
+async def client(db_path, monkeypatch):
+    _db_path = db_path
+
+    @asynccontextmanager
+    async def _get_db_override(path=None):
+        async with get_db(_db_path) as db:
+            yield db
+
+    monkeypatch.setattr(db_module, "DB_PATH", _db_path)
+    monkeypatch.setattr(news_sources_module, "get_db", _get_db_override)
+
+    app = create_app(db_path=db_path)
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        yield c
+
+
+# ---------------------------------------------------------------------------
+# System sources seeded on init
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_system_sources_seeded_on_init(client):
+    resp = await client.get("/news-sources")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert len(data) == 4
+    names = {s["name"] for s in data}
+    assert names == {"HN Top", "TechCrunch RSS", "AI News (Serper)", "GitHub Trending"}
+    for src in data:
+        assert src["is_system"] is True
+
+
+# ---------------------------------------------------------------------------
+# CRUD for user sources
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_create_news_source(client):
+    resp = await client.post("/news-sources", json={
+        "name": "My Blog RSS",
+        "source_type": "rss",
+        "config": {"url": "https://example.com/feed"},
+        "tags": ["blog", "personal"],
+        "priority": 3,
+        "max_items": 10,
+    })
+    assert resp.status_code == 201
+    data = resp.json()
+    assert data["name"] == "My Blog RSS"
+    assert data["source_type"] == "rss"
+    assert data["tags"] == ["blog", "personal"]
+    assert data["priority"] == 3
+    assert data["max_items"] == 10
+    assert data["is_system"] is False
+    assert data["status"] == "active"
+    assert data["config"] == {"url": "https://example.com/feed"}
+
+
+@pytest.mark.asyncio
+async def test_get_news_source(client):
+    create_resp = await client.post("/news-sources", json={
+        "name": "Test Source",
+        "source_type": "url",
+    })
+    src_id = create_resp.json()["id"]
+
+    resp = await client.get(f"/news-sources/{src_id}")
+    assert resp.status_code == 200
+    assert resp.json()["id"] == src_id
+    assert resp.json()["name"] == "Test Source"
+
+
+@pytest.mark.asyncio
+async def test_get_nonexistent_source_returns_404(client):
+    resp = await client.get(f"/news-sources/{uuid.uuid4()}")
+    assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_update_news_source(client):
+    create_resp = await client.post("/news-sources", json={
+        "name": "Old Name",
+        "source_type": "rss",
+        "priority": 5,
+        "max_items": 10,
+        "tags": [],
+    })
+    src_id = create_resp.json()["id"]
+
+    resp = await client.put(f"/news-sources/{src_id}", json={
+        "name": "New Name",
+        "priority": 9,
+        "tags": ["updated"],
+        "fighter_affinity": "fighter-abc",
+    })
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["name"] == "New Name"
+    assert data["priority"] == 9
+    assert data["tags"] == ["updated"]
+    assert data["fighter_affinity"] == "fighter-abc"
+    # unchanged fields preserved
+    assert data["source_type"] == "rss"
+    assert data["max_items"] == 10
+
+
+@pytest.mark.asyncio
+async def test_delete_user_source(client):
+    create_resp = await client.post("/news-sources", json={
+        "name": "To Delete",
+        "source_type": "url",
+    })
+    src_id = create_resp.json()["id"]
+
+    del_resp = await client.delete(f"/news-sources/{src_id}")
+    assert del_resp.status_code == 204
+
+    get_resp = await client.get(f"/news-sources/{src_id}")
+    assert get_resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_delete_system_source_returns_403(client):
+    """System sources cannot be deleted."""
+    list_resp = await client.get("/news-sources")
+    system_src = next(s for s in list_resp.json() if s["is_system"])
+
+    resp = await client.delete(f"/news-sources/{system_src['id']}")
+    assert resp.status_code == 403
+
+
+# ---------------------------------------------------------------------------
+# Configurable fields
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_tags_priority_max_items_fighter_affinity_configurable(client):
+    resp = await client.post("/news-sources", json={
+        "name": "Configurable Source",
+        "source_type": "api",
+        "tags": ["ai", "ml"],
+        "priority": 8,
+        "max_items": 50,
+        "fighter_affinity": "my-fighter",
+    })
+    assert resp.status_code == 201
+    data = resp.json()
+    assert data["tags"] == ["ai", "ml"]
+    assert data["priority"] == 8
+    assert data["max_items"] == 50
+    assert data["fighter_affinity"] == "my-fighter"
+
+
+@pytest.mark.asyncio
+async def test_update_status_to_disabled(client):
+    """System sources can be disabled (not deleted)."""
+    list_resp = await client.get("/news-sources")
+    system_src = next(s for s in list_resp.json() if s["is_system"])
+
+    resp = await client.put(f"/news-sources/{system_src['id']}", json={"status": "disabled"})
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "disabled"


### PR DESCRIPTION
Implements global source pool for news boards (FR-21, FR-30).

## Summary
- New `news_source` table in SQLite schema
- 4 system sources seeded on first start: HN Top, TechCrunch RSS, AI News (Serper), GitHub Trending
- CRUD API: GET/POST /news-sources, GET/PUT/DELETE /news-sources/{id}
- System sources protected from deletion (403); can be disabled via PUT
- Tags, priority, max_items, fighter_affinity all configurable
- Sources management UI with add form, list, disable/delete actions
- 9 new tests; full suite 140 passed

## Acceptance Criteria
- [x] CRUD API for news sources works
- [x] 4 system sources created on first start
- [x] Source management UI functional
- [x] Tags, priority, max_items, fighter_affinity all configurable
- [x] System sources cannot be deleted (only disabled)

Closes #258

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>