### PR TITLE
fix: align default CLI port to 7979 (was 7878)

### DIFF
--- a/prd/01-prd.md
+++ b/prd/01-prd.md
@@ -52,7 +52,7 @@ After running, the final output of each fighter is judged side-by-side: quality 
 
 **In scope**
 
-- CLI that starts a local FastAPI server on a configurable port (default 7878) and opens the browser
+- CLI that starts a local FastAPI server on a configurable port (default 7979) and opens the browser
 - Single-page web UI (Alpine.js, no build step): sidebar layout with battle list + provider management on the left, battle detail on the right; Paper Light brand theme
 - **Battle creation**:
   - Name + judge config (provider, model, rubric)

--- a/prd/03-functional-requirements.md
+++ b/prd/03-functional-requirements.md
@@ -2,7 +2,7 @@
 
 | # | Area | Summary |
 |---|------|---------|
-| FR-1 | CLI & Server | `t01-llm-battle serve` starts FastAPI on port 7878, opens browser |
+| FR-1 | CLI & Server | `t01-llm-battle serve` starts FastAPI on port 7979, opens browser |
 | FR-2 | Battle Creation | Name, sources, fighters (multi-step pipelines or manual), judge config (optional) |
 | FR-3 | Sources | Upload text/md files or a CSV; each file or CSV row = one input item |
 | FR-4 | Fighters & Steps | Named pipelines; each step has system prompt, provider, model, config |

--- a/prd/05-user-stories.md
+++ b/prd/05-user-stories.md
@@ -23,7 +23,7 @@
 
 ## Key Workflow: Multi-Step Pipeline Battle (US-1)
 
-1. `pipx install t01-llm-battle && t01-llm-battle serve` → browser opens at `localhost:7878`
+1. `pipx install t01-llm-battle && t01-llm-battle serve` → browser opens at `localhost:7979`
 2. Click **New Battle**
 3. Enter name + judge config (provider, model, rubric)
 4. **Add sources**: upload `cases.csv` (10 rows → 10 source items)

--- a/t01_llm_battle/cli.py
+++ b/t01_llm_battle/cli.py
@@ -6,7 +6,7 @@ app = typer.Typer(help="LLM Battle Arena — compare LLMs side by side.")
 
 @app.command()
 def serve(
-    port: int = typer.Option(7878, help="Port to listen on"),
+    port: int = typer.Option(7979, help="Port to listen on"),
     no_browser: bool = typer.Option(False, "--no-browser", help="Don't open browser"),
 ) -> None:
     """Start the LLM Battle server."""


### PR DESCRIPTION
Closes #270

## Summary
- CLI default port: 7878 → 7979
- Updated PRD (01-prd.md, 03-functional-requirements.md, 05-user-stories.md)
- Tests: 140 passed

Resolves inconsistency between CLI and automation tooling (heartbeat, battle-dev-app, battle-discover).