### PR TITLE
fix: guard fetchStatus against undefined runId

### DIFF
--- a/t01_llm_battle/static/index.html
+++ b/t01_llm_battle/static/index.html
@@ -2131,6 +2131,7 @@ Do not wrap the JSON in markdown fences.`;
         },
 
         async fetchStatus() {
+          if (!this.runId) return;
           try {
             const resp = await fetch('/runs/' + this.runId + '/status');
             if (!resp.ok) throw new Error(await resp.text());


### PR DESCRIPTION
Closes #269

## Summary
- Added guard: `if (!this.runId) return;` in fetchStatus()
- Prevents spurious 404 errors on initial page load
- Tests: 140 passed

Fixes polling logic firing when no run is active.