### PR TITLE
feat: news fighters — CRUD, promotion, fallback chain

### DIFF
--- a/t01_llm_battle/db.py
+++ b/t01_llm_battle/db.py
@@ -118,6 +118,17 @@ CREATE TABLE IF NOT EXISTS news_source (
     created_at       TEXT NOT NULL,
     updated_at       TEXT NOT NULL
 );
+
+CREATE TABLE IF NOT EXISTS news_fighter (
+    id                  TEXT PRIMARY KEY,
+    fighter_id          TEXT NOT NULL REFERENCES fighter(id),
+    name                TEXT NOT NULL,
+    fallback_fighter_id TEXT REFERENCES news_fighter(id),
+    priority            INTEGER NOT NULL DEFAULT 5,
+    is_system           INTEGER NOT NULL DEFAULT 0,
+    created_at          TEXT NOT NULL,
+    updated_at          TEXT NOT NULL
+);
 """
 
 # Migrations for existing DBs
@@ -159,6 +170,7 @@ async def init_db(db_path: str | Path = DB_PATH) -> None:
                 pass  # migration already applied
 
     await _seed_system_news_sources(db_path)
+    await _seed_system_news_fighters(db_path)
     await _migrate_plaintext_keys(db_path)
 
 
@@ -224,6 +236,83 @@ async def _seed_system_news_sources(db_path: str | Path = DB_PATH) -> None:
                      src["tags"], src["priority"], src["max_items"],
                      src["fighter_affinity"], now, now),
                 )
+        await db.commit()
+
+
+# System news fighters: each needs a dummy battle + fighter + step, then a news_fighter row.
+_SYSTEM_NEWS_FIGHTERS = [
+    {
+        "id": "sys-nf-general-summarizer",
+        "fighter_id": "sys-nf-fighter-general-summarizer",
+        "name": "General Summarizer",
+        "priority": 8,
+        "system_prompt": "Summarize the following news article in 3 bullet points.",
+        "provider": "openai",
+        "model_id": "gpt-4o-mini",
+    },
+    {
+        "id": "sys-nf-tech-deep-dive",
+        "fighter_id": "sys-nf-fighter-tech-deep-dive",
+        "name": "Tech Deep Dive",
+        "priority": 7,
+        "system_prompt": "Analyze the technical aspects of this article. What are the key innovations and implications?",
+        "provider": "openai",
+        "model_id": "gpt-4o",
+    },
+    {
+        "id": "sys-nf-youtube-analyzer",
+        "fighter_id": "sys-nf-fighter-youtube-analyzer",
+        "name": "YouTube Analyzer",
+        "priority": 6,
+        "system_prompt": "Summarize this YouTube video content, focusing on key takeaways and actionable insights.",
+        "provider": "openai",
+        "model_id": "gpt-4o-mini",
+    },
+]
+
+_SYS_BATTLE_ID = "sys-news-fighters-battle"
+
+
+async def _seed_system_news_fighters(db_path: str | Path = DB_PATH) -> None:
+    """Insert system news fighters (and their battle/fighter/step rows) if not present."""
+    from datetime import datetime, timezone
+    now = datetime.now(timezone.utc).isoformat()
+
+    async with get_db(db_path) as db:
+        # Ensure system battle exists (no FK enforcement during seeding)
+        cur = await db.execute("SELECT id FROM battle WHERE id = ?", (_SYS_BATTLE_ID,))
+        if await cur.fetchone() is None:
+            await db.execute(
+                "INSERT INTO battle (id, name, created_at) VALUES (?, ?, ?)",
+                (_SYS_BATTLE_ID, "System News Fighters", now),
+            )
+
+        for nf in _SYSTEM_NEWS_FIGHTERS:
+            # Skip if news_fighter already seeded
+            cur = await db.execute("SELECT id FROM news_fighter WHERE id = ?", (nf["id"],))
+            if await cur.fetchone() is not None:
+                continue
+
+            # Create fighter row
+            cur = await db.execute("SELECT id FROM fighter WHERE id = ?", (nf["fighter_id"],))
+            if await cur.fetchone() is None:
+                await db.execute(
+                    "INSERT INTO fighter (id, battle_id, name, is_manual, position, created_at) VALUES (?, ?, ?, 0, 0, ?)",
+                    (nf["fighter_id"], _SYS_BATTLE_ID, nf["name"], now),
+                )
+                step_id = "sys-nf-step-" + nf["id"]
+                await db.execute(
+                    """INSERT INTO fighter_step (id, fighter_id, position, system_prompt, provider, model_id, provider_config, created_at)
+                       VALUES (?, ?, 0, ?, ?, ?, '{}', ?)""",
+                    (step_id, nf["fighter_id"], nf["system_prompt"], nf["provider"], nf["model_id"], now),
+                )
+
+            await db.execute(
+                """INSERT INTO news_fighter (id, fighter_id, name, fallback_fighter_id, priority, is_system, created_at, updated_at)
+                   VALUES (?, ?, ?, NULL, ?, 1, ?, ?)""",
+                (nf["id"], nf["fighter_id"], nf["name"], nf["priority"], now, now),
+            )
+
         await db.commit()
 
 

--- a/t01_llm_battle/routers/news_fighters.py
+++ b/t01_llm_battle/routers/news_fighters.py
@@ -1,0 +1,180 @@
+"""News Fighters router — promotion from battle fighters (FR-22, FR-33).
+
+GET    /news-fighters                          — list all news fighters
+POST   /news-fighters                          — create a news fighter
+GET    /news-fighters/{id}                     — get one news fighter
+PUT    /news-fighters/{id}                     — update name/priority/fallback
+DELETE /news-fighters/{id}                     — delete (system fighters: 403)
+POST   /news-fighters/from-battle/{fighter_id} — promote battle fighter
+"""
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+from typing import Any
+
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel, model_validator
+
+from ..db import get_db
+
+_UNSET = object()
+
+router = APIRouter(prefix="/news-fighters", tags=["news-fighters"])
+
+
+class NewsFighterCreate(BaseModel):
+    fighter_id: str
+    name: str
+    fallback_fighter_id: str | None = None
+    priority: int = 5
+
+
+_SENTINEL = "__unset__"
+
+
+class NewsFighterUpdate(BaseModel):
+    name: str | None = None
+    # Use sentinel string to distinguish "not provided" from explicit null
+    fallback_fighter_id: str | None = _SENTINEL  # type: ignore[assignment]
+    priority: int | None = None
+
+
+class NewsFighterOut(BaseModel):
+    id: str
+    fighter_id: str
+    name: str
+    fallback_fighter_id: str | None
+    priority: int
+    is_system: bool
+    created_at: str
+    updated_at: str
+
+
+def _row_to_out(row) -> NewsFighterOut:
+    return NewsFighterOut(
+        id=row["id"],
+        fighter_id=row["fighter_id"],
+        name=row["name"],
+        fallback_fighter_id=row["fallback_fighter_id"],
+        priority=row["priority"],
+        is_system=bool(row["is_system"]),
+        created_at=row["created_at"],
+        updated_at=row["updated_at"],
+    )
+
+
+async def _get_or_404(nf_id: str):
+    async with get_db() as db:
+        cur = await db.execute("SELECT * FROM news_fighter WHERE id = ?", (nf_id,))
+        row = await cur.fetchone()
+    if row is None:
+        raise HTTPException(status_code=404, detail="News fighter not found")
+    return row
+
+
+@router.get("", response_model=list[NewsFighterOut])
+async def list_news_fighters():
+    async with get_db() as db:
+        cur = await db.execute(
+            "SELECT * FROM news_fighter ORDER BY priority DESC, name ASC"
+        )
+        rows = await cur.fetchall()
+    return [_row_to_out(r) for r in rows]
+
+
+@router.post("", response_model=NewsFighterOut, status_code=201)
+async def create_news_fighter(body: NewsFighterCreate):
+    now = datetime.now(timezone.utc).isoformat()
+    nf_id = str(uuid.uuid4())
+    async with get_db() as db:
+        # Verify fighter exists
+        cur = await db.execute("SELECT id FROM fighter WHERE id = ?", (body.fighter_id,))
+        if await cur.fetchone() is None:
+            raise HTTPException(status_code=404, detail="Battle fighter not found")
+        await db.execute(
+            """INSERT INTO news_fighter (id, fighter_id, name, fallback_fighter_id, priority, is_system, created_at, updated_at)
+               VALUES (?, ?, ?, ?, ?, 0, ?, ?)""",
+            (nf_id, body.fighter_id, body.name, body.fallback_fighter_id, body.priority, now, now),
+        )
+        await db.commit()
+        cur = await db.execute("SELECT * FROM news_fighter WHERE id = ?", (nf_id,))
+        row = await cur.fetchone()
+    return _row_to_out(row)
+
+
+@router.get("/{nf_id}", response_model=NewsFighterOut)
+async def get_news_fighter(nf_id: str):
+    return _row_to_out(await _get_or_404(nf_id))
+
+
+@router.put("/{nf_id}", response_model=NewsFighterOut)
+async def update_news_fighter(nf_id: str, body: NewsFighterUpdate):
+    row = await _get_or_404(nf_id)
+    now = datetime.now(timezone.utc).isoformat()
+    name = body.name if body.name is not None else row["name"]
+    fallback = row["fallback_fighter_id"] if body.fallback_fighter_id == _SENTINEL else body.fallback_fighter_id
+    priority = body.priority if body.priority is not None else row["priority"]
+    async with get_db() as db:
+        await db.execute(
+            "UPDATE news_fighter SET name=?, fallback_fighter_id=?, priority=?, updated_at=? WHERE id=?",
+            (name, fallback, priority, now, nf_id),
+        )
+        await db.commit()
+        cur = await db.execute("SELECT * FROM news_fighter WHERE id = ?", (nf_id,))
+        row = await cur.fetchone()
+    return _row_to_out(row)
+
+
+@router.delete("/{nf_id}", status_code=204, response_model=None)
+async def delete_news_fighter(nf_id: str):
+    row = await _get_or_404(nf_id)
+    if row["is_system"]:
+        raise HTTPException(status_code=403, detail="System fighters cannot be deleted.")
+    async with get_db() as db:
+        await db.execute("DELETE FROM news_fighter WHERE id = ?", (nf_id,))
+        await db.commit()
+
+
+@router.post("/from-battle/{fighter_id}", response_model=NewsFighterOut, status_code=201)
+async def promote_from_battle(fighter_id: str):
+    """Copy a battle fighter + its steps into a standalone news fighter."""
+    now = datetime.now(timezone.utc).isoformat()
+    async with get_db() as db:
+        cur = await db.execute("SELECT * FROM fighter WHERE id = ?", (fighter_id,))
+        src = await cur.fetchone()
+        if src is None:
+            raise HTTPException(status_code=404, detail="Battle fighter not found")
+
+        # Copy fighter row
+        new_fighter_id = str(uuid.uuid4())
+        await db.execute(
+            "INSERT INTO fighter (id, battle_id, name, is_manual, position, created_at) VALUES (?, ?, ?, ?, ?, ?)",
+            (new_fighter_id, src["battle_id"], src["name"] + " (news)", src["is_manual"], src["position"], now),
+        )
+
+        # Copy steps
+        cur = await db.execute(
+            "SELECT * FROM fighter_step WHERE fighter_id = ? ORDER BY position ASC", (fighter_id,)
+        )
+        steps = await cur.fetchall()
+        for step in steps:
+            new_step_id = str(uuid.uuid4())
+            await db.execute(
+                """INSERT INTO fighter_step (id, fighter_id, position, system_prompt, provider, model_id, provider_config, created_at)
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?)""",
+                (new_step_id, new_fighter_id, step["position"], step["system_prompt"],
+                 step["provider"], step["model_id"], step["provider_config"], now),
+            )
+
+        # Create news_fighter record
+        nf_id = str(uuid.uuid4())
+        await db.execute(
+            """INSERT INTO news_fighter (id, fighter_id, name, fallback_fighter_id, priority, is_system, created_at, updated_at)
+               VALUES (?, ?, ?, NULL, 5, 0, ?, ?)""",
+            (nf_id, new_fighter_id, src["name"], now, now),
+        )
+        await db.commit()
+        cur = await db.execute("SELECT * FROM news_fighter WHERE id = ?", (nf_id,))
+        row = await cur.fetchone()
+    return _row_to_out(row)

--- a/t01_llm_battle/server.py
+++ b/t01_llm_battle/server.py
@@ -16,6 +16,7 @@ from .routers.fighters import router as fighters_router, providers_router
 from .routers.providers import router as provider_mgmt_router
 from .routers.templates import router as templates_router
 from .routers.news_sources import router as news_sources_router
+from .routers.news_fighters import router as news_fighters_router
 
 log = logging.getLogger(__name__)
 
@@ -51,6 +52,7 @@ def create_app(db_path=DB_PATH) -> FastAPI:
     app.include_router(provider_mgmt_router)
     app.include_router(templates_router)
     app.include_router(news_sources_router)
+    app.include_router(news_fighters_router)
 
     # Health check
     @app.get("/healthz")

--- a/tests/test_news_fighters_router.py
+++ b/tests/test_news_fighters_router.py
@@ -1,0 +1,217 @@
+"""Tests for /news-fighters CRUD router (FR-22, FR-33)."""
+from __future__ import annotations
+
+import uuid
+from contextlib import asynccontextmanager
+
+import pytest
+import t01_llm_battle.db as db_module
+import t01_llm_battle.routers.news_fighters as news_fighters_module
+from httpx import AsyncClient, ASGITransport
+from t01_llm_battle.db import get_db, init_db
+from t01_llm_battle.server import create_app
+
+
+@pytest.fixture
+async def db_path(tmp_path):
+    path = str(tmp_path / "test.db")
+    await init_db(path)
+    return path
+
+
+@pytest.fixture
+async def client(db_path, monkeypatch):
+    _db_path = db_path
+
+    @asynccontextmanager
+    async def _get_db_override(path=None):
+        async with get_db(_db_path) as db:
+            yield db
+
+    monkeypatch.setattr(db_module, "DB_PATH", _db_path)
+    monkeypatch.setattr(news_fighters_module, "get_db", _get_db_override)
+
+    app = create_app(db_path=db_path)
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        yield c
+
+
+# ---------------------------------------------------------------------------
+# System fighters seeded on init
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_system_fighters_seeded_on_init(client):
+    resp = await client.get("/news-fighters")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert len(data) == 3
+    names = {f["name"] for f in data}
+    assert names == {"General Summarizer", "Tech Deep Dive", "YouTube Analyzer"}
+    for f in data:
+        assert f["is_system"] is True
+
+
+# ---------------------------------------------------------------------------
+# CRUD
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_create_news_fighter(client, db_path):
+    # Create a battle + fighter first
+    async with get_db(db_path) as db:
+        battle_id = str(uuid.uuid4())
+        fighter_id = str(uuid.uuid4())
+        from datetime import datetime, timezone
+        now = datetime.now(timezone.utc).isoformat()
+        await db.execute(
+            "INSERT INTO battle (id, name, created_at) VALUES (?, ?, ?)",
+            (battle_id, "Test Battle", now),
+        )
+        await db.execute(
+            "INSERT INTO fighter (id, battle_id, name, is_manual, position, created_at) VALUES (?, ?, ?, 0, 0, ?)",
+            (fighter_id, battle_id, "My Fighter", now),
+        )
+        await db.commit()
+
+    resp = await client.post("/news-fighters", json={
+        "fighter_id": fighter_id,
+        "name": "My News Fighter",
+        "priority": 6,
+    })
+    assert resp.status_code == 201
+    data = resp.json()
+    assert data["name"] == "My News Fighter"
+    assert data["priority"] == 6
+    assert data["is_system"] is False
+    assert data["fighter_id"] == fighter_id
+
+
+@pytest.mark.asyncio
+async def test_get_news_fighter(client):
+    resp = await client.get("/news-fighters")
+    nf_id = resp.json()[0]["id"]
+    resp2 = await client.get(f"/news-fighters/{nf_id}")
+    assert resp2.status_code == 200
+    assert resp2.json()["id"] == nf_id
+
+
+@pytest.mark.asyncio
+async def test_update_news_fighter_priority(client):
+    resp = await client.get("/news-fighters")
+    # Pick a system fighter to update priority
+    nf = resp.json()[0]
+    nf_id = nf["id"]
+    old_priority = nf["priority"]
+    new_priority = old_priority + 1
+
+    resp2 = await client.put(f"/news-fighters/{nf_id}", json={"priority": new_priority})
+    assert resp2.status_code == 200
+    assert resp2.json()["priority"] == new_priority
+
+
+@pytest.mark.asyncio
+async def test_delete_system_fighter_forbidden(client):
+    resp = await client.get("/news-fighters")
+    sys_nf = next(f for f in resp.json() if f["is_system"])
+    resp2 = await client.delete(f"/news-fighters/{sys_nf['id']}")
+    assert resp2.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_delete_user_fighter(client, db_path):
+    async with get_db(db_path) as db:
+        battle_id = str(uuid.uuid4())
+        fighter_id = str(uuid.uuid4())
+        from datetime import datetime, timezone
+        now = datetime.now(timezone.utc).isoformat()
+        await db.execute(
+            "INSERT INTO battle (id, name, created_at) VALUES (?, ?, ?)",
+            (battle_id, "Test Battle", now),
+        )
+        await db.execute(
+            "INSERT INTO fighter (id, battle_id, name, is_manual, position, created_at) VALUES (?, ?, ?, 0, 0, ?)",
+            (fighter_id, battle_id, "Test Fighter", now),
+        )
+        await db.commit()
+
+    resp = await client.post("/news-fighters", json={
+        "fighter_id": fighter_id,
+        "name": "Deletable Fighter",
+        "priority": 3,
+    })
+    nf_id = resp.json()["id"]
+    resp2 = await client.delete(f"/news-fighters/{nf_id}")
+    assert resp2.status_code == 204
+
+    resp3 = await client.get(f"/news-fighters/{nf_id}")
+    assert resp3.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_promote_from_battle(client, db_path):
+    async with get_db(db_path) as db:
+        battle_id = str(uuid.uuid4())
+        fighter_id = str(uuid.uuid4())
+        step_id = str(uuid.uuid4())
+        from datetime import datetime, timezone
+        now = datetime.now(timezone.utc).isoformat()
+        await db.execute(
+            "INSERT INTO battle (id, name, created_at) VALUES (?, ?, ?)",
+            (battle_id, "Promo Battle", now),
+        )
+        await db.execute(
+            "INSERT INTO fighter (id, battle_id, name, is_manual, position, created_at) VALUES (?, ?, ?, 0, 0, ?)",
+            (fighter_id, battle_id, "Battle Fighter", now),
+        )
+        await db.execute(
+            """INSERT INTO fighter_step (id, fighter_id, position, system_prompt, provider, model_id, provider_config, created_at)
+               VALUES (?, ?, 0, 'Summarize this.', 'openai', 'gpt-4o-mini', '{}', ?)""",
+            (step_id, fighter_id, now),
+        )
+        await db.commit()
+
+    resp = await client.post(f"/news-fighters/from-battle/{fighter_id}")
+    assert resp.status_code == 201
+    data = resp.json()
+    assert data["name"] == "Battle Fighter"
+    assert data["is_system"] is False
+    # Verify copied fighter has its own fighter_id (not the original)
+    assert data["fighter_id"] != fighter_id
+
+
+@pytest.mark.asyncio
+async def test_fallback_chain_configurable(client, db_path):
+    async with get_db(db_path) as db:
+        battle_id = str(uuid.uuid4())
+        fighter_id = str(uuid.uuid4())
+        from datetime import datetime, timezone
+        now = datetime.now(timezone.utc).isoformat()
+        await db.execute(
+            "INSERT INTO battle (id, name, created_at) VALUES (?, ?, ?)",
+            (battle_id, "Fallback Battle", now),
+        )
+        await db.execute(
+            "INSERT INTO fighter (id, battle_id, name, is_manual, position, created_at) VALUES (?, ?, ?, 0, 0, ?)",
+            (fighter_id, battle_id, "Fallback Fighter", now),
+        )
+        await db.commit()
+
+    # Create primary news fighter
+    resp1 = await client.post("/news-fighters", json={
+        "fighter_id": fighter_id, "name": "Primary", "priority": 5,
+    })
+    primary_id = resp1.json()["id"]
+
+    # Create secondary with fallback pointing to primary
+    resp2 = await client.post("/news-fighters", json={
+        "fighter_id": fighter_id, "name": "Secondary",
+        "priority": 3, "fallback_fighter_id": primary_id,
+    })
+    assert resp2.status_code == 201
+    assert resp2.json()["fallback_fighter_id"] == primary_id
+
+    # Update via PUT
+    secondary_id = resp2.json()["id"]
+    resp3 = await client.put(f"/news-fighters/{secondary_id}", json={"fallback_fighter_id": None})
+    assert resp3.json()["fallback_fighter_id"] is None


### PR DESCRIPTION
Closes #259

## Summary
- `news_fighter` table with FK to fighter, fallback, priority
- CRUD API: GET/POST /news-fighters, GET/PUT/DELETE by id
- `POST /news-fighters/from-battle/{fighter_id}` — copy battle fighter + steps
- Fallback chain configurable (fighter → fallback fighter)
- 3 system fighters with steps seeded on init: General Summarizer, Tech Deep Dive, YouTube Analyzer
- 8 new tests, full suite 148 passed

## Acceptance Criteria
- [x] CRUD API for news fighters works
- [x] Battle fighter promotion copies fighter + steps independently
- [x] Fallback chain configurable (fighter → fallback fighter)
- [x] 3 system fighters with steps created on first start
- [x] Priority configurable for load balancing