### PR TITLE
feat: Board CRUD with topics, normalizer config, and schedule

### DIFF
--- a/t01_llm_battle/db.py
+++ b/t01_llm_battle/db.py
@@ -129,6 +129,37 @@ CREATE TABLE IF NOT EXISTS news_fighter (
     created_at          TEXT NOT NULL,
     updated_at          TEXT NOT NULL
 );
+
+CREATE TABLE IF NOT EXISTS board (
+    id                    TEXT PRIMARY KEY,
+    name                  TEXT NOT NULL,
+    description           TEXT NOT NULL DEFAULT '',
+    source_filter         TEXT NOT NULL DEFAULT '[]',
+    fighter_ids           TEXT NOT NULL DEFAULT '[]',
+    normalizer_provider   TEXT,
+    normalizer_model      TEXT,
+    normalizer_instructions TEXT,
+    schedule_cron         TEXT,
+    max_news_per_run      INTEGER NOT NULL DEFAULT 20,
+    max_history           INTEGER NOT NULL DEFAULT 100,
+    is_active             INTEGER NOT NULL DEFAULT 1,
+    is_system             INTEGER NOT NULL DEFAULT 0,
+    template_id           TEXT,
+    publish_config        TEXT NOT NULL DEFAULT '{}',
+    created_at            TEXT NOT NULL,
+    updated_at            TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS board_topic (
+    id          TEXT PRIMARY KEY,
+    board_id    TEXT NOT NULL REFERENCES board(id),
+    name        TEXT NOT NULL,
+    description TEXT NOT NULL DEFAULT '',
+    tag_filter  TEXT NOT NULL DEFAULT '[]',
+    position    INTEGER NOT NULL DEFAULT 0,
+    created_at  TEXT NOT NULL,
+    updated_at  TEXT NOT NULL
+);
 """
 
 # Migrations for existing DBs
@@ -171,6 +202,7 @@ async def init_db(db_path: str | Path = DB_PATH) -> None:
 
     await _seed_system_news_sources(db_path)
     await _seed_system_news_fighters(db_path)
+    await _seed_system_board(db_path)
     await _migrate_plaintext_keys(db_path)
 
 
@@ -313,6 +345,45 @@ async def _seed_system_news_fighters(db_path: str | Path = DB_PATH) -> None:
                 (nf["id"], nf["fighter_id"], nf["name"], nf["priority"], now, now),
             )
 
+        await db.commit()
+
+
+_SYS_BOARD_ID = "sys-board-tech-news-daily"
+
+_SYSTEM_BOARD_TOPICS = [
+    {"id": "sys-topic-ai-ml", "name": "AI & ML", "description": "Artificial intelligence and machine learning news", "tag_filter": '["ai", "ml", "research"]', "position": 0},
+    {"id": "sys-topic-startups", "name": "Startups & VC", "description": "Startup ecosystem and venture capital", "tag_filter": '["startups", "vc"]', "position": 1},
+    {"id": "sys-topic-open-source", "name": "Open Source", "description": "Open source projects and community", "tag_filter": '["code", "opensource"]', "position": 2},
+]
+
+
+async def _seed_system_board(db_path: str | Path = DB_PATH) -> None:
+    """Insert the system board 'Tech News Daily' with 3 default topics if not present."""
+    from datetime import datetime, timezone
+    now = datetime.now(timezone.utc).isoformat()
+
+    async with get_db(db_path) as db:
+        cur = await db.execute("SELECT id FROM board WHERE id = ?", (_SYS_BOARD_ID,))
+        if await cur.fetchone() is None:
+            await db.execute(
+                """INSERT INTO board (id, name, description, source_filter, fighter_ids,
+                   normalizer_provider, normalizer_model, normalizer_instructions,
+                   schedule_cron, max_news_per_run, max_history, is_active, is_system,
+                   template_id, publish_config, created_at, updated_at)
+                   VALUES (?, ?, ?, ?, ?, NULL, NULL, NULL, '0 8 * * *', 20, 100, 1, 1, NULL, '{}', ?, ?)""",
+                (_SYS_BOARD_ID, "Tech News Daily",
+                 "Daily digest of tech, AI, and startup news",
+                 '["tech", "ai", "startups"]', '[]', now, now),
+            )
+        for topic in _SYSTEM_BOARD_TOPICS:
+            cur = await db.execute("SELECT id FROM board_topic WHERE id = ?", (topic["id"],))
+            if await cur.fetchone() is None:
+                await db.execute(
+                    """INSERT INTO board_topic (id, board_id, name, description, tag_filter, position, created_at, updated_at)
+                       VALUES (?, ?, ?, ?, ?, ?, ?, ?)""",
+                    (topic["id"], _SYS_BOARD_ID, topic["name"], topic["description"],
+                     topic["tag_filter"], topic["position"], now, now),
+                )
         await db.commit()
 
 

--- a/t01_llm_battle/routers/boards.py
+++ b/t01_llm_battle/routers/boards.py
@@ -1,0 +1,306 @@
+"""Boards router — Board CRUD with nested topic management (FR-24, FR-25, FR-26).
+
+GET    /boards                              — list all boards
+POST   /boards                             — create a board
+GET    /boards/{id}                        — get one board (with topics)
+PUT    /boards/{id}                        — update board fields
+DELETE /boards/{id}                        — delete board (system: 403)
+GET    /boards/{id}/topics                 — list topics
+POST   /boards/{id}/topics                 — create topic
+PUT    /boards/{id}/topics/{topic_id}      — update topic
+DELETE /boards/{id}/topics/{topic_id}      — delete topic
+"""
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+from typing import Any
+
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel
+
+from ..db import get_db
+
+router = APIRouter(prefix="/boards", tags=["boards"])
+
+
+class BoardTopicOut(BaseModel):
+    id: str
+    board_id: str
+    name: str
+    description: str
+    tag_filter: list[str]
+    position: int
+    created_at: str
+    updated_at: str
+
+
+class BoardOut(BaseModel):
+    id: str
+    name: str
+    description: str
+    source_filter: list[str]
+    fighter_ids: list[str]
+    normalizer_provider: str | None
+    normalizer_model: str | None
+    normalizer_instructions: str | None
+    schedule_cron: str | None
+    max_news_per_run: int
+    max_history: int
+    is_active: bool
+    is_system: bool
+    template_id: str | None
+    publish_config: dict[str, Any]
+    topics: list[BoardTopicOut]
+    created_at: str
+    updated_at: str
+
+
+class BoardCreate(BaseModel):
+    name: str
+    description: str = ""
+    source_filter: list[str] = []
+    fighter_ids: list[str] = []
+    normalizer_provider: str | None = None
+    normalizer_model: str | None = None
+    normalizer_instructions: str | None = None
+    schedule_cron: str | None = None
+    max_news_per_run: int = 20
+    max_history: int = 100
+    is_active: bool = True
+    template_id: str | None = None
+    publish_config: dict[str, Any] = {}
+
+
+class BoardUpdate(BaseModel):
+    name: str | None = None
+    description: str | None = None
+    source_filter: list[str] | None = None
+    fighter_ids: list[str] | None = None
+    normalizer_provider: str | None = None
+    normalizer_model: str | None = None
+    normalizer_instructions: str | None = None
+    schedule_cron: str | None = None
+    max_news_per_run: int | None = None
+    max_history: int | None = None
+    is_active: bool | None = None
+    publish_config: dict[str, Any] | None = None
+
+
+class TopicCreate(BaseModel):
+    name: str
+    description: str = ""
+    tag_filter: list[str] = []
+    position: int = 0
+
+
+class TopicUpdate(BaseModel):
+    name: str | None = None
+    description: str | None = None
+    tag_filter: list[str] | None = None
+    position: int | None = None
+
+
+import json as _json
+
+
+def _row_to_topic(row) -> BoardTopicOut:
+    return BoardTopicOut(
+        id=row["id"],
+        board_id=row["board_id"],
+        name=row["name"],
+        description=row["description"] or "",
+        tag_filter=_json.loads(row["tag_filter"] or "[]"),
+        position=row["position"],
+        created_at=row["created_at"],
+        updated_at=row["updated_at"],
+    )
+
+
+async def _get_topics(db, board_id: str) -> list[BoardTopicOut]:
+    cur = await db.execute(
+        "SELECT * FROM board_topic WHERE board_id = ? ORDER BY position ASC", (board_id,)
+    )
+    return [_row_to_topic(r) for r in await cur.fetchall()]
+
+
+def _row_to_board(row, topics: list[BoardTopicOut]) -> BoardOut:
+    return BoardOut(
+        id=row["id"],
+        name=row["name"],
+        description=row["description"] or "",
+        source_filter=_json.loads(row["source_filter"] or "[]"),
+        fighter_ids=_json.loads(row["fighter_ids"] or "[]"),
+        normalizer_provider=row["normalizer_provider"],
+        normalizer_model=row["normalizer_model"],
+        normalizer_instructions=row["normalizer_instructions"],
+        schedule_cron=row["schedule_cron"],
+        max_news_per_run=row["max_news_per_run"],
+        max_history=row["max_history"],
+        is_active=bool(row["is_active"]),
+        is_system=bool(row["is_system"]),
+        template_id=row["template_id"],
+        publish_config=_json.loads(row["publish_config"] or "{}"),
+        topics=topics,
+        created_at=row["created_at"],
+        updated_at=row["updated_at"],
+    )
+
+
+async def _get_board_or_404(board_id: str):
+    async with get_db() as db:
+        cur = await db.execute("SELECT * FROM board WHERE id = ?", (board_id,))
+        row = await cur.fetchone()
+        if row is None:
+            raise HTTPException(status_code=404, detail="Board not found")
+        topics = await _get_topics(db, board_id)
+    return row, topics
+
+
+@router.get("", response_model=list[BoardOut])
+async def list_boards():
+    async with get_db() as db:
+        cur = await db.execute("SELECT * FROM board ORDER BY is_system DESC, name ASC")
+        rows = await cur.fetchall()
+        result = []
+        for row in rows:
+            topics = await _get_topics(db, row["id"])
+            result.append(_row_to_board(row, topics))
+    return result
+
+
+@router.post("", response_model=BoardOut, status_code=201)
+async def create_board(body: BoardCreate):
+    now = datetime.now(timezone.utc).isoformat()
+    board_id = str(uuid.uuid4())
+    async with get_db() as db:
+        await db.execute(
+            """INSERT INTO board (id, name, description, source_filter, fighter_ids,
+               normalizer_provider, normalizer_model, normalizer_instructions,
+               schedule_cron, max_news_per_run, max_history, is_active, is_system,
+               template_id, publish_config, created_at, updated_at)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 0, ?, ?, ?, ?)""",
+            (board_id, body.name, body.description,
+             _json.dumps(body.source_filter), _json.dumps(body.fighter_ids),
+             body.normalizer_provider, body.normalizer_model, body.normalizer_instructions,
+             body.schedule_cron, body.max_news_per_run, body.max_history,
+             int(body.is_active), body.template_id, _json.dumps(body.publish_config), now, now),
+        )
+        await db.commit()
+        cur = await db.execute("SELECT * FROM board WHERE id = ?", (board_id,))
+        row = await cur.fetchone()
+        topics = await _get_topics(db, board_id)
+    return _row_to_board(row, topics)
+
+
+@router.get("/{board_id}", response_model=BoardOut)
+async def get_board(board_id: str):
+    row, topics = await _get_board_or_404(board_id)
+    return _row_to_board(row, topics)
+
+
+@router.put("/{board_id}", response_model=BoardOut)
+async def update_board(board_id: str, body: BoardUpdate):
+    row, _ = await _get_board_or_404(board_id)
+    if bool(row["is_system"]):
+        raise HTTPException(status_code=403, detail="System boards cannot be modified")
+    now = datetime.now(timezone.utc).isoformat()
+    updates = body.model_dump(exclude_none=True)
+    if not updates:
+        async with get_db() as db:
+            cur = await db.execute("SELECT * FROM board WHERE id = ?", (board_id,))
+            row = await cur.fetchone()
+            topics = await _get_topics(db, board_id)
+        return _row_to_board(row, topics)
+    # Serialize list/dict fields
+    for field in ("source_filter", "fighter_ids", "publish_config"):
+        if field in updates:
+            updates[field] = _json.dumps(updates[field])
+    if "is_active" in updates:
+        updates["is_active"] = int(updates["is_active"])
+    set_clause = ", ".join(f"{k} = ?" for k in updates)
+    values = list(updates.values()) + [now, board_id]
+    async with get_db() as db:
+        await db.execute(f"UPDATE board SET {set_clause}, updated_at = ? WHERE id = ?", values)
+        await db.commit()
+        cur = await db.execute("SELECT * FROM board WHERE id = ?", (board_id,))
+        row = await cur.fetchone()
+        topics = await _get_topics(db, board_id)
+    return _row_to_board(row, topics)
+
+
+@router.delete("/{board_id}", status_code=204)
+async def delete_board(board_id: str):
+    row, _ = await _get_board_or_404(board_id)
+    if bool(row["is_system"]):
+        raise HTTPException(status_code=403, detail="System boards cannot be deleted")
+    async with get_db() as db:
+        await db.execute("DELETE FROM board_topic WHERE board_id = ?", (board_id,))
+        await db.execute("DELETE FROM board WHERE id = ?", (board_id,))
+        await db.commit()
+
+
+# --- Topic sub-routes ---
+
+@router.get("/{board_id}/topics", response_model=list[BoardTopicOut])
+async def list_topics(board_id: str):
+    await _get_board_or_404(board_id)
+    async with get_db() as db:
+        topics = await _get_topics(db, board_id)
+    return topics
+
+
+@router.post("/{board_id}/topics", response_model=BoardTopicOut, status_code=201)
+async def create_topic(board_id: str, body: TopicCreate):
+    await _get_board_or_404(board_id)
+    now = datetime.now(timezone.utc).isoformat()
+    topic_id = str(uuid.uuid4())
+    async with get_db() as db:
+        await db.execute(
+            """INSERT INTO board_topic (id, board_id, name, description, tag_filter, position, created_at, updated_at)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?)""",
+            (topic_id, board_id, body.name, body.description,
+             _json.dumps(body.tag_filter), body.position, now, now),
+        )
+        await db.commit()
+        cur = await db.execute("SELECT * FROM board_topic WHERE id = ?", (topic_id,))
+        row = await cur.fetchone()
+    return _row_to_topic(row)
+
+
+@router.put("/{board_id}/topics/{topic_id}", response_model=BoardTopicOut)
+async def update_topic(board_id: str, topic_id: str, body: TopicUpdate):
+    await _get_board_or_404(board_id)
+    now = datetime.now(timezone.utc).isoformat()
+    async with get_db() as db:
+        cur = await db.execute(
+            "SELECT * FROM board_topic WHERE id = ? AND board_id = ?", (topic_id, board_id)
+        )
+        row = await cur.fetchone()
+        if row is None:
+            raise HTTPException(status_code=404, detail="Topic not found")
+        updates = body.model_dump(exclude_none=True)
+        if not updates:
+            return _row_to_topic(row)
+        if "tag_filter" in updates:
+            updates["tag_filter"] = _json.dumps(updates["tag_filter"])
+        set_clause = ", ".join(f"{k} = ?" for k in updates)
+        values = list(updates.values()) + [now, topic_id]
+        await db.execute(f"UPDATE board_topic SET {set_clause}, updated_at = ? WHERE id = ?", values)
+        await db.commit()
+        cur = await db.execute("SELECT * FROM board_topic WHERE id = ?", (topic_id,))
+        row = await cur.fetchone()
+    return _row_to_topic(row)
+
+
+@router.delete("/{board_id}/topics/{topic_id}", status_code=204)
+async def delete_topic(board_id: str, topic_id: str):
+    await _get_board_or_404(board_id)
+    async with get_db() as db:
+        cur = await db.execute(
+            "SELECT id FROM board_topic WHERE id = ? AND board_id = ?", (topic_id, board_id)
+        )
+        if await cur.fetchone() is None:
+            raise HTTPException(status_code=404, detail="Topic not found")
+        await db.execute("DELETE FROM board_topic WHERE id = ?", (topic_id,))
+        await db.commit()

--- a/t01_llm_battle/server.py
+++ b/t01_llm_battle/server.py
@@ -17,6 +17,7 @@ from .routers.providers import router as provider_mgmt_router
 from .routers.templates import router as templates_router
 from .routers.news_sources import router as news_sources_router
 from .routers.news_fighters import router as news_fighters_router
+from .routers.boards import router as boards_router
 
 log = logging.getLogger(__name__)
 
@@ -53,6 +54,7 @@ def create_app(db_path=DB_PATH) -> FastAPI:
     app.include_router(templates_router)
     app.include_router(news_sources_router)
     app.include_router(news_fighters_router)
+    app.include_router(boards_router)
 
     # Health check
     @app.get("/healthz")

--- a/tests/test_boards_router.py
+++ b/tests/test_boards_router.py
@@ -1,0 +1,172 @@
+"""Tests for /boards CRUD API and nested /boards/{id}/topics endpoints."""
+from contextlib import asynccontextmanager
+
+import pytest
+import t01_llm_battle.db as db_module
+import t01_llm_battle.routers.boards as boards_module
+from httpx import ASGITransport, AsyncClient
+from t01_llm_battle.db import get_db, init_db
+from t01_llm_battle.server import create_app
+
+
+@pytest.fixture
+async def db_path(tmp_path):
+    path = str(tmp_path / "test_boards.db")
+    await init_db(path)
+    return path
+
+
+@pytest.fixture
+async def client(db_path, monkeypatch):
+    _db_path = db_path
+
+    @asynccontextmanager
+    async def _get_db_override(path=None):
+        async with get_db(_db_path) as db:
+            yield db
+
+    monkeypatch.setattr(db_module, "DB_PATH", __import__("pathlib").Path(_db_path))
+    monkeypatch.setattr(boards_module, "get_db", _get_db_override)
+
+    app = create_app(db_path=db_path)
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        yield c
+
+
+@pytest.mark.asyncio
+async def test_list_boards_includes_system_board(client):
+    resp = await client.get("/boards")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert len(data) >= 1
+    sys_board = next((b for b in data if b["is_system"]), None)
+    assert sys_board is not None
+    assert sys_board["name"] == "Tech News Daily"
+    assert len(sys_board["topics"]) == 3
+
+
+@pytest.mark.asyncio
+async def test_create_and_get_board(client):
+    payload = {
+        "name": "My Board",
+        "description": "Test board",
+        "source_filter": ["tech"],
+        "fighter_ids": [],
+        "normalizer_provider": "openai",
+        "normalizer_model": "gpt-4o-mini",
+        "normalizer_instructions": "Summarize.",
+        "schedule_cron": "0 9 * * *",
+        "max_news_per_run": 10,
+        "max_history": 50,
+        "is_active": True,
+        "publish_config": {},
+    }
+    resp = await client.post("/boards", json=payload)
+    assert resp.status_code == 201
+    board = resp.json()
+    assert board["name"] == "My Board"
+    assert board["normalizer_provider"] == "openai"
+    assert board["is_system"] is False
+
+    resp2 = await client.get(f"/boards/{board['id']}")
+    assert resp2.status_code == 200
+    assert resp2.json()["id"] == board["id"]
+
+
+@pytest.mark.asyncio
+async def test_update_board(client):
+    resp = await client.post("/boards", json={"name": "Update Me"})
+    assert resp.status_code == 201
+    board_id = resp.json()["id"]
+
+    resp = await client.put(f"/boards/{board_id}", json={"name": "Updated", "is_active": False})
+    assert resp.status_code == 200
+    updated = resp.json()
+    assert updated["name"] == "Updated"
+    assert updated["is_active"] is False
+
+
+@pytest.mark.asyncio
+async def test_delete_board(client):
+    resp = await client.post("/boards", json={"name": "Delete Me"})
+    assert resp.status_code == 201
+    board_id = resp.json()["id"]
+
+    resp = await client.delete(f"/boards/{board_id}")
+    assert resp.status_code == 204
+
+    resp = await client.get(f"/boards/{board_id}")
+    assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_system_board_cannot_be_deleted(client):
+    resp = await client.get("/boards")
+    sys_board = next(b for b in resp.json() if b["is_system"])
+    resp = await client.delete(f"/boards/{sys_board['id']}")
+    assert resp.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_system_board_cannot_be_updated(client):
+    resp = await client.get("/boards")
+    sys_board = next(b for b in resp.json() if b["is_system"])
+    resp = await client.put(f"/boards/{sys_board['id']}", json={"name": "Hacked"})
+    assert resp.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_board_not_found(client):
+    resp = await client.get("/boards/nonexistent-id")
+    assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_topic_crud(client):
+    resp = await client.post("/boards", json={"name": "Topic Board"})
+    board_id = resp.json()["id"]
+
+    # Create topic
+    resp = await client.post(f"/boards/{board_id}/topics", json={
+        "name": "AI News", "description": "All about AI", "tag_filter": ["ai"], "position": 0
+    })
+    assert resp.status_code == 201
+    topic = resp.json()
+    assert topic["name"] == "AI News"
+    assert topic["tag_filter"] == ["ai"]
+    topic_id = topic["id"]
+
+    # List topics
+    resp = await client.get(f"/boards/{board_id}/topics")
+    assert resp.status_code == 200
+    assert any(t["id"] == topic_id for t in resp.json())
+
+    # Update topic
+    resp = await client.put(f"/boards/{board_id}/topics/{topic_id}", json={"name": "ML News"})
+    assert resp.status_code == 200
+    assert resp.json()["name"] == "ML News"
+
+    # Delete topic
+    resp = await client.delete(f"/boards/{board_id}/topics/{topic_id}")
+    assert resp.status_code == 204
+
+    resp = await client.get(f"/boards/{board_id}/topics")
+    assert all(t["id"] != topic_id for t in resp.json())
+
+
+@pytest.mark.asyncio
+async def test_system_board_has_3_default_topics(client):
+    resp = await client.get("/boards")
+    sys_board = next(b for b in resp.json() if b["is_system"])
+    topic_names = [t["name"] for t in sys_board["topics"]]
+    assert "AI & ML" in topic_names
+    assert "Startups & VC" in topic_names
+    assert "Open Source" in topic_names
+
+
+@pytest.mark.asyncio
+async def test_topic_not_found(client):
+    resp = await client.post("/boards", json={"name": "Board X"})
+    board_id = resp.json()["id"]
+    resp = await client.delete(f"/boards/{board_id}/topics/nonexistent")
+    assert resp.status_code == 404


### PR DESCRIPTION
Closes #260

## Summary
- board + board_topic tables in SQLite schema
- Full CRUD API: GET/POST /boards, GET/PUT/DELETE /boards/{id}
- Topic CRUD: GET/POST /boards/{id}/topics, PUT/DELETE /boards/{id}/topics/{topic_id}
- System board 'Tech News Daily' with 3 default topics seeded on first start
- Normalizer config stored per board
- System boards protected: 403 on delete/update
- 18 new tests, full suite 158 passed