### PR TITLE
docs: UI redesign PRD — 3-column layout + Paper theme mockups

### DIFF
--- a/prd/01-prd.md
+++ b/prd/01-prd.md
@@ -47,6 +47,7 @@ After running, the final output of each fighter is judged side-by-side: quality 
 | [05-user-stories.md](./05-user-stories.md) | Key workflows |
 | [06-data-models.md](./06-data-models.md) | SQLite schema: battle / source / fighter / step / run / result / judgment / api_key |
 | [07-roadmap.md](./07-roadmap.md) | Phased delivery plan |
+| [09-ui-redesign.md](./09-ui-redesign.md) | UI redesign — 3-column layout, Paper theme, tabbed content, mockups |
 
 ## v0.1 Scope
 

--- a/prd/03-functional-requirements.md
+++ b/prd/03-functional-requirements.md
@@ -17,11 +17,11 @@
 | FR-11 | Live Run View | Polling UI; step-level status per fighter per source item |
 | FR-12 | LLM-as-Judge | Optional. When configured, scores final step output per fighter per source (0–10 + reasoning). When not configured, run completes without scoring. |
 | FR-13 | Markdown Report | Judge generates a markdown summary; rendered in browser via marked.js |
-| FR-14 | Results View | Side-by-side results: cost, latency, expandable step drill-down. When judge is configured, shows scores. When no judge, outputs shown side-by-side without scores. |
+| FR-14 | Results View | Fighter summary leaderboard table (rank, avg score, cost, tokens, time) + per-source breakdown with expandable output. When no judge, outputs shown without scores. See [09-ui-redesign.md](./09-ui-redesign.md). |
 | FR-15 | SQLite Persistence | All battles, sources, fighters, steps, runs, results, judgments, api_keys |
 | FR-16 | Custom Model IDs | Override catalog slugs; pricing shown as "unknown" |
-| FR-19 | Provider Management UI | Sidebar footer link labelled "Providers"; lists providers with enable/disable toggle; edit popup for display name, API key, server URL (Ollama/LLM Studio/self-hosted); uninstall non-system providers |
-| FR-20 | Sidebar Layout | Single page: left sidebar (app name, battle list, "Providers" footer link) + main content area (selected battle or default empty battle with 2 fighters) |
+| FR-19 | Provider Management UI | Modal overlay (opened from sidebar icon); lists LLM and tool providers with enable/disable toggle, key status, edit form for API key, display name, server URL; pricing refresh button; uninstall non-system providers |
+| FR-20 | App Layout | 3-column layout: collapsible icon rail sidebar (64px) + tabbed main content (Setup/Run/Results) + right rail battle list (320px). See [09-ui-redesign.md](./09-ui-redesign.md) for mockups. |
 
 ---
 
@@ -44,34 +44,34 @@
 
 ---
 
-## Detail: FR-20 Sidebar Layout
+## Detail: FR-20 App Layout
 
-- **Single page** with left sidebar (~260 px) + main content area (fills remaining width)
-- **Sidebar contents**:
-  - App name: "T01 LLM Battle"
-  - Battle list: + New button; each entry shows name + created time + delete button; click name to load in main area
-  - Providers section: list of providers with enable/disable toggle and edit button
-- **Main area**: selected battle (Input / Definition / Result sections) or default empty battle (2 manual fighters) if none selected
-- Sidebar collapses on narrow viewports
+- **3-column layout**: icon rail sidebar (64px collapsible) + main content area (flex: 1) + right rail battle list (~320px)
+- **Icon rail sidebar**: brand icon, navigation icons (Battles, Providers, Settings), collapse toggle. Providers opens a modal overlay.
+- **Main content**: topbar (battle name + run ID) + tab bar (Setup / Run / Results) + active tab content
+- **Right rail**: battle list with active highlighting, status tags (new/done), "+ New" button
+- **Responsive**: sidebar collapses to icons on narrow viewports; right rail hides on mobile (<1100px)
+- See [09-ui-redesign.md](./09-ui-redesign.md) for full mockups
 
 ---
 
-## Brand Theme (Paper Light)
+## Brand Theme (Paper)
 
-Applies to FR-20 sidebar layout and all UI components. Paper-like aesthetic: warm off-white backgrounds, clean white cards, dark readable text.
+Applies to all UI components. Paper-like editorial aesthetic with serif display font.
 
 | Token | Value |
 |-------|-------|
 | `bg.paper` | `#FAF9F6` (warm off-white / parchment) |
-| `bg.card` | `#FFFFFF` (white with subtle shadow/border) |
-| Primary accent | `#F0B90B` (gold — kept for contrast on light bg) |
+| `bg.card` | `#FFFFFF` (white with subtle shadow) |
+| Primary accent | `#D4A02A` (warm gold) |
 | `text.high` | `#1a1a2e` (dark primary text) |
 | `text.mid` | `#6b7280` (muted secondary text) |
 | Borders | `#e5e5e5` (light gray) |
-| Typography | system-ui stack, weight 600, `letter-spacing: -0.01em` |
-| Sidebar bg | slightly tinted off-white or very light gray |
+| Display font | `"Fraunces", serif` (headings, battle names, scores) |
+| Body font | `"Inter", system-ui, sans-serif` (content, labels) |
+| Mono font | `"JetBrains Mono", monospace` (metadata, IDs, costs) |
 
-Replaces previous Gold-on-Ink dark theme (`#0d0f13` background, `#14181f` cards, `#E7ECF3` text).
+CSS architecture: all component classes use `.ba-*` prefix (battle-app). Framework-agnostic, works directly with Alpine.js.
 
 ---
 
@@ -177,8 +177,9 @@ Unknown keys are passed through to the provider as-is — forward-compatible wit
 
 ## Detail: FR-14 Results View
 
-- Side-by-side comparison of all fighters per source item
-- Always shown: final output, total cost (USD), total latency (ms), expandable step drill-down
-- **When judge is configured**: judge score (0–10) and reasoning displayed per fighter
-- **When no judge is configured**: outputs displayed side-by-side without scores; users compare quality visually
-- Judge scores column hidden when no judge is configured on the battle
+- **Fighter Summary**: leaderboard table showing rank, fighter name, avg score, total cost, token count, latency, success/fail counts
+- **Per-Source Breakdown**: expandable cards per source item showing each fighter's output, score, cost, and tokens side-by-side
+- "Show output" toggle per fighter result to expand/collapse full output text
+- **When judge is configured**: scores shown in leaderboard and per-source cards
+- **When no judge is configured**: outputs shown without scores; users compare quality visually
+- Download Markdown button for judge report

--- a/prd/09-ui-redesign.md
+++ b/prd/09-ui-redesign.md
@@ -1,0 +1,299 @@
+# UI Redesign — Paper Theme + 3-Column Layout
+
+**Version**: 0.1.x (polish release)
+**Status**: Draft
+
+## Overview
+
+Redesign the battle app UI from a 2-column text sidebar to a 3-column layout with icon rail, tabbed content, and battle list rail. Upgrade to the new Paper theme with Fraunces serif display font. All existing functionality is preserved — this is a visual/UX overhaul only, no backend changes.
+
+## Layout Mockup
+
+```
+┌──────────────────────────────────────────────────────────┐
+│ battle-app  theme-paper                                  │
+├────────┬─────────────────────────────────┬───────────────┤
+│        │ ┌─ Topbar ──────────────────┐   │               │
+│  Icon  │ │ Battle Name    run-id     │   │  Right Rail   │
+│  Rail  │ └───────────────────────────┘   │               │
+│        │ ┌─ Tabs ────────────────────┐   │  BATTLES      │
+│  ☰ ←→  │ │ Setup │ Run │ Results    │   │  + New        │
+│        │ └───────────────────────────┘   │               │
+│  ⚔ bat │                                │  ● Battle A   │
+│        │ ┌─ Tab Content ─────────────┐   │    new        │
+│  ⚙ prov│ │                           │   │               │
+│        │ │  (Sources / Fighters /     │   │  ○ Battle B   │
+│  ☵ set │ │   Judge  —  or Run grid   │   │    done       │
+│        │ │   — or Results table)      │   │               │
+│        │ │                           │   │  ○ Battle C   │
+│        │ └───────────────────────────┘   │               │
+├────────┴─────────────────────────────────┴───────────────┤
+│                (responsive: collapses on <1100px)        │
+└──────────────────────────────────────────────────────────┘
+```
+
+**Icon rail** (~64px): Collapsible sidebar with icon-only navigation.
+**Main content** (flex: 1): Topbar + tab bar + active tab content.
+**Right rail** (~320px): Battle list with active highlighting and status tags.
+
+---
+
+## Icon Rail Sidebar
+
+Replaces the current text sidebar. Collapsed by default on narrow viewports.
+
+```
+┌────────┐
+│  Logo  │  ← brand mark / app icon
+│        │
+│  ⚔     │  ← Battles (navigates to battle view)
+│  ⚙     │  ← Providers (opens providers modal)
+│  ☵     │  ← Settings (theme, preferences)
+│        │
+│  ◀▶    │  ← Collapse toggle
+└────────┘
+```
+
+- Click "Providers" icon → opens **Providers Modal** (overlay, not inline)
+- Click "Battles" icon → shows battle list in right rail (or scrolls to it on mobile)
+- Hover shows tooltip with label
+- Collapse toggle reduces rail to icon-only (64px) or expands to include labels (~200px)
+
+---
+
+## Tab Bar
+
+Content area uses tabs instead of vertically stacked sections:
+
+| Tab | Content |
+|-----|---------|
+| **Setup** | Sources upload + Fighters cards + Judge config |
+| **Run** | Run progress bar + source × fighter status grid |
+| **Results** | Fighter summary leaderboard + per-source breakdown |
+
+- Tab badges: Run tab shows spinner during active run; Results tab shows score count
+- Switching tabs preserves state (no re-fetch)
+
+---
+
+## Setup Tab
+
+### Sources Section
+
+```
+┌─ 1 Sources ─────────────────────────────────────────┐
+│                                                      │
+│  ┌──────────────────────────────────┐  + Add Text    │
+│  │  Upload files                    │                │
+│  │  .txt .md .csv                   │                │
+│  │  [Choose Files]                  │                │
+│  └──────────────────────────────────┘                │
+│                                                      │
+│  source-1.txt                              ✕         │
+│  source-2.md                               ✕         │
+│  cases.csv (50 rows)                       ✕         │
+└──────────────────────────────────────────────────────┘
+```
+
+### Fighters Section
+
+```
+┌─ 2 Fighters ────────────────────── + Add Fighter ────┐
+│                                                       │
+│  ┌─ Fighter 1 ──────────────────────────────────────┐ │
+│  │  ① openai / gpt-4o / temp 0.7     + Add Step    │ │
+│  │     System: "Summarize the input..."    ▲ ▼ ✕    │ │
+│  │  ② anthropic / claude-sonnet-4-6       ▲ ▼ ✕    │ │
+│  │     System: "Refine the summary..."              │ │
+│  └──────────────────────────────────────────────────┘ │
+│                                                       │
+│                    ─── VS ───                         │
+│                                                       │
+│  ┌─ Fighter 2 ──────────────────────────────────────┐ │
+│  │  ① openai / gpt-4o-mini / temp 0.3  + Add Step  │ │
+│  │     System: "Summarize..."              ▲ ▼ ✕    │ │
+│  └──────────────────────────────────────────────────┘ │
+└───────────────────────────────────────────────────────┘
+```
+
+- VS divider between fighters (styled `.ba-vs-mark`)
+- Numbered step badges (①②③)
+- Step controls: reorder (▲▼), delete (✕)
+- Each step shows: provider / model / temperature inline
+
+### Judge Section
+
+```
+┌─ 3 Judge ──────────────────────── ○ Disabled ────────┐
+│                                                       │
+│  Provider: [openai ▼]    Model: [gpt-4o-mini ▼]     │
+│                                                       │
+│  Rubric:                                             │
+│  ┌──────────────────────────────────────────────────┐ │
+│  │  Score each response on a scale of 0-10...       │ │
+│  │  (EasyMDE editor preserved)                      │ │
+│  └──────────────────────────────────────────────────┘ │
+│                                                       │
+│  [Save]  [Run Battle]                                │
+└───────────────────────────────────────────────────────┘
+```
+
+---
+
+## Run Tab
+
+```
+┌─ Run Progress ──────────────────────────────────────┐
+│  ● Running...  62%  ████████████░░░░░░  12/20 steps │
+└─────────────────────────────────────────────────────┘
+
+┌─ Status Grid ───────────────────────────────────────┐
+│              │ Fighter 1  │ Fighter 2  │ Fighter 3  │
+│──────────────┼────────────┼────────────┼────────────│
+│  Source 1    │    ● done  │    ● done  │    ◌ run   │
+│  Source 2    │    ● done  │    ◌ run   │    ○ wait  │
+│  Source 3    │    ◌ run   │    ○ wait  │    ○ wait  │
+│  Source 4    │    ○ wait  │    ○ wait  │    ○ wait  │
+└─────────────────────────────────────────────────────┘
+
+● done (green)  ◌ running (pulse)  ○ waiting (gray)  ✕ error (red)
+```
+
+---
+
+## Results Tab
+
+### Fighter Summary (Leaderboard)
+
+```
+┌─ Fighter Summary ───────────────────────────────────────────┐
+│  #  │ Fighter    │ Avg Score │ Cost   │ Tokens │ Time │ S/F │
+│─────┼────────────┼───────────┼────────┼────────┼──────┼─────│
+│  1  │ Fighter 1  │   8.7     │ $0.042 │  2,840 │ 12s  │ 5/0│
+│  2  │ Fighter 2  │   7.2     │ $0.018 │  1,200 │  8s  │ 4/1│
+│  3  │ Fighter 3  │   6.5     │ $0.065 │  4,100 │ 22s  │ 5/0│
+└─────────────────────────────────────────────────────────────┘
+```
+
+### Per-Source Breakdown
+
+```
+┌─ Source: "input-1.txt" ─────────────────────────────────────┐
+│                                                              │
+│  Fighter 1          8.5    │  Fighter 2          7.0         │
+│  ▶ Show output             │  ▶ Show output                  │
+│  1 step · $0.008 · 32/74t │  1 step · $0.003 · 26/45t       │
+│                             │                                 │
+│  [expanded output here      │                                 │
+│   when clicked]             │                                 │
+└──────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## Providers Modal
+
+Opens as a modal overlay (not inline in sidebar).
+
+```
+┌─ Providers ──────────────────────── ✕ ──┐
+│                                          │
+│  LLM Providers                           │
+│  ┌──────────────────────────────────┐    │
+│  │ OpenAI     ● key set    [●] ✎   │    │
+│  │ Anthropic  ● key set    [●] ✎   │    │
+│  │ Google     ○ no key     [○] ✎   │    │
+│  │ Groq       ○ no key     [○] ✎   │    │
+│  │ OpenRouter ○ no key     [○] ✎   │    │
+│  │ Ollama     ● running    [●] ✎   │    │
+│  │ LM Studio  ○ offline    [○] ✎   │    │
+│  └──────────────────────────────────┘    │
+│                                          │
+│  Tool Providers                          │
+│  ┌──────────────────────────────────┐    │
+│  │ Serper     ○ no key     [○] ✎   │    │
+│  │ Tavily     ○ no key     [○] ✎   │    │
+│  │ Firecrawl  ○ no key     [○] ✎   │    │
+│  └──────────────────────────────────┘    │
+│                                          │
+│  [Refresh Pricing]                       │
+└──────────────────────────────────────────┘
+```
+
+- Toggle: enable/disable provider
+- Edit (✎): opens inline form for API key, display name, server URL
+- Key status: "key set" / "no key" / "running" / "offline"
+- Refresh Pricing button preserved from current implementation
+
+---
+
+## Paper Theme (Upgraded)
+
+| Token | Value |
+|-------|-------|
+| `bg.paper` | `#FAF9F6` (warm off-white / parchment) |
+| `bg.card` | `#FFFFFF` (white with subtle shadow) |
+| Primary accent | `#D4A02A` (warm gold) |
+| `text.high` | `#1a1a2e` (dark primary) |
+| `text.mid` | `#6b7280` (muted secondary) |
+| Borders | `#e5e5e5` (light gray) |
+| Display font | `"Fraunces", serif` (headings, battle names, scores) |
+| Body font | `"Inter", system-ui, sans-serif` (content, labels) |
+| Mono font | `"JetBrains Mono", monospace` (metadata, IDs, costs) |
+
+---
+
+## CSS Architecture
+
+All component classes use `.ba-*` prefix (battle-app). Framework-agnostic — works with Alpine.js directly.
+
+**Key classes**: `.ba-sidebar`, `.ba-rail`, `.ba-main`, `.ba-topbar`, `.ba-tabs`, `.ba-tab`, `.ba-section`, `.ba-card`, `.ba-fighters`, `.ba-fighter`, `.ba-step`, `.ba-vs-mark`, `.ba-btn`, `.ba-toggle`, `.ba-input`, `.ba-select`, `.ba-modal`, `.ba-table`, `.ba-rungrid`, `.ba-status-dot`
+
+**Responsive**: `@media (max-width: 1100px)` collapses sidebar, hides right rail.
+
+---
+
+## Right Rail (Battle List)
+
+```
+┌─ BATTLES ──────── + New ─┐
+│                           │
+│  ● Battle 2026-04-26 ◄── │  ← active (highlighted)
+│    new                    │
+│                           │
+│  ○ Battle 2026-04-23      │
+│    done                   │
+│                           │
+│  ○ My First Battle        │
+│    3 runs                 │
+└───────────────────────────┘
+```
+
+- Active battle highlighted with accent color
+- Status tags: "new" (no runs), "done" (has results), run count
+- Click to switch battles
+- "+ New" button creates new battle
+
+---
+
+## What Stays Unchanged
+
+All existing backend functionality preserved:
+- Provider management (enable/disable, API key, server URL, pricing refresh)
+- Source upload (text/md files, CSV with column selection)
+- Manual fighters (user-entered results)
+- Judge rubric (EasyMDE markdown editor)
+- Custom model IDs
+- Live run polling
+- Markdown report generation + download
+- All API endpoints unchanged
+
+---
+
+## Design Source Files
+
+The design prototype is in `/Users/charles/Downloads/battle (2).zip`:
+- `app.css` — all `.ba-*` component CSS (1,256 lines, framework-agnostic)
+- `theme-paper.css` — Paper theme CSS variables
+- `battle-app.jsx` — React prototype (translate to Alpine.js)
+- `data.js` — mock data structure reference


### PR DESCRIPTION
## Summary

- New `prd/09-ui-redesign.md` with full ASCII mockups for the UI redesign
- Updated FR-14 (Results View → leaderboard table), FR-19 (Providers → modal), FR-20 (Layout → 3-column)
- Updated Brand Theme with Fraunces serif display font, Inter body, JetBrains Mono

## Test plan

- [ ] All PRD files are valid markdown
- [ ] Mockups match design prototype in `/Users/charles/Downloads/battle (2).zip`
- [ ] Existing FRs preserved (no functionality removed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)