### PR TITLE
feat: In-process scheduler for board execution

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ dependencies = [
     "typer>=0.12",
     "python-multipart>=0.0.9",
     "feedparser>=6",
+    "apscheduler>=3,<4",
 ]
 
 [project.scripts]

--- a/t01_llm_battle/board_engine.py
+++ b/t01_llm_battle/board_engine.py
@@ -232,6 +232,24 @@ def _assign_topics(item_tags: list[str], topics: list[dict]) -> list[str]:
     return matched
 
 
+# --- History pruning ---
+
+async def _prune_history(board_id: str, max_history: int, db_path=DB_PATH) -> None:
+    """Delete board_run rows (and their items) beyond max_history."""
+    async with get_db(db_path) as db:
+        cur = await db.execute(
+            "SELECT id FROM board_run WHERE board_id = ? ORDER BY started_at DESC",
+            (board_id,),
+        )
+        all_runs = [r["id"] for r in await cur.fetchall()]
+        to_delete = all_runs[max_history:]
+        for run_id in to_delete:
+            await db.execute("DELETE FROM board_news_item WHERE run_id = ?", (run_id,))
+            await db.execute("DELETE FROM board_run WHERE id = ?", (run_id,))
+        if to_delete:
+            await db.commit()
+
+
 # --- Main run execution ---
 
 async def execute_board_run(board_id: str, db_path=DB_PATH) -> str:
@@ -340,6 +358,9 @@ async def execute_board_run(board_id: str, db_path=DB_PATH) -> str:
                 (items_fetched, items_processed, _now(), run_id),
             )
             await db.commit()
+
+        # Prune old runs beyond max_history
+        await _prune_history(board_id, board["max_history"], db_path)
 
     except Exception as e:
         async with get_db(db_path) as db:

--- a/t01_llm_battle/routers/boards.py
+++ b/t01_llm_battle/routers/boards.py
@@ -228,6 +228,14 @@ async def update_board(board_id: str, body: BoardUpdate):
         cur = await db.execute("SELECT * FROM board WHERE id = ?", (board_id,))
         row = await cur.fetchone()
         topics = await _get_topics(db, board_id)
+    # Notify scheduler if schedule-relevant fields changed
+    if "is_active" in updates or "schedule_cron" in updates:
+        from .. import scheduler as board_scheduler
+        board_scheduler.sync_board(
+            board_id,
+            bool(row["is_active"]),
+            row["schedule_cron"],
+        )
     return _row_to_board(row, topics)
 
 

--- a/t01_llm_battle/scheduler.py
+++ b/t01_llm_battle/scheduler.py
@@ -1,0 +1,107 @@
+"""Board scheduler — APScheduler-backed cron scheduler for board execution (FR-27)."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+
+from apscheduler.schedulers.asyncio import AsyncIOScheduler
+from apscheduler.triggers.cron import CronTrigger
+
+from .board_engine import execute_board_run
+from .db import DB_PATH
+
+log = logging.getLogger(__name__)
+
+_scheduler: AsyncIOScheduler | None = None
+
+
+def get_scheduler() -> AsyncIOScheduler:
+    global _scheduler
+    if _scheduler is None:
+        _scheduler = AsyncIOScheduler()
+    return _scheduler
+
+
+async def _run_board(board_id: str, db_path: str) -> None:
+    try:
+        run_id = await execute_board_run(board_id, db_path)
+        log.info("scheduler: board %s run completed: %s", board_id, run_id)
+    except Exception:
+        log.exception("scheduler: board %s run failed", board_id)
+
+
+def _job_id(board_id: str) -> str:
+    return f"board-{board_id}"
+
+
+def start(db_path: str = DB_PATH) -> AsyncIOScheduler:
+    """Start the scheduler (call on FastAPI startup)."""
+    scheduler = get_scheduler()
+    if not scheduler.running:
+        scheduler.start()
+    return scheduler
+
+
+def stop() -> None:
+    """Stop the scheduler gracefully (call on FastAPI shutdown)."""
+    global _scheduler
+    if _scheduler is not None and _scheduler.running:
+        _scheduler.shutdown(wait=False)
+    _scheduler = None
+
+
+async def load_boards(db_path: str = DB_PATH) -> None:
+    """Register cron jobs for all active boards with a schedule_cron."""
+    from .db import get_db
+    scheduler = get_scheduler()
+    async with get_db(db_path) as db:
+        cur = await db.execute(
+            "SELECT id, schedule_cron FROM board WHERE is_active = 1 AND schedule_cron IS NOT NULL"
+        )
+        rows = await cur.fetchall()
+    for row in rows:
+        _register(row["id"], row["schedule_cron"], db_path)
+    log.info("scheduler: loaded %d board job(s)", len(rows))
+
+
+def _register(board_id: str, cron_expr: str, db_path: str = DB_PATH) -> None:
+    scheduler = get_scheduler()
+    job_id = _job_id(board_id)
+    if scheduler.get_job(job_id):
+        scheduler.remove_job(job_id)
+    try:
+        parts = cron_expr.strip().split()
+        if len(parts) != 5:
+            log.warning("scheduler: invalid cron '%s' for board %s — skipped", cron_expr, board_id)
+            return
+        minute, hour, day, month, day_of_week = parts
+        trigger = CronTrigger(
+            minute=minute, hour=hour, day=day, month=month, day_of_week=day_of_week
+        )
+        scheduler.add_job(
+            _run_board,
+            trigger=trigger,
+            args=[board_id, db_path],
+            id=job_id,
+            replace_existing=True,
+        )
+        log.info("scheduler: registered board %s with cron '%s'", board_id, cron_expr)
+    except Exception:
+        log.exception("scheduler: failed to register board %s", board_id)
+
+
+def _deregister(board_id: str) -> None:
+    scheduler = get_scheduler()
+    job_id = _job_id(board_id)
+    if scheduler.get_job(job_id):
+        scheduler.remove_job(job_id)
+        log.info("scheduler: deregistered board %s", board_id)
+
+
+def sync_board(board_id: str, is_active: bool, schedule_cron: str | None, db_path: str = DB_PATH) -> None:
+    """Called by update_board to keep scheduler in sync with DB changes."""
+    if is_active and schedule_cron:
+        _register(board_id, schedule_cron, db_path)
+    else:
+        _deregister(board_id)

--- a/t01_llm_battle/server.py
+++ b/t01_llm_battle/server.py
@@ -18,18 +18,25 @@ from .routers.templates import router as templates_router
 from .routers.news_sources import router as news_sources_router
 from .routers.news_fighters import router as news_fighters_router
 from .routers.boards import router as boards_router
+from . import scheduler as board_scheduler
 
 log = logging.getLogger(__name__)
 
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
-    await init_db()
+    db_path = getattr(app.state, "db_path", DB_PATH)
+    await init_db(db_path)
     # Auto-refresh LLM pricing if no user cache exists
     cache = get_cache_info()
     if cache["age_seconds"] is None:
         asyncio.create_task(_background_pricing_refresh())
+    # Start board scheduler and register active boards
+    board_scheduler.start(db_path)
+    await board_scheduler.load_boards(db_path)
     yield
+    # Graceful shutdown
+    board_scheduler.stop()
 
 
 async def _background_pricing_refresh():
@@ -43,6 +50,7 @@ async def _background_pricing_refresh():
 
 def create_app(db_path=DB_PATH) -> FastAPI:
     app = FastAPI(title="t01-llm-battle", lifespan=lifespan)
+    app.state.db_path = db_path
 
     app.include_router(battles_router)
     app.include_router(keys_router)

--- a/tests/test_board_pruning.py
+++ b/tests/test_board_pruning.py
@@ -1,0 +1,86 @@
+"""Tests for board run history pruning."""
+from __future__ import annotations
+
+import uuid
+
+import pytest
+
+from t01_llm_battle.board_engine import _prune_history
+from t01_llm_battle.db import get_db
+
+
+async def _insert_run(db, board_id: str, started_at: str) -> str:
+    run_id = str(uuid.uuid4())
+    await db.execute(
+        "INSERT INTO board_run (id, board_id, status, started_at) VALUES (?, ?, 'complete', ?)",
+        (run_id, board_id, started_at),
+    )
+    await db.commit()
+    return run_id
+
+
+@pytest.mark.asyncio
+async def test_prune_keeps_max_history(db_path):
+    from t01_llm_battle.db import get_db as _get_db
+    async with _get_db(db_path) as db:
+        board_id = str(uuid.uuid4())
+        await db.execute(
+            """INSERT INTO board (id, name, description, source_filter, fighter_ids,
+               max_news_per_run, max_history, is_active, is_system,
+               template_id, publish_config, created_at, updated_at)
+               VALUES (?, 'Prune Test', '', '[]', '[]', 20, 3, 1, 0, NULL, '{}', '2024-01-01', '2024-01-01')""",
+            (board_id,),
+        )
+        await db.commit()
+        # Insert 5 runs
+        run_ids = []
+        for i in range(5):
+            rid = await _insert_run(db, board_id, f"2024-01-0{i+1}T00:00:00")
+            run_ids.append(rid)
+
+    await _prune_history(board_id, max_history=3, db_path=db_path)
+
+    async with _get_db(db_path) as db:
+        cur = await db.execute(
+            "SELECT id FROM board_run WHERE board_id = ? ORDER BY started_at DESC",
+            (board_id,),
+        )
+        remaining = [r["id"] for r in await cur.fetchall()]
+
+    assert len(remaining) == 3
+    # Most recent 3 kept
+    assert run_ids[-1] in remaining
+    assert run_ids[-2] in remaining
+    assert run_ids[-3] in remaining
+    # Oldest 2 deleted
+    assert run_ids[0] not in remaining
+    assert run_ids[1] not in remaining
+
+
+@pytest.mark.asyncio
+async def test_prune_noop_when_within_limit(db_path):
+    from t01_llm_battle.db import get_db as _get_db
+    async with _get_db(db_path) as db:
+        board_id = str(uuid.uuid4())
+        await db.execute(
+            """INSERT INTO board (id, name, description, source_filter, fighter_ids,
+               max_news_per_run, max_history, is_active, is_system,
+               template_id, publish_config, created_at, updated_at)
+               VALUES (?, 'Prune Noop', '', '[]', '[]', 20, 10, 1, 0, NULL, '{}', '2024-01-01', '2024-01-01')""",
+            (board_id,),
+        )
+        await db.commit()
+        run_ids = []
+        for i in range(3):
+            rid = await _insert_run(db, board_id, f"2024-01-0{i+1}T00:00:00")
+            run_ids.append(rid)
+
+    await _prune_history(board_id, max_history=10, db_path=db_path)
+
+    async with _get_db(db_path) as db:
+        cur = await db.execute(
+            "SELECT id FROM board_run WHERE board_id = ?", (board_id,)
+        )
+        remaining = [r["id"] for r in await cur.fetchall()]
+
+    assert len(remaining) == 3

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -1,0 +1,133 @@
+"""Tests for board scheduler (FR-27)."""
+from __future__ import annotations
+
+import pytest
+
+from t01_llm_battle.scheduler import (
+    _deregister,
+    _job_id,
+    _register,
+    get_scheduler,
+    load_boards,
+    start,
+    stop,
+    sync_board,
+)
+
+
+@pytest.fixture(autouse=True)
+async def reset_scheduler():
+    """Ensure a fresh scheduler for each test (async so event loop is running)."""
+    import t01_llm_battle.scheduler as sched_mod
+    sched_mod._scheduler = None
+    yield
+    stop()
+    sched_mod._scheduler = None
+
+
+@pytest.mark.asyncio
+async def test_start_creates_running_scheduler():
+    s = start()
+    assert s.running
+    stop()
+
+
+@pytest.mark.asyncio
+async def test_stop_shuts_down_scheduler():
+    start()
+    stop()
+    import t01_llm_battle.scheduler as sched_mod
+    assert sched_mod._scheduler is None
+
+
+@pytest.mark.asyncio
+async def test_register_adds_job():
+    start()
+    _register("board-abc", "0 * * * *")
+    assert get_scheduler().get_job(_job_id("board-abc")) is not None
+
+
+@pytest.mark.asyncio
+async def test_register_invalid_cron_skipped():
+    start()
+    _register("board-bad", "not-a-cron")
+    assert get_scheduler().get_job(_job_id("board-bad")) is None
+
+
+@pytest.mark.asyncio
+async def test_deregister_removes_job():
+    start()
+    _register("board-xyz", "30 6 * * *")
+    _deregister("board-xyz")
+    assert get_scheduler().get_job(_job_id("board-xyz")) is None
+
+
+@pytest.mark.asyncio
+async def test_sync_board_active_with_cron_registers():
+    start()
+    sync_board("board-s1", is_active=True, schedule_cron="0 8 * * *")
+    assert get_scheduler().get_job(_job_id("board-s1")) is not None
+
+
+@pytest.mark.asyncio
+async def test_sync_board_inactive_deregisters():
+    start()
+    _register("board-s2", "0 8 * * *")
+    sync_board("board-s2", is_active=False, schedule_cron="0 8 * * *")
+    assert get_scheduler().get_job(_job_id("board-s2")) is None
+
+
+@pytest.mark.asyncio
+async def test_sync_board_no_cron_deregisters():
+    start()
+    _register("board-s3", "0 8 * * *")
+    sync_board("board-s3", is_active=True, schedule_cron=None)
+    assert get_scheduler().get_job(_job_id("board-s3")) is None
+
+
+@pytest.mark.asyncio
+async def test_register_replaces_existing_job():
+    start()
+    _register("board-rep", "0 6 * * *")
+    _register("board-rep", "0 9 * * *")
+    # Still only one job
+    jobs = [j for j in get_scheduler().get_jobs() if j.id == _job_id("board-rep")]
+    assert len(jobs) == 1
+
+
+@pytest.mark.asyncio
+async def test_load_boards_registers_active_boards(db_path):
+    """load_boards registers active boards with schedule_cron from DB."""
+    from t01_llm_battle.db import get_db
+    board_id = "test-load-board-1"
+    async with get_db(db_path) as db:
+        await db.execute(
+            """INSERT INTO board (id, name, description, source_filter, fighter_ids,
+               schedule_cron, max_news_per_run, max_history, is_active, is_system,
+               template_id, publish_config, created_at, updated_at)
+               VALUES (?, 'Test', '', '[]', '[]', '0 6 * * *', 20, 10, 1, 0, NULL, '{}', '2024-01-01T00:00:00', '2024-01-01T00:00:00')""",
+            (board_id,),
+        )
+        await db.commit()
+    start()
+    await load_boards(db_path)
+    assert get_scheduler().get_job(_job_id(board_id)) is not None
+
+
+@pytest.mark.asyncio
+async def test_load_boards_skips_inactive(db_path):
+    """load_boards does not register inactive boards."""
+    from t01_llm_battle.db import get_db
+    board_id = "test-load-board-inactive"
+    async with get_db(db_path) as db:
+        await db.execute(
+            """INSERT INTO board (id, name, description, source_filter, fighter_ids,
+               schedule_cron, max_news_per_run, max_history, is_active, is_system,
+               template_id, publish_config, created_at, updated_at)
+               VALUES (?, 'Inactive', '', '[]', '[]', '0 6 * * *', 20, 10, 0, 0, NULL, '{}', '2024-01-01T00:00:00', '2024-01-01T00:00:00')""",
+            (board_id,),
+        )
+        await db.commit()
+    start()
+    await load_boards(db_path)
+    assert get_scheduler().get_job(_job_id(board_id)) is None


### PR DESCRIPTION
Implements APScheduler integration for scheduled board runs (FR-27).

## Summary
- Add APScheduler dependency and scheduler.py module
- Wire scheduler start/stop into FastAPI lifespan
- load_boards() registers active boards on startup
- update_board() re-syncs scheduler on is_active/schedule_cron changes
- History pruning: delete runs beyond max_history after each execution
- "Run Now" endpoint existing for manual triggers

## Tests
- 192 tests pass (179 existing + 13 new)
- Scheduler registration, deregistration, sync, and history pruning tested
- All 7 acceptance criteria verified

Closes #262