### PR TITLE
fix: guard $root.params?.id in Alpine x-for class binding

### DIFF
--- a/t01_llm_battle/static/index.html
+++ b/t01_llm_battle/static/index.html
@@ -1849,7 +1849,7 @@
         </template>
         <template x-for="b in battles" :key="b.id">
           <div class="battle-item"
-               :class="{ active: $root.params.id === b.id }"
+               :class="{ active: $root.params?.id === b.id }"
                @click="window.location.hash = '#/battles/' + b.id">
             <span class="battle-item-name" x-text="b.name"></span>
             <span x-show="!b.has_sources" class="badge-muted" style="font-size:0.68rem;padding:1px 5px;">new</span>


### PR DESCRIPTION
Closes #297

## Summary
Adds optional chaining guard to prevent TypeError when `$root.params` is undefined on initial render.

## Change
- Line 1852 (index.html): `$root.params.id === b.id` → `$root.params?.id === b.id`

## Tests
✓ 209 passed