### PR TITLE
feat: Battles rail click opens current battle, remove obsolete list page

### DIFF
--- a/t01_llm_battle/static/index.html
+++ b/t01_llm_battle/static/index.html
@@ -735,8 +735,8 @@
 
       <!-- Nav icons -->
       <div class="rail-nav">
-        <button class="rail-btn" :class="{ active: route === 'battles/detail' || route === 'battles' }"
-                @click="window.location.hash = params.id ? '#/battles/' + params.id : '#/battles'"
+        <button class="rail-btn" :class="{ active: route === 'battles/detail' || route === 'battles/new' }"
+                @click="resolveBattlesHash()"
                 title="Battles">
           <span>⚔</span>
           <span class="rail-btn-label">Battles</span>
@@ -791,14 +791,6 @@
         <span>⚠ No API keys configured. Battles require at least one active provider.</span>
         <button class="btn-warning" @click="$dispatch('open-providers-modal')">Configure API Keys →</button>
       </div>
-
-      <!-- Empty state when no battle selected -->
-      <section x-show="route === 'battles'" style="height:70%;display:flex;align-items:center;justify-content:center;">
-        <div style="text-align:center;">
-          <p class="text-muted" style="font-size:1rem;margin-bottom:1rem;">Select a battle from the sidebar or create a new one.</p>
-          <button class="btn-primary" @click="$dispatch('create-battle')">+ New Battle</button>
-        </div>
-      </section>
 
       <!-- ── Battle detail ───────────────────────── -->
       <section x-show="route === 'battles/detail'"
@@ -1461,7 +1453,7 @@
               <span class="badge-muted" x-text="runId ? runId.slice(0,8) + '...' : ''"></span>
             </template>
           </div>
-          <a :href="run && run.battle_id ? '#/battles/' + run.battle_id : '#/battles'"
+          <a :href="run && run.battle_id ? '#/battles/' + run.battle_id : '#/battles/new'"
              class="text-muted" style="text-decoration:none;font-size:0.86rem;">← Back to Battle</a>
         </div>
 
@@ -1589,7 +1581,7 @@
               class="ba-btn ba-btn-secondary" style="color:var(--ba-accent,#d4a02a);border-color:rgba(212,160,42,0.3);">
               Download Markdown
             </button>
-            <a :href="results && results.battle_id ? '#/battles/' + results.battle_id : '#/battles'"
+            <a :href="results && results.battle_id ? '#/battles/' + results.battle_id : '#/battles/new'"
                class="text-muted" style="text-decoration:none;font-size:0.86rem;">← Back to Battle</a>
           </div>
         </div>
@@ -1818,7 +1810,7 @@
       <section x-show="route === 'not-found'">
         <h1>Page not found</h1>
         <p class="text-muted">No route matches <code x-text="window.location.hash"></code>.
-          <a href="#/battles" style="color:var(--gold);text-decoration:none;">Go home</a>.
+          <a href="#/" style="color:var(--gold);text-decoration:none;">Go home</a>.
         </p>
       </section>
 

--- a/t01_llm_battle/static/js/app.js
+++ b/t01_llm_battle/static/js/app.js
@@ -16,6 +16,24 @@ function app() {
       } catch(_) { this.hasActiveProvider = true; }
     },
 
+    async resolveBattlesHash() {
+      try {
+        const resp = await fetch('/battles');
+        const battles = (await resp.json()).filter(b => b && b.id);
+        if (battles.length === 0) {
+          window.location.hash = '/battles/new';
+          return;
+        }
+        const lastId = localStorage.getItem('t01-battle:lastBattleId');
+        if (lastId && battles.some(b => b.id === lastId)) {
+          window.location.hash = '/battles/' + lastId;
+        } else {
+          const sorted = battles.sort((a, b) => b.created_at > a.created_at ? 1 : -1);
+          window.location.hash = '/battles/' + sorted[0].id;
+        }
+      } catch(_) { window.location.hash = '/battles/new'; }
+    },
+
     async init() {
       this.parseRoute();
       await this.checkKeys();
@@ -25,16 +43,7 @@ function app() {
       window.addEventListener('set-active-tab', e => { this.activeTab = e.detail; });
       const h = window.location.hash;
       if (!h || h === '#/' || h === '#/battles' || h === '#/battles/new') {
-        try {
-          const resp = await fetch('/battles');
-          const battles = (await resp.json()).filter(b => b && b.id);
-          if (battles.length > 0) {
-            const sorted = battles.sort((a, b) => b.created_at > a.created_at ? 1 : -1);
-            window.location.hash = '/battles/' + sorted[0].id;
-          } else {
-            window.location.hash = '/battles';
-          }
-        } catch(_) { window.location.hash = '/battles'; }
+        await this.resolveBattlesHash();
       }
     },
 
@@ -43,9 +52,13 @@ function app() {
       const hash = raw || 'battles';
       const parts = hash.split('/');
 
-      if (hash === 'battles' || hash === '' || (parts[0] === 'battles' && parts[1] === 'new')) {
-        this.route = 'battles'; this.params = {};
+      if (hash === 'battles' || hash === '') {
+        this.resolveBattlesHash();
+        return;
+      } else if (parts[0] === 'battles' && parts[1] === 'new') {
+        this.route = 'battles/new'; this.params = {};
       } else if (parts[0] === 'battles' && parts[1]) {
+        localStorage.setItem('t01-battle:lastBattleId', parts[1]);
         this.route = 'battles/detail'; this.params = { id: parts[1] };
       } else if (parts[0] === 'runs' && parts[1]) {
         this.route = 'runs/detail'; this.params = { id: parts[1] };


### PR DESCRIPTION
Persist lastBattleId to localStorage on battle detail visit.
Resolve #/battles to last-opened → first-by-date → /battles/new.
Remove empty-state section. Rail button calls resolveBattlesHash().

Closes #304