### PR TITLE
feat: rail expanded by default, add News Boards entry, nest Sources under it

### DIFF
--- a/t01_llm_battle/static/index.html
+++ b/t01_llm_battle/static/index.html
@@ -747,11 +747,11 @@
           <span>⚙</span>
           <span class="rail-btn-label">Providers</span>
         </button>
-        <button class="rail-btn" :class="{ active: route === 'news-sources' }"
-                @click="window.location.hash = '#/news-sources'"
-                title="News Sources">
-          <span>☵</span>
-          <span class="rail-btn-label">Sources</span>
+        <button class="rail-btn" :class="{ active: route === 'news-boards' || route === 'news-sources' }"
+                @click="window.location.hash = '#/news-boards'"
+                title="News Boards">
+          <span>📋</span>
+          <span class="rail-btn-label">Boards</span>
         </button>
       </div>
 
@@ -1449,6 +1449,23 @@
         </div>
 
       </section>
+
+      <!-- ── News Boards ─────────────────────────── -->
+      <section x-show="route === 'news-boards'">
+        <h1>News Boards</h1>
+        <p class="text-muted" style="margin-bottom:2rem;">Create and manage news boards. Track sources, schedule publishing, and monitor live updates.</p>
+        <div style="display:flex;gap:1rem;flex-wrap:wrap;margin-bottom:2rem;">
+          <button class="btn-primary" @click="$dispatch('create-board')">+ New Board</button>
+          <a href="#/news-boards/sources" class="btn-secondary" style="text-decoration:none;display:inline-block;padding:0.5rem 1rem;border-radius:0.25rem;border:1px solid var(--gold);color:var(--gold);">Manage Sources</a>
+        </div>
+        <div class="text-muted" style="font-size:0.9rem;">No boards yet. Create your first board to start.</div>
+      </section>
+
+      <!-- ── News Sources (sub-route of boards) ──── -->
+      <section x-show="route === 'news-sources'">
+        <div style="margin-bottom:1.5rem;">
+          <a href="#/news-boards" style="color:var(--gold);text-decoration:none;font-size:0.9rem;">← Back to Boards</a>
+        </div>
 
       <!-- ── Live run view ───────────────────────── -->
       <section x-show="route === 'runs/detail'" x-data="runView()"

--- a/t01_llm_battle/static/js/app.js
+++ b/t01_llm_battle/static/js/app.js
@@ -5,7 +5,7 @@ function app() {
     params: {},
     hasActiveProvider: true,
     sidebarOpen: false,
-    railExpanded: false,
+    railExpanded: true,
     activeTab: 'setup',
 
     async checkKeys() {
@@ -51,8 +51,13 @@ function app() {
         this.route = 'runs/detail'; this.params = { id: parts[1] };
       } else if (parts[0] === 'results' && parts[1]) {
         this.route = 'results/detail'; this.params = { id: parts[1] };
-      } else if (parts[0] === 'news-sources') {
+      } else if (parts[0] === 'news-boards' && parts[1] === 'sources') {
         this.route = 'news-sources'; this.params = {};
+      } else if (parts[0] === 'news-boards') {
+        this.route = 'news-boards'; this.params = {};
+      } else if (parts[0] === 'news-sources') {
+        window.location.hash = '#/news-boards/sources';
+        return;
       } else {
         this.route = 'not-found'; this.params = {};
       }

--- a/t01_llm_battle/static/js/news-boards.js
+++ b/t01_llm_battle/static/js/news-boards.js
@@ -1,0 +1,11 @@
+// ── News Boards (stub) ────────────────────────────────────
+function newsBoards() {
+  return {
+    boards: [],
+
+    async init() {
+      // TODO: fetch boards from /news-boards API (in follow-up PR #262)
+      this.boards = [];
+    }
+  };
+}


### PR DESCRIPTION
- Set railExpanded: true (line 8 app.js)
- Replace Sources rail button with News Boards button
- Add News Boards page section (stub)
- Redirect #/news-sources to #/news-boards/sources
- Add back link from Sources sub-page to Boards

Closes #303