### PR TITLE
fix: number each fighter card 1..N with position ordinal badge

### DIFF
--- a/t01_llm_battle/static/ba.css
+++ b/t01_llm_battle/static/ba.css
@@ -352,6 +352,21 @@
   font-family: var(--ba-font-mono);
 }
 
+.ba-fighter-num {
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  border: 2px solid var(--ba-accent);
+  color: var(--ba-accent);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 11px;
+  font-weight: 700;
+  flex-shrink: 0;
+  font-family: var(--ba-font-mono);
+}
+
 .ba-fighter-body {
   flex: 1;
   display: flex;

--- a/t01_llm_battle/static/index.html
+++ b/t01_llm_battle/static/index.html
@@ -939,6 +939,7 @@
                   <div class="ba-card">
                     <div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:8px;">
                       <div style="display:flex;align-items:center;gap:8px;">
+                        <div class="ba-fighter-num" x-text="fighter.position"></div>
                         <span style="font-weight:600;font-size:13px;" x-text="fighter.name"></span>
                         <span x-show="fighter.is_manual" class="badge-muted">manual</span>
                       </div>

--- a/t01_llm_battle/static/js/fighter-list.js
+++ b/t01_llm_battle/static/js/fighter-list.js
@@ -136,7 +136,7 @@ function fighterList() {
           } catch(_) {}
           return { ...f, steps: [] };
         }));
-        this.fighters = withSteps;
+        this.fighters = withSteps.slice().sort((a, b) => (a.position ?? 0) - (b.position ?? 0));
         this._dispatchCount();
       } catch(e) { this.fightersError = e.message; }
       finally { this.loadingFighters = false; }


### PR DESCRIPTION
Closes #308

## Changes
- Add fighter ordinal badge (position 1..N) to each fighter card header
- Sort fighters by position in load() to ensure correct order
- New .ba-fighter-num style: border-only circle, distinct from step number badge

## Acceptance Criteria
- [x] Each fighter card shows 1-based position prominently
- [x] Ordinals reflect fighter.position from API (not insertion order)
- [x] Visual style distinct from step number (border vs filled)
- [x] Section title remains 'Fighters'; only per-card numbering changes
- [x] No console errors; tests pass