### PR TITLE
fix: validate source_filter tags on board create/update

### DIFF
--- a/t01_llm_battle/routers/boards.py
+++ b/t01_llm_battle/routers/boards.py
@@ -149,6 +149,26 @@ def _row_to_board(row, topics: list[BoardTopicOut]) -> BoardOut:
     )
 
 
+async def _validate_source_filter(source_filter: list[str]) -> None:
+    """Raise 422 if source_filter is non-empty but no active news_source matches any tag."""
+    if not source_filter:
+        return
+    async with get_db() as db:
+        cur = await db.execute(
+            "SELECT tags FROM news_source WHERE status = 'active'"
+        )
+        rows = await cur.fetchall()
+    all_tags: set[str] = set()
+    for row in rows:
+        all_tags.update(_json.loads(row["tags"] or "[]"))
+    unmatched = [t for t in source_filter if t not in all_tags]
+    if unmatched:
+        raise HTTPException(
+            status_code=422,
+            detail=f"source_filter contains tags that match no active source: {unmatched}",
+        )
+
+
 async def _get_board_or_404(board_id: str):
     async with get_db() as db:
         cur = await db.execute("SELECT * FROM board WHERE id = ?", (board_id,))
@@ -173,6 +193,7 @@ async def list_boards():
 
 @router.post("", response_model=BoardOut, status_code=201)
 async def create_board(body: BoardCreate):
+    await _validate_source_filter(body.source_filter)
     now = datetime.now(timezone.utc).isoformat()
     board_id = str(uuid.uuid4())
     async with get_db() as db:
@@ -206,6 +227,8 @@ async def update_board(board_id: str, body: BoardUpdate):
     row, _ = await _get_board_or_404(board_id)
     if bool(row["is_system"]):
         raise HTTPException(status_code=403, detail="System boards cannot be modified")
+    if body.source_filter is not None:
+        await _validate_source_filter(body.source_filter)
     now = datetime.now(timezone.utc).isoformat()
     updates = body.model_dump(exclude_none=True)
     if not updates:

--- a/tests/test_boards_router.py
+++ b/tests/test_boards_router.py
@@ -362,3 +362,56 @@ async def test_publish_static_endpoint(client, db_path, tmp_path):
 async def test_publish_unknown_board_returns_404(client):
     resp = await client.post("/boards/nonexistent-id/publish")
     assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# source_filter validation (FR-26 bug fix)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_create_board_invalid_source_filter_returns_422(client):
+    """source_filter with tags matching no active news_source must return 422."""
+    resp = await client.post("/boards", json={"name": "Bad Filter", "source_filter": ["nonexistent-tag-xyz"]})
+    assert resp.status_code == 422
+    detail = resp.json()["detail"]
+    assert "nonexistent-tag-xyz" in detail
+
+
+@pytest.mark.asyncio
+async def test_create_board_empty_source_filter_allowed(client):
+    """Empty source_filter skips validation — board created successfully."""
+    resp = await client.post("/boards", json={"name": "No Filter", "source_filter": []})
+    assert resp.status_code == 201
+
+
+@pytest.mark.asyncio
+async def test_create_board_valid_source_filter_allowed(client):
+    """source_filter with tags matching a system news_source succeeds."""
+    resp = await client.post("/boards", json={"name": "Valid Filter", "source_filter": ["tech"]})
+    assert resp.status_code == 201
+    assert resp.json()["source_filter"] == ["tech"]
+
+
+@pytest.mark.asyncio
+async def test_update_board_invalid_source_filter_returns_422(client):
+    """Updating source_filter to invalid tags returns 422."""
+    resp = await client.post("/boards", json={"name": "Update Filter Board"})
+    assert resp.status_code == 201
+    board_id = resp.json()["id"]
+
+    resp = await client.put(f"/boards/{board_id}", json={"source_filter": ["no-such-tag-abc"]})
+    assert resp.status_code == 422
+    assert "no-such-tag-abc" in resp.json()["detail"]
+
+
+@pytest.mark.asyncio
+async def test_update_board_omitted_source_filter_skips_validation(client):
+    """update_board with no source_filter field does not trigger validation."""
+    resp = await client.post("/boards", json={"name": "Skip Validation Board"})
+    assert resp.status_code == 201
+    board_id = resp.json()["id"]
+
+    resp = await client.put(f"/boards/{board_id}", json={"name": "Renamed"})
+    assert resp.status_code == 200
+    assert resp.json()["name"] == "Renamed"


### PR DESCRIPTION
Closes #322

## Problem
`BoardCreate.source_filter` accepted any tag values with no validation. If tags matched no active `news_source`, board runs silently fetched 0 items with no error surfaced to the caller.

## Fix
Added `_validate_source_filter()` helper in `routers/boards.py` that queries active `news_source` tags before create/update. Returns 422 with the offending tags listed if no source matches.

## Changes
- `t01_llm_battle/routers/boards.py` — `_validate_source_filter()` helper; called in `create_board` and `update_board` (only when `source_filter` is present in update)
- `tests/test_boards_router.py` — 5 new tests covering invalid tags, empty filter, valid filter, update invalid, update omitted

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>