### PR TITLE
fix: store assigned news_fighter name in board_news_item rows

### DIFF
--- a/t01_llm_battle/board_engine.py
+++ b/t01_llm_battle/board_engine.py
@@ -302,6 +302,7 @@ async def execute_board_run(board_id: str, db_path=DB_PATH) -> str:
             for item in items[:src["max_items"]]:
                 item["source_name"] = src["name"]
                 item["source_id"] = src["id"]
+                item["source_affinity"] = src.get("fighter_affinity") or "[]"
                 all_raw.append(item)
 
         items_fetched = len(all_raw)
@@ -332,8 +333,36 @@ async def execute_board_run(board_id: str, db_path=DB_PATH) -> str:
 
         items_processed = len(deduped)
 
+        # Load fighter names for attribution
+        fighter_ids = json.loads(board["fighter_ids"] or "[]")
+        fighter_name_map: dict[str, str] = {}
+        if fighter_ids:
+            async with get_db(db_path) as db:
+                placeholders = ",".join("?" * len(fighter_ids))
+                cur = await db.execute(
+                    f"SELECT id, name FROM news_fighter WHERE id IN ({placeholders})",
+                    fighter_ids,
+                )
+                fighter_name_map = {r["id"]: r["name"] for r in await cur.fetchall()}
+
+        def _pick_fighter_name(item: dict) -> str:
+            """Pick fighter for item: prefer affinity match, else first board fighter."""
+            src_affinity = json.loads(item.get("source_affinity") or "[]")
+            for fid in src_affinity:
+                if fid in fighter_name_map:
+                    return fighter_name_map[fid]
+            # Fallback: first board fighter
+            for fid in fighter_ids:
+                if fid in fighter_name_map:
+                    return fighter_name_map[fid]
+            return ""
+
+        # Tag each item with its assigned fighter name
+        for item in deduped:
+            item["fighter_name"] = _pick_fighter_name(item)
+
         # Normalize and store items
-        norm_tasks = [_normalize_item(item, board, item.get("source_name", ""), db_path) for item in deduped]
+        norm_tasks = [_normalize_item(item, board, item["fighter_name"], db_path) for item in deduped]
         norm_results = await asyncio.gather(*norm_tasks, return_exceptions=True)
 
         async with get_db(db_path) as db:
@@ -349,7 +378,7 @@ async def execute_board_run(board_id: str, db_path=DB_PATH) -> str:
                        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
                     (item_id, run_id, board_id, norm["title"], norm["summary"],
                      raw.get("url", ""), raw.get("source_name", ""),
-                     "", norm["category"], tags_json,
+                     raw.get("fighter_name", ""), norm["category"], tags_json,
                      norm["relevance_score"], raw.get("published_at"), now),
                 )
             # Update run as complete

--- a/tests/test_board_runs_router.py
+++ b/tests/test_board_runs_router.py
@@ -210,3 +210,85 @@ def test_dedup_hash_deterministic():
     # Different title → different hash
     h3 = hashlib.sha256("https://ex.com|Other Title".encode()).hexdigest()
     assert h1 != h3
+
+
+# ---------------------------------------------------------------------------
+# fighter_name attribution (bug fix #318)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_execute_board_run_stores_fighter_name(db_path):
+    """board_news_item.fighter_name must be the assigned news_fighter name, not empty."""
+    import t01_llm_battle.board_engine as engine_mod
+    from unittest.mock import patch, AsyncMock
+    from t01_llm_battle.board_engine import execute_board_run
+    from t01_llm_battle.db import get_db
+
+    # Seed a news_fighter row
+    fighter_id = str(uuid.uuid4())
+    battle_fighter_id = str(uuid.uuid4())
+    battle_id_seed = str(uuid.uuid4())
+    now = "2026-01-01T00:00:00+00:00"
+    async with get_db(db_path) as db:
+        await db.execute(
+            "INSERT INTO battle (id, name, judge_provider, judge_model, judge_rubric, created_at) VALUES (?, ?, '', '', '', ?)",
+            (battle_id_seed, "Seed Battle", now),
+        )
+        await db.execute(
+            "INSERT INTO fighter (id, battle_id, name, is_manual, position) VALUES (?, ?, ?, 0, 1)",
+            (battle_fighter_id, battle_id_seed, "Test Fighter"),
+        )
+        await db.execute(
+            "INSERT INTO news_fighter (id, fighter_id, name, priority, is_system, created_at, updated_at) VALUES (?, ?, ?, 1, 0, ?, ?)",
+            (fighter_id, battle_fighter_id, "My News Fighter", now, now),
+        )
+        # Get system board and update fighter_ids
+        cur = await db.execute("SELECT id FROM board WHERE is_system = 1 LIMIT 1")
+        row = await cur.fetchone()
+        board_id = row["id"]
+        await db.execute(
+            "UPDATE board SET fighter_ids = ? WHERE id = ?",
+            (json.dumps([fighter_id]), board_id),
+        )
+        await db.commit()
+
+    # Mock _fetch_source to return one item
+    fake_item = {"title": "Test Article", "content": "Some content", "url": "https://ex.com/1", "published_at": now}
+    with patch.object(engine_mod, "_fetch_source", new=AsyncMock(return_value=[fake_item])):
+        run_id = await execute_board_run(board_id, db_path=db_path)
+
+    # Verify fighter_name is stored
+    async with get_db(db_path) as db:
+        cur = await db.execute("SELECT fighter_name FROM board_news_item WHERE run_id = ?", (run_id,))
+        rows = await cur.fetchall()
+
+    assert len(rows) > 0, "Expected at least one board_news_item row"
+    assert rows[0]["fighter_name"] == "My News Fighter", f"Expected 'My News Fighter', got '{rows[0]['fighter_name']}'"
+
+
+@pytest.mark.asyncio
+async def test_execute_board_run_fighter_name_empty_when_no_fighters(db_path):
+    """fighter_name is empty string when board has no fighter_ids."""
+    import t01_llm_battle.board_engine as engine_mod
+    from unittest.mock import patch, AsyncMock
+    from t01_llm_battle.board_engine import execute_board_run
+    from t01_llm_battle.db import get_db
+
+    now = "2026-01-01T00:00:00+00:00"
+    async with get_db(db_path) as db:
+        cur = await db.execute("SELECT id FROM board WHERE is_system = 1 LIMIT 1")
+        row = await cur.fetchone()
+        board_id = row["id"]
+        await db.execute("UPDATE board SET fighter_ids = '[]' WHERE id = ?", (board_id,))
+        await db.commit()
+
+    fake_item = {"title": "No Fighter Item", "content": "Content", "url": "https://ex.com/2", "published_at": now}
+    with patch.object(engine_mod, "_fetch_source", new=AsyncMock(return_value=[fake_item])):
+        run_id = await execute_board_run(board_id, db_path=db_path)
+
+    async with get_db(db_path) as db:
+        cur = await db.execute("SELECT fighter_name FROM board_news_item WHERE run_id = ?", (run_id,))
+        rows = await cur.fetchall()
+
+    assert len(rows) > 0
+    assert rows[0]["fighter_name"] == ""


### PR DESCRIPTION
Closes #318

## Problem
`board_engine.py` hardcoded `""` as `fighter_name` in the INSERT for every `board_news_item`. The fighter assigned to process each item was never recorded.

## Root Cause
Two bugs:
1. Line 336: `_normalize_item` was called with `item.get('source_name', '')` as `fighter_name` — passing the source name instead of the fighter name
2. Line 350: INSERT used hardcoded `""` instead of the assigned fighter name

## Fix
- Added fighter name lookup after dedup: loads `news_fighter` rows for the board's `fighter_ids`
- Added `_pick_fighter_name(item)` helper: uses source `fighter_affinity` for preferred assignment, falls back to first board fighter, then `""`
- Tags each item with `fighter_name` before normalization
- INSERT now uses `raw.get('fighter_name', '')`
- Also propagates source `fighter_affinity` to item dict during fetch

## Changes
- `t01_llm_battle/board_engine.py` — fighter name lookup + `_pick_fighter_name()` + INSERT fix
- `tests/test_board_runs_router.py` — 2 new integration tests verifying fighter_name stored and empty when no fighters

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>