### PR TITLE
feat: add POST /api/templates and DELETE /api/templates/{id}

### DIFF
--- a/t01_llm_battle/routers/templates.py
+++ b/t01_llm_battle/routers/templates.py
@@ -1,0 +1,69 @@
+"""API router: board template discovery, retrieval, upload, and deletion."""
+
+from __future__ import annotations
+
+import re
+
+from fastapi import APIRouter, HTTPException, UploadFile
+
+from fastapi.responses import HTMLResponse
+
+from ..template_service import (
+    list_templates,
+    get_template_html,
+    save_user_template,
+    delete_user_template,
+)
+
+router = APIRouter(prefix="/api/templates", tags=["templates"])
+
+_VALID_ID = re.compile(r'^[a-z0-9][a-z0-9-]{0,63}$')
+
+
+@router.get("")
+async def list_board_templates():
+    """List all available board templates (bundled + user-custom)."""
+    return list_templates()
+
+
+@router.post("", status_code=201)
+async def upload_user_template(file: UploadFile):
+    """Upload a user-custom HTML template.
+
+    The template ID is derived from the filename (stem, lowercased).
+    Accepts only .html files. Cannot overwrite bundled templates.
+    """
+    filename = file.filename or ""
+    if not filename.lower().endswith(".html"):
+        raise HTTPException(status_code=422, detail="Only .html files are accepted")
+
+    template_id = filename[:-5].lower()  # strip .html
+    if not _VALID_ID.match(template_id):
+        raise HTTPException(
+            status_code=422,
+            detail="Template ID (filename stem) must be lowercase alphanumeric with hyphens, 1–64 chars",
+        )
+
+    content = await file.read()
+    info = save_user_template(template_id, content)
+    return info
+
+
+@router.get("/{template_id}", response_class=HTMLResponse)
+async def get_board_template(template_id: str):
+    """Return the HTML content of a specific board template."""
+    html = get_template_html(template_id)
+    if html is None:
+        raise HTTPException(status_code=404, detail=f"Template '{template_id}' not found")
+    return HTMLResponse(content=html)
+
+
+@router.delete("/{template_id}", status_code=204)
+async def delete_board_template(template_id: str):
+    """Delete a user-custom template. Bundled templates cannot be deleted."""
+    try:
+        found = delete_user_template(template_id)
+    except ValueError as exc:
+        raise HTTPException(status_code=403, detail=str(exc))
+    if not found:
+        raise HTTPException(status_code=404, detail=f"Template '{template_id}' not found")

--- a/t01_llm_battle/server.py
+++ b/t01_llm_battle/server.py
@@ -14,6 +14,7 @@ from .routers.runs import router as runs_router
 from .routers.sources import router as sources_router
 from .routers.fighters import router as fighters_router, providers_router
 from .routers.providers import router as provider_mgmt_router
+from .routers.templates import router as templates_router
 
 log = logging.getLogger(__name__)
 
@@ -49,6 +50,7 @@ def create_app(db_path=DB_PATH) -> FastAPI:
     app.include_router(fighters_router)
     app.include_router(providers_router)
     app.include_router(provider_mgmt_router)
+    app.include_router(templates_router)
 
     # Health check
     @app.get("/healthz")

--- a/t01_llm_battle/template_service.py
+++ b/t01_llm_battle/template_service.py
@@ -1,0 +1,74 @@
+"""Board template discovery: bundled + user-custom templates."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TypedDict
+
+_BUNDLED_DIR = Path(__file__).parent / "board_templates"
+_USER_DIR = Path.home() / ".t01-llm-battle" / "templates"
+
+_BUNDLED_META: dict[str, str] = {
+    "card-grid": "Card Grid",
+    "news-feed": "News Feed List",
+}
+
+
+class TemplateInfo(TypedDict):
+    id: str
+    name: str
+    source: str  # "bundled" | "user"
+    path: str
+
+
+def list_templates() -> list[TemplateInfo]:
+    """Return all available templates (bundled first, then user-custom)."""
+    results: list[TemplateInfo] = []
+
+    for stem, label in _BUNDLED_META.items():
+        html_path = _BUNDLED_DIR / f"{stem}.html"
+        if html_path.exists():
+            results.append({"id": stem, "name": label, "source": "bundled", "path": str(html_path)})
+
+    if _USER_DIR.exists():
+        for html_file in sorted(_USER_DIR.glob("*.html")):
+            tid = html_file.stem
+            if any(t["id"] == tid for t in results):
+                continue  # user cannot override bundled names
+            results.append({"id": tid, "name": tid.replace("-", " ").title(), "source": "user", "path": str(html_file)})
+
+    return results
+
+
+def get_template_path(template_id: str) -> Path | None:
+    """Return resolved Path for a template ID, or None if not found."""
+    for t in list_templates():
+        if t["id"] == template_id:
+            return Path(t["path"])
+    return None
+
+
+def get_template_html(template_id: str) -> str | None:
+    """Return HTML content for a template ID, or None if not found."""
+    path = get_template_path(template_id)
+    return path.read_text(encoding="utf-8") if path else None
+
+
+def save_user_template(template_id: str, content: bytes) -> TemplateInfo:
+    """Save an HTML file to _USER_DIR. Returns the new TemplateInfo."""
+    _USER_DIR.mkdir(parents=True, exist_ok=True)
+    dest = _USER_DIR / f"{template_id}.html"
+    dest.write_bytes(content)
+    return {"id": template_id, "name": template_id.replace("-", " ").title(), "source": "user", "path": str(dest)}
+
+
+def delete_user_template(template_id: str) -> bool:
+    """Delete a user template by ID. Returns True if deleted, False if not found.
+    Raises ValueError if template_id refers to a bundled template."""
+    if template_id in _BUNDLED_META:
+        raise ValueError(f"Cannot delete bundled template '{template_id}'")
+    dest = _USER_DIR / f"{template_id}.html"
+    if not dest.exists():
+        return False
+    dest.unlink()
+    return True

--- a/tests/test_templates_router.py
+++ b/tests/test_templates_router.py
@@ -1,0 +1,75 @@
+"""Tests for POST /api/templates and DELETE /api/templates/{id}."""
+
+from __future__ import annotations
+
+import io
+import pytest
+
+
+async def test_list_templates_empty(client):
+    resp = await client.get("/api/templates")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert isinstance(data, list)
+
+
+async def test_upload_template_success(client, tmp_path, monkeypatch):
+    import t01_llm_battle.template_service as ts
+    user_dir = tmp_path / "templates"
+    monkeypatch.setattr(ts, "_USER_DIR", user_dir)
+
+    html_content = b"<html><body>Hello</body></html>"
+    resp = await client.post(
+        "/api/templates",
+        files={"file": ("my-template.html", io.BytesIO(html_content), "text/html")},
+    )
+    assert resp.status_code == 201
+    data = resp.json()
+    assert data["id"] == "my-template"
+    assert data["source"] == "user"
+    assert (user_dir / "my-template.html").read_bytes() == html_content
+
+
+async def test_upload_template_non_html_rejected(client):
+    resp = await client.post(
+        "/api/templates",
+        files={"file": ("bad.txt", io.BytesIO(b"text"), "text/plain")},
+    )
+    assert resp.status_code == 422
+
+
+async def test_upload_template_invalid_id_rejected(client):
+    resp = await client.post(
+        "/api/templates",
+        files={"file": ("Bad Name!.html", io.BytesIO(b"<html/>"), "text/html")},
+    )
+    assert resp.status_code == 422
+
+
+async def test_delete_user_template_success(client, tmp_path, monkeypatch):
+    import t01_llm_battle.template_service as ts
+    user_dir = tmp_path / "templates"
+    user_dir.mkdir()
+    (user_dir / "my-tmpl.html").write_text("<html/>")
+    monkeypatch.setattr(ts, "_USER_DIR", user_dir)
+
+    resp = await client.delete("/api/templates/my-tmpl")
+    assert resp.status_code == 204
+    assert not (user_dir / "my-tmpl.html").exists()
+
+
+async def test_delete_template_not_found(client, tmp_path, monkeypatch):
+    import t01_llm_battle.template_service as ts
+    monkeypatch.setattr(ts, "_USER_DIR", tmp_path / "templates")
+
+    resp = await client.delete("/api/templates/nonexistent")
+    assert resp.status_code == 404
+
+
+async def test_delete_bundled_template_forbidden(client, tmp_path, monkeypatch):
+    import t01_llm_battle.template_service as ts
+    monkeypatch.setattr(ts, "_USER_DIR", tmp_path / "templates")
+
+    # "card-grid" is a bundled template
+    resp = await client.delete("/api/templates/card-grid")
+    assert resp.status_code == 403


### PR DESCRIPTION
Closes #321

## Changes
- `POST /api/templates`: multipart .html upload; validates extension + ID format (lowercase alphanumeric/hyphens); saves to `~/.t01-llm-battle/templates/`; returns 201 + TemplateInfo
- `DELETE /api/templates/{id}`: 204 on success; 403 for bundled templates; 404 if not found
- `template_service.py`: add `save_user_template()` and `delete_user_template()`
- 7 new tests covering all paths

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>