### PR TITLE
fix: wire fighters-updated listener so fighterCount updates Run Battle button

### DIFF
--- a/t01_llm_battle/static/index.html
+++ b/t01_llm_battle/static/index.html
@@ -827,7 +827,7 @@
       <!-- ── Battle detail ───────────────────────── -->
       <section x-show="route === 'battles/detail'"
                x-data="battleDetail()"
-               x-init="$watch('params.id', id => { if (id) load(id); }); if (params.id) load(params.id);">
+               x-init="init(); $watch('params.id', id => { if (id) load(id); }); if (params.id) load(params.id);">
 
         <!-- Battle name row (compact, under topbar) -->
         <div style="display:flex;align-items:center;gap:0.75rem;margin-bottom:1.5rem;flex-wrap:wrap;" x-show="activeTab === 'setup'">

--- a/t01_llm_battle/static/js/battle-detail.js
+++ b/t01_llm_battle/static/js/battle-detail.js
@@ -10,6 +10,10 @@ function battleDetail() {
     judgeEnabled: false, judgeProvider: 'openai', judgeModel: 'gpt-4o', judgeModelCustom: '',
     judgeRubric: DEFAULT_RUBRIC, judgeSaving: false, judgeSaved: false, judgeError: null,
 
+    init() {
+      window.addEventListener('fighters-updated', e => { this.fighterCount = e.detail.count; });
+    },
+
     llmProviders() {
       const pi = window._providerInfoList || [];
       return pi.filter(p => p.provider_type === 'llm' && p.enabled);


### PR DESCRIPTION
Closes #334

Problem: Run Battle button always disabled — fighterCount never updates from fighter list

Solution: Wire fighters-updated event listener in battleDetail() init hook to copy event.detail.count into fighterCount.

Changes:
- battle-detail.js: Add init() method
- index.html: Call init() in battleDetail x-init

Tests: 126 pass, no debug code, spec match verified.