### PR TITLE
chore: add Makefile clean target to purge stale __pycache__ from removed modules

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,5 @@
+.PHONY: clean
+
+clean:
+	find . -name "__pycache__" -not -path "./.git/*" -exec rm -rf {} +
+	find . -name "*.pyc" -not -path "./.git/*" -delete


### PR DESCRIPTION
## Summary

- Adds `Makefile` with a `make clean` target
- Removes all `__pycache__` directories and `.pyc` files (stale bytecode from removed boards/news_fighters/news_sources modules)

## Issues

Closes #343

🤖 Generated with [Claude Code](https://claude.com/claude-code)