### PR TITLE
docs: update PRD for UI restructuring — rename Results to Runs

### DIFF
--- a/prd/03-functional-requirements.md
+++ b/prd/03-functional-requirements.md
@@ -14,14 +14,14 @@
 | FR-8 | Provider Management | Per-provider config: display name (optional, defaults to provider slug), API key, server URL / base URL (optional, for Ollama, LLM Studio, self-hosted); stored in SQLite; env vars override key at runtime; API key masked in UI |
 | FR-9 | Rate Limiting | Per-provider RPM throttling with bounded concurrency |
 | FR-10 | Run Execution | Parallel across fighters × sources; sequential within a fighter's steps |
-| FR-11 | Live Run View | Polling UI; step-level status per fighter per source item |
+| FR-11 | Live Run View | Polling UI; step-level status per fighter per source item. The live view is a **section within the Run detail page** (`#/runs/{id}`), not a standalone route/tab. |
 | FR-12 | LLM-as-Judge | Optional. When configured, scores final step output per fighter per source (0–10 + reasoning). When not configured, run completes without scoring. |
 | FR-13 | Markdown Report | Judge generates a markdown summary; rendered in browser via marked.js |
-| FR-14 | Results View | Fighter summary leaderboard table (rank, avg score, cost, tokens, time) + per-source breakdown with expandable output. When no judge, outputs shown without scores. See [09-ui-redesign.md](./09-ui-redesign.md). |
+| FR-14 | Runs & Results View | Battle detail has two tabs: **Setup** \| **Runs**. The Runs tab lists all runs (newest first) with run-level aggregates (status, started, duration, fighter count, source count, total cost, judge Y/N). Clicking a run row opens the **Run detail page** (`#/runs/{id}`): a single page combining a **Progress** section (live polling while `pending`/`running`) and a **Results** section (leaderboard + per-source breakdown + judge report, shown once `complete`). "Run Battle" on Setup navigates directly to the Run detail page. See [09-ui-redesign.md](./09-ui-redesign.md). |
 | FR-15 | SQLite Persistence | All battles, sources, fighters, steps, runs, results, judgments, api_keys |
 | FR-16 | Custom Model IDs | Override catalog slugs; pricing shown as "unknown" |
 | FR-19 | Provider Management UI | Modal overlay (opened from sidebar icon); lists LLM and tool providers with enable/disable toggle, key status, edit form for API key, display name, server URL; pricing refresh button; uninstall non-system providers |
-| FR-20 | App Layout | 3-column layout: collapsible icon rail sidebar (64px) + tabbed main content (Setup/Run/Results) + right rail battle list (320px). See [09-ui-redesign.md](./09-ui-redesign.md) for mockups. |
+| FR-20 | App Layout | 3-column layout: collapsible icon rail sidebar (64px) + tabbed main content (Setup/Runs) + right rail battle list (320px). See [09-ui-redesign.md](./09-ui-redesign.md) for mockups. |
 
 ---
 
@@ -175,11 +175,25 @@ Unknown keys are passed through to the provider as-is — forward-compatible wit
 
 ---
 
-## Detail: FR-14 Results View
+## Detail: FR-14 Runs & Results View
 
-- **Fighter Summary**: leaderboard table showing rank, fighter name, avg score, total cost, token count, latency, success/fail counts
-- **Per-Source Breakdown**: expandable cards per source item showing each fighter's output, score, cost, and tokens side-by-side
-- "Show output" toggle per fighter result to expand/collapse full output text
-- **When judge is configured**: scores shown in leaderboard and per-source cards
-- **When no judge is configured**: outputs shown without scores; users compare quality visually
-- Download Markdown button for judge report
+### Runs Tab (within battle detail)
+
+- Lists all runs for the current battle, newest first
+- Columns: Started, Status, Duration, Fighters, Sources, Total cost, Judge (Y/N)
+- Empty state: "No runs yet. Run a battle to see runs here."
+- Clicking a run row navigates to `#/runs/{run_id}`
+
+### Run Detail Page (`#/runs/{run_id}`)
+
+Combines Progress and Results in one page (no tab switch needed):
+
+- **Progress section**: live polling status grid (source × fighter); shown while status is `pending`/`running`; condenses to a status header once terminal
+- **Results section**: appears when run reaches `complete` (or shows "Waiting for completion..." placeholder while running)
+  - **Fighter Summary**: leaderboard table showing rank, fighter name, avg score, total cost, token count, latency, success/fail counts
+  - **Per-Source Breakdown**: expandable cards per source item showing each fighter's output, score, cost, and tokens side-by-side; "Show output" toggle per fighter
+  - **When judge is configured**: scores shown in leaderboard and per-source cards
+  - **When no judge is configured**: outputs shown without scores; users compare quality visually
+  - Download Markdown + Copy Report affordances
+- Polling stops once status is terminal
+- `#/results/{run_id}` (old bookmarks) redirects to `#/runs/{run_id}`

--- a/prd/05-user-stories.md
+++ b/prd/05-user-stories.md
@@ -9,11 +9,11 @@
 | US-5 | Any user | Upload markdown files as sources | I can test with my actual documentation or prompts |
 | US-6 | Any user | Enter my API keys once in the UI | I don't have to set env vars every time |
 | US-7 | Any user | Configure temperature and tools per step | I can test OpenAI web_search in step 1 vs not using it |
-| US-8 | Any user | Watch live results appear step by step | I'm not staring at a blank screen during a long run |
+| US-8 | Any user | Watch live results appear step by step on the Run detail page | I'm not staring at a blank screen during a long run (the live Progress section is part of the same page as Results — no navigation needed once the run completes) |
 | US-9 | Any user | Edit the judge rubric | I can score based on my domain's definition of "good" |
 | US-10 | Power user | Enter a custom model ID not in the catalog | I can test new models as soon as providers ship them |
 | US-11 | Any user | See a markdown report summarising fighter rankings | I can share findings with a colleague by copy-pasting the markdown |
-| US-12 | Any user | Drill down into each step's input/output | I can debug which step in a pipeline caused a poor result |
+| US-12 | Any user | Drill down into each step's input/output on the Run detail page | I can debug which step in a pipeline caused a poor result (the same page hosts both live progress and results, so drill-down is continuous from running → complete) |
 | US-13 | Developer | Use Serper search as step 1, GPT-4o as step 2 | I can compare pipelines that include web search |
 | US-14 | Developer | See credit costs alongside token costs in results | I can compare total cost of mixed LLM+tool pipelines |
 | US-15 | Any user | Manage providers in the sidebar (enable/disable, edit API key, server URL) | I can configure my providers without touching env vars or config files |

--- a/prd/09-ui-redesign.md
+++ b/prd/09-ui-redesign.md
@@ -17,7 +17,7 @@ Redesign the battle app UI from a 2-column text sidebar to a 3-column layout wit
 │  Icon  │ │ Battle Name    run-id     │   │  Right Rail   │
 │  Rail  │ └───────────────────────────┘   │               │
 │        │ ┌─ Tabs ────────────────────┐   │  BATTLES      │
-│  ☰ ←→  │ │ Setup │ Run │ Results    │   │  + New        │
+│  ☰ ←→  │ │ Setup │ Runs           │   │  + New        │
 │        │ └───────────────────────────┘   │               │
 │  ⚔ bat │                                │  ● Battle A   │
 │        │ ┌─ Tab Content ─────────────┐   │    new        │
@@ -33,7 +33,7 @@ Redesign the battle app UI from a 2-column text sidebar to a 3-column layout wit
 ```
 
 **Icon rail** (~64px): Collapsible sidebar with icon-only navigation.
-**Main content** (flex: 1): Topbar + tab bar + active tab content.
+**Main content** (flex: 1): Topbar + tab bar (Setup / Runs) + active tab content.
 **Right rail** (~320px): Battle list with active highlighting and status tags.
 
 ---
@@ -63,16 +63,34 @@ Replaces the current text sidebar. Collapsed by default on narrow viewports.
 
 ## Tab Bar
 
-Content area uses tabs instead of vertically stacked sections:
+Content area uses two tabs within battle detail:
 
 | Tab | Content |
 |-----|---------|
-| **Setup** | Sources upload + Fighters cards + Judge config |
-| **Run** | Run progress bar + source × fighter status grid |
-| **Results** | Fighter summary leaderboard + per-source breakdown |
+| **Setup** | Sources upload + Fighters cards + Judge config + Run Battle button |
+| **Runs** | List of all runs for this battle (newest first); click row → Run detail page |
 
-- Tab badges: Run tab shows spinner during active run; Results tab shows score count
+- "Run Battle" button on Setup navigates directly to `#/runs/{new_run_id}` after creating the run
 - Switching tabs preserves state (no re-fetch)
+
+## Run Detail Page (`#/runs/{run_id}`)
+
+A standalone page (not a tab) combining Progress and Results:
+
+```
+┌─ Run: abc12345 ────────────────── ← Back to Battle ──┐
+│  Status: running                                      │
+├─ Progress ────────────────────────────────────────────┤
+│  ████████████░░░░░░  62%                              │
+│              │ Fighter 1  │ Fighter 2                 │
+│  Source 1    │    ● done  │    ◌ run                  │
+│  Source 2    │    ◌ run   │    ○ wait                 │
+├─ Results (waiting for completion…) ───────────────────┤
+│  [shown once run is complete]                         │
+└───────────────────────────────────────────────────────┘
+```
+
+Once complete, Progress condenses to a status header and Results section becomes the focus.
 
 ---
 
@@ -140,7 +158,26 @@ Content area uses tabs instead of vertically stacked sections:
 
 ---
 
-## Run Tab
+## Runs Tab (within battle detail)
+
+```
+┌─ Runs ──────────────────────────────────────────────────────┐
+│  Started          Status    Duration  Fighters  Cost  Judge  │
+│─────────────────────────────────────────────────────────────│
+│  2026-05-05 14:22  complete  11.2s     2         $0.04  ✓   │
+│  2026-05-04 09:11  complete  8.7s      2         $0.03  ✓   │
+└─────────────────────────────────────────────────────────────┘
+
+Empty state: "No runs yet. Run a battle to see runs here."
+```
+
+Row click → navigates to `#/runs/{run_id}`
+
+---
+
+## Run Detail Page
+
+### Progress Section (while pending/running)
 
 ```
 ┌─ Run Progress ──────────────────────────────────────┐
@@ -159,11 +196,9 @@ Content area uses tabs instead of vertically stacked sections:
 ● done (green)  ◌ running (pulse)  ○ waiting (gray)  ✕ error (red)
 ```
 
----
+### Results Section (once complete)
 
-## Results Tab
-
-### Fighter Summary (Leaderboard)
+#### Fighter Summary (Leaderboard)
 
 ```
 ┌─ Fighter Summary ───────────────────────────────────────────┐
@@ -175,7 +210,7 @@ Content area uses tabs instead of vertically stacked sections:
 └─────────────────────────────────────────────────────────────┘
 ```
 
-### Per-Source Breakdown
+#### Per-Source Breakdown
 
 ```
 ┌─ Source: "input-1.txt" ─────────────────────────────────────┐


### PR DESCRIPTION
Closes #350

Updates PRD documentation to reflect renamed Results tab → Runs tab and merged progress/results into single run detail page.

- FR-14: Updated description to reflect new Runs tab + Run detail page
- US-8, US-12: Updated user story descriptions for Run detail page  
- UI redesign: Changed tab bar from 3 to 2 tabs

All acceptance criteria met.