### PR TITLE
feat: show per-step execution time in results view

### DIFF
--- a/t01_llm_battle/routers/runs.py
+++ b/t01_llm_battle/routers/runs.py
@@ -395,6 +395,46 @@ async def get_run_results(run_id: str):
             for r in await cursor.fetchall()
         }
 
+    # Fetch per-step detail for results view (latency, tokens, cost per step)
+    async with get_db() as db:
+        cursor = await db.execute(
+            """
+            SELECT
+                sr.fighter_id,
+                sr.source_id,
+                COALESCE(fs.position, 0) AS step_index,
+                COALESCE(fs.label, 'step ' || (COALESCE(fs.position, 0) + 1)) AS step_label,
+                sr.latency_ms,
+                sr.input_tokens,
+                sr.output_tokens,
+                sr.cost_usd,
+                sr.output_text,
+                sr.error
+            FROM step_result sr
+            LEFT JOIN fighter_step fs ON fs.id = sr.step_id
+            WHERE sr.run_id = ?
+            ORDER BY sr.fighter_id, sr.source_id, step_index
+            """,
+            (run_id,),
+        )
+        sr_detail_rows = [dict(r) for r in await cursor.fetchall()]
+
+    sr_detail: dict[tuple[str, str], list[dict]] = {}
+    for sr in sr_detail_rows:
+        key = (sr["fighter_id"], sr["source_id"])
+        sr_detail.setdefault(key, []).append(
+            {
+                "step_index": sr["step_index"],
+                "step_label": sr["step_label"],
+                "latency_ms": sr["latency_ms"],
+                "input_tokens": sr["input_tokens"],
+                "output_tokens": sr["output_tokens"],
+                "cost_usd": sr["cost_usd"],
+                "output_text": sr["output_text"],
+                "error": sr["error"],
+            }
+        )
+
     summary = []
     for fr in fr_rows:
         key = (fr["fighter_id"], fr["source_id"])
@@ -415,6 +455,7 @@ async def get_run_results(run_id: str):
                 "total_output_tokens": agg["agg_output_tokens"] if agg else fr["total_output_tokens"],
                 "final_output": final_output,
                 "step_count": agg["step_count"] if agg else 0,
+                "step_results": sr_detail.get(key, []),
                 "status": fr["status"],
             }
         )

--- a/t01_llm_battle/routers/runs.py
+++ b/t01_llm_battle/routers/runs.py
@@ -403,7 +403,7 @@ async def get_run_results(run_id: str):
                 sr.fighter_id,
                 sr.source_id,
                 COALESCE(fs.position, 0) AS step_index,
-                COALESCE(fs.label, 'step ' || (COALESCE(fs.position, 0) + 1)) AS step_label,
+                'step ' || (COALESCE(fs.position, 0) + 1) AS step_label,
                 sr.latency_ms,
                 sr.input_tokens,
                 sr.output_tokens,

--- a/t01_llm_battle/static/index.html
+++ b/t01_llm_battle/static/index.html
@@ -1698,6 +1698,9 @@
                         </template>
                         <div style="font-size:0.76rem;color:var(--ba-text-mid,#6b7280);margin-top:6px;">
                           <span x-text="fighter.step_count + ' step(s)'"></span>
+                          <template x-if="fighter.total_latency_ms > 0">
+                            <span>&nbsp;·&nbsp;<span style="font-family:var(--ba-font-mono,monospace);" x-text="formatDuration(fighter.total_latency_ms)"></span></span>
+                          </template>
                           &nbsp;·&nbsp;
                           <span style="font-family:var(--ba-font-mono,monospace);"
                                 x-text="fighter.total_cost_usd === null && (fighter.total_input_tokens || fighter.total_output_tokens) ? 'unknown pricing' : '$' + (fighter.total_cost_usd || 0).toFixed(4) + ' total'"></span>
@@ -1708,6 +1711,41 @@
                             <span>&nbsp;·&nbsp;<span style="color:var(--ba-accent,#d4a02a);">credit-based</span></span>
                           </template>
                         </div>
+                        <!-- Per-step breakdown (only when multiple steps have latency data) -->
+                        <template x-if="fighter.step_results && fighter.step_results.length > 1">
+                          <div style="margin-top:6px;">
+                            <div @click="toggleSteps(source.label + '::' + fighter.fighter_name)"
+                                 style="cursor:pointer;font-size:0.76rem;color:var(--ba-accent,#d4a02a);user-select:none;margin-bottom:4px;">
+                              <span x-text="stepsExpanded[source.label + '::' + fighter.fighter_name] ? '▼ Hide step timing' : '▶ Show step timing'"></span>
+                            </div>
+                            <template x-if="stepsExpanded[source.label + '::' + fighter.fighter_name]">
+                              <table style="width:100%;border-collapse:collapse;font-size:0.74rem;font-family:var(--ba-font-mono,monospace);">
+                                <thead>
+                                  <tr style="color:var(--ba-text-mid,#6b7280);">
+                                    <th style="text-align:left;padding:2px 6px;border-bottom:1px solid var(--ba-border,#e5e5e5);">#</th>
+                                    <th style="text-align:left;padding:2px 6px;border-bottom:1px solid var(--ba-border,#e5e5e5);">Step</th>
+                                    <th style="text-align:right;padding:2px 6px;border-bottom:1px solid var(--ba-border,#e5e5e5);">Duration</th>
+                                    <th style="text-align:right;padding:2px 6px;border-bottom:1px solid var(--ba-border,#e5e5e5);">In/Out tokens</th>
+                                    <th style="text-align:right;padding:2px 6px;border-bottom:1px solid var(--ba-border,#e5e5e5);">Cost</th>
+                                  </tr>
+                                </thead>
+                                <tbody>
+                                  <template x-for="(step, si) in fighter.step_results" :key="si">
+                                    <tr>
+                                      <td style="padding:2px 6px;color:var(--ba-text-mid,#6b7280);" x-text="step.step_index + 1"></td>
+                                      <td style="padding:2px 6px;" x-text="step.step_label"></td>
+                                      <td style="text-align:right;padding:2px 6px;" x-text="formatDuration(step.latency_ms)"></td>
+                                      <td style="text-align:right;padding:2px 6px;color:var(--ba-text-mid,#6b7280);"
+                                          x-text="(step.input_tokens || step.output_tokens) ? (step.input_tokens || 0) + ' / ' + (step.output_tokens || 0) : '—'"></td>
+                                      <td style="text-align:right;padding:2px 6px;"
+                                          x-text="step.cost_usd !== null && step.cost_usd !== undefined ? '$' + step.cost_usd.toFixed(4) : '—'"></td>
+                                    </tr>
+                                  </template>
+                                </tbody>
+                              </table>
+                            </template>
+                          </div>
+                        </template>
                       </div>
                     </div>
                   </template>

--- a/t01_llm_battle/static/js/results-view.js
+++ b/t01_llm_battle/static/js/results-view.js
@@ -1,10 +1,10 @@
 // ── Results view ─────────────────────────────────────────
 function resultsView() {
   return {
-    runId: null, results: null, expanded: {}, error: null, loading: false,
+    runId: null, results: null, expanded: {}, stepsExpanded: {}, error: null, loading: false,
 
     async load(runId) {
-      this.runId = runId; this.results = null; this.error = null; this.expanded = {}; this.loading = true;
+      this.runId = runId; this.results = null; this.error = null; this.expanded = {}; this.stepsExpanded = {}; this.loading = true;
       try {
         const resp = await fetch('/runs/' + runId + '/results');
         if (!resp.ok) throw new Error(await resp.text());
@@ -14,6 +14,13 @@ function resultsView() {
     },
 
     toggleExpand(key) { this.expanded[key] = !this.expanded[key]; },
+    toggleSteps(key) { this.stepsExpanded[key] = !this.stepsExpanded[key]; },
+
+    formatDuration(ms) {
+      if (ms === null || ms === undefined) return '—';
+      if (ms < 1000) return ms + 'ms';
+      return (ms / 1000).toFixed(1) + 's';
+    },
 
     fighterSummary() {
       if (!this.results || !this.results.summary) return [];


### PR DESCRIPTION
Closes #348

Adds per-step execution timing details to the Results view per-source breakdown.

- Backend: Fetches step_result rows with per-step latency, tokens, cost
- Frontend: Shows step table (Step #, Duration, In/Out tokens, Cost) with expand/collapse toggle
- Only shown when multiple steps exist for a fighter/source combination

Tests: 119 tests pass.