### PR TITLE
refactor: rename Results tab to Runs and merge progress with results

### DIFF
--- a/t01_llm_battle/static/index.html
+++ b/t01_llm_battle/static/index.html
@@ -795,10 +795,10 @@
     <!-- ── Main Wrapper ─────────────────────────────── -->
     <div class="main-wrapper">
 
-      <!-- Topbar (battle/run/results views) -->
-      <div class="main-topbar" x-show="route === 'battles/detail' || route === 'runs/detail' || route === 'results/detail'">
+      <!-- Topbar (battle/run views) -->
+      <div class="main-topbar" x-show="route === 'battles/detail' || route === 'runs/detail'">
         <span class="main-topbar-name"
-              x-text="route === 'battles/detail' ? 'Battle Setup' : route === 'runs/detail' ? 'Live Run' : 'Results'">
+              x-text="route === 'battles/detail' ? 'Battle Setup' : 'Run'">
         </span>
         <span class="main-topbar-id"
               x-text="params.id ? params.id.slice(0,8) + '...' : ''"></span>
@@ -807,8 +807,7 @@
       <!-- Tab bar (battle detail only) -->
       <div class="tab-bar" x-show="route === 'battles/detail'">
         <button class="tab-btn" :class="{ active: activeTab === 'setup' }" @click="activeTab = 'setup'">Setup</button>
-        <button class="tab-btn" :class="{ active: activeTab === 'run' }" @click="activeTab = 'run'">Run</button>
-        <button class="tab-btn" :class="{ active: activeTab === 'results' }" @click="activeTab = 'results'">Results</button>
+        <button class="tab-btn" :class="{ active: activeTab === 'runs' }" @click="activeTab = 'runs'">Runs</button>
       </div>
 
     <!-- ── Main content ────────────────────────────── -->
@@ -1262,252 +1261,95 @@
 
         </div><!-- end tab: setup -->
 
-        <!-- Tab: Run -->
-        <div x-show="activeTab === 'run'">
-          <template x-if="!currentRunId">
+        <!-- Tab: Runs -->
+        <div x-show="activeTab === 'runs'"
+             x-data="runsTab()"
+             x-init="$watch('currentBattleId', id => { if (id && activeTab === 'runs') load(id); }); if (currentBattleId && activeTab === 'runs') load(currentBattleId);">
+
+          <template x-if="loading">
+            <p class="text-muted">Loading runs...</p>
+          </template>
+          <template x-if="error">
+            <div style="color:var(--ba-danger,#c00);font-size:0.88rem;" x-text="error"></div>
+          </template>
+          <template x-if="!loading && !error && runs.length === 0">
             <div class="placeholder" style="height:180px;">
               <div style="text-align:center;">
-                <p class="text-muted" style="margin:0 0 0.5rem;font-size:0.9rem;">No active run.</p>
-                <p class="text-muted" style="margin:0;font-size:0.82rem;">Use <strong>Run Battle</strong> in Setup to start.</p>
+                <p class="text-muted" style="margin:0 0 0.5rem;font-size:0.9rem;">No runs yet.</p>
+                <p class="text-muted" style="margin:0;font-size:0.82rem;">Run a battle to see runs here.</p>
               </div>
             </div>
           </template>
-          <template x-if="currentRunId">
-            <div>
-              <!-- Progress bar -->
-              <div class="ba-runbar-wrap">
-                <div class="ba-runbar-label">
-                  <span x-text="currentRun ? (currentRun.status === 'complete' ? 'Complete' : currentRun.status === 'error' ? 'Error' : 'Running...') : 'Starting...'"></span>
-                  <span x-text="runProgress() + '%'"></span>
-                </div>
-                <div class="ba-runbar">
-                  <div class="ba-runbar-fill" :class="{ running: currentRun && currentRun.status === 'running' }"
-                       :style="'width:' + runProgress() + '%'"></div>
-                </div>
-              </div>
-              <!-- Status grid -->
-              <template x-if="currentRun && runSources().length > 0 && runFighters().length > 0">
-                <div style="overflow-x:auto;">
-                  <table class="ba-rungrid">
-                    <thead>
-                      <tr>
-                        <th style="text-align:left;">Source</th>
-                        <template x-for="f in runFighters()" :key="f.fighter_id">
-                          <th x-text="f.fighter_name"></th>
-                        </template>
-                      </tr>
-                    </thead>
-                    <tbody>
-                      <template x-for="s in runSources()" :key="s.source_id">
-                        <tr>
-                          <td style="text-align:left;font-family:var(--mono);font-size:0.82rem;" x-text="s.source_label"></td>
-                          <template x-for="f in runFighters()" :key="f.fighter_id">
-                            <td x-data="{ get cell() { return getRunCell(f.fighter_id, s.source_id); } }">
-                              <span class="ba-status-dot"
-                                    :class="cell ? (cell.status === 'complete' ? 'done' : cell.status === 'error' ? 'error' : cell.status === 'running' ? 'running' : 'waiting') : 'waiting'"
-                                    :title="cell ? cell.status : 'waiting'"
-                                    x-text="cell ? (cell.status === 'complete' ? '●' : cell.status === 'error' ? '✕' : cell.status === 'running' ? '◌' : '○') : '○'">
-                              </span>
-                            </td>
-                          </template>
-                        </tr>
-                      </template>
-                    </tbody>
-                  </table>
-                </div>
-              </template>
-              <!-- Actions -->
-              <div style="margin-top:1rem;display:flex;gap:0.75rem;align-items:center;">
-                <template x-if="currentRun && currentRun.status === 'complete'">
-                  <a :href="'#/results/' + currentRunId"
-                     style="background:var(--success);color:#fff;padding:5px 14px;border-radius:6px;font-size:0.84rem;font-weight:600;text-decoration:none;">
-                    View Results →
-                  </a>
-                </template>
-                <template x-if="currentRun && (currentRun.status === 'running' || currentRun.status === 'pending')">
-                  <button @click="cancelRun()" class="btn-secondary"
-                          style="padding:5px 14px;font-size:0.84rem;color:var(--danger);border-color:var(--danger);">
-                    Cancel Run
-                  </button>
-                </template>
-              </div>
-            </div>
-          </template>
-        </div>
-
-        <!-- Tab: Results -->
-        <div x-show="activeTab === 'results'"
-             x-data="battleResultsTab()"
-             x-init="$watch('currentBattleId', id => { if (id && activeTab === 'results') load(id); }); if (currentBattleId && activeTab === 'results') load(currentBattleId);">
-
-          <template x-if="tabLoading">
-            <p class="text-muted">Loading results...</p>
-          </template>
-          <template x-if="tabError">
-            <div style="color:var(--ba-danger,#c00);font-size:0.88rem;" x-text="tabError"></div>
-          </template>
-          <template x-if="!tabLoading && !tabError && !results">
-            <div class="placeholder" style="height:180px;">
-              <div style="text-align:center;">
-                <p class="text-muted" style="margin:0 0 0.5rem;font-size:0.9rem;">No results yet.</p>
-                <p class="text-muted" style="margin:0;font-size:0.82rem;">Run a battle to see results here.</p>
-              </div>
-            </div>
-          </template>
-
-          <template x-if="results">
-            <div>
-              <!-- Header -->
-              <div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:1.25rem;">
-                <span class="badge-muted" x-text="results.run_id ? results.run_id.slice(0,8) + '...' : ''"></span>
-                <button @click="downloadMarkdown()" class="ba-btn ba-btn-secondary" style="font-size:0.82rem;">
-                  Download Markdown
-                </button>
-              </div>
-
-              <!-- Fighter Summary Leaderboard -->
-              <h2 style="font-size:1rem;margin:0 0 0.75rem;">Fighter Summary</h2>
-              <div class="ba-section" style="overflow-x:auto;margin-bottom:2rem;">
-                <table class="ba-table">
-                  <thead>
-                    <tr>
-                      <th>#</th>
-                      <th>Fighter</th>
-                      <th style="text-align:right;">Avg Score</th>
-                      <th style="text-align:right;">Cost</th>
-                      <th style="text-align:right;">Tokens</th>
-                      <th style="text-align:right;">Time</th>
-                      <th style="text-align:right;">S/F</th>
+          <template x-if="runs.length > 0">
+            <div class="ba-section" style="overflow-x:auto;">
+              <table class="ba-table">
+                <thead>
+                  <tr>
+                    <th style="text-align:left;">Started</th>
+                    <th style="text-align:left;">Status</th>
+                    <th style="text-align:right;">Duration</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <template x-for="r in runs" :key="r.id">
+                    <tr style="cursor:pointer;" @click="navigate('#/runs/' + r.id)">
+                      <td style="font-size:0.84rem;" x-text="formatStarted(r.started_at)"></td>
+                      <td><span :style="statusColor(r.status)" x-text="r.status"></span></td>
+                      <td style="text-align:right;font-family:var(--ba-font-mono,monospace);font-size:0.82rem;"
+                          x-text="formatDuration(r.started_at, r.finished_at)"></td>
                     </tr>
-                  </thead>
-                  <tbody>
-                    <template x-for="(f, idx) in fighterSummary()" :key="f.fighter_name">
-                      <tr>
-                        <td>
-                          <span class="ba-rank-badge" :class="'rank-' + (idx+1)" x-text="idx+1"></span>
-                        </td>
-                        <td style="font-weight:600;" x-text="f.fighter_name"></td>
-                        <td style="text-align:right;">
-                          <span :style="f.avg_score !== null ? scoreColor(f.avg_score) : ''"
-                                x-text="f.avg_score !== null ? f.avg_score.toFixed(2) : '—'"></span>
-                        </td>
-                        <td style="text-align:right;font-family:var(--ba-font-mono,monospace);font-size:0.82rem;"
-                            x-text="f.pricing_unknown ? 'unknown' : '$' + f.total_cost.toFixed(4)"></td>
-                        <td style="text-align:right;font-family:var(--ba-font-mono,monospace);font-size:0.82rem;"
-                            x-text="(f.token_cost > 0 || f.credit_cost > 0) ? ((f.token_cost || 0) + (f.credit_cost || 0)).toFixed(4) : '—'"></td>
-                        <td style="text-align:right;font-family:var(--ba-font-mono,monospace);font-size:0.82rem;"
-                            x-text="f.total_latency_ms > 0 ? (f.total_latency_ms / 1000).toFixed(1) + 's' : '—'"></td>
-                        <td style="text-align:right;">
-                          <span x-text="f.success_count"></span>/<span style="color:var(--danger,#c00);" x-text="f.failed_count"></span>
-                        </td>
-                      </tr>
-                    </template>
-                  </tbody>
-                </table>
-              </div>
-
-              <!-- Per-Source Breakdown -->
-              <h2 style="font-size:1rem;margin:0 0 0.75rem;">Per-Source Breakdown</h2>
-              <template x-for="source in sourceGroups()" :key="source.label">
-                <div class="ba-card" style="padding:0;overflow:hidden;margin-bottom:1rem;">
-                  <div style="padding:9px 14px;font-weight:600;font-size:0.88rem;border-bottom:1px solid var(--ba-border,#e5e5e5);background:var(--ba-bg-paper,#faf9f6);">
-                    <span x-text="source.label"></span>
-                  </div>
-                  <div :style="'display:grid;grid-template-columns:repeat(' + source.fighters.length + ', 1fr);gap:0;'">
-                    <template x-for="(fighter, fi) in source.fighters" :key="fighter.fighter_name">
-                      <div :style="fi > 0 ? 'border-left:1px solid var(--ba-border,#e5e5e5);' : ''">
-                        <div style="padding:8px 14px;border-bottom:1px solid var(--ba-border,#e5e5e5);display:flex;align-items:center;justify-content:space-between;">
-                          <span style="font-weight:600;font-size:0.84rem;" x-text="fighter.fighter_name"></span>
-                          <span :style="'font-size:0.8rem;font-weight:700;padding:2px 8px;border-radius:4px;' + scoreColor(fighter.score)"
-                                x-text="fighter.score !== null && fighter.score !== undefined ? fighter.score.toFixed(1) : 'N/A'"></span>
-                        </div>
-                        <div style="padding:10px 14px;">
-                          <template x-if="fighter.reasoning">
-                            <div style="font-size:0.78rem;color:var(--ba-text-mid,#6b7280);font-style:italic;margin-bottom:6px;line-height:1.4;" x-text="fighter.reasoning"></div>
-                          </template>
-                          <div @click="toggleExpand(source.label + '::' + fighter.fighter_name)"
-                               style="cursor:pointer;display:flex;align-items:center;gap:6px;font-size:0.8rem;color:var(--ba-accent,#d4a02a);margin-bottom:6px;user-select:none;">
-                            <span x-text="tabExpanded[source.label + '::' + fighter.fighter_name] ? '▼ Hide output' : '▶ Show output'"></span>
-                          </div>
-                          <template x-if="tabExpanded[source.label + '::' + fighter.fighter_name]">
-                            <pre style="background:var(--ba-bg-paper,#faf9f6);border:1px solid var(--ba-border,#e5e5e5);border-radius:4px;padding:10px;font-size:0.78rem;white-space:pre-wrap;word-break:break-word;margin:0;max-height:300px;overflow-y:auto;"
-                                 x-text="fighter.final_output || '(no output)'"></pre>
-                          </template>
-                          <div style="font-size:0.76rem;color:var(--ba-text-mid,#6b7280);margin-top:6px;">
-                            <span x-text="fighter.step_count + ' step(s)'"></span>
-                            &nbsp;·&nbsp;
-                            <span style="font-family:var(--ba-font-mono,monospace);"
-                                  x-text="fighter.total_cost_usd === null && (fighter.total_input_tokens || fighter.total_output_tokens) ? 'unknown pricing' : '$' + (fighter.total_cost_usd || 0).toFixed(4) + ' total'"></span>
-                            <template x-if="fighter.total_input_tokens || fighter.total_output_tokens">
-                              <span>&nbsp;·&nbsp;<span x-text="(fighter.total_input_tokens || 0) + ' in / ' + (fighter.total_output_tokens || 0) + ' out tokens'"></span></span>
-                            </template>
-                            <template x-if="(!fighter.total_input_tokens && !fighter.total_output_tokens) && fighter.total_cost_usd">
-                              <span>&nbsp;·&nbsp;<span style="color:var(--ba-accent,#d4a02a);">credit-based</span></span>
-                            </template>
-                          </div>
-                        </div>
-                      </div>
-                    </template>
-                  </div>
-                </div>
-              </template>
-
-              <!-- Judge Report -->
-              <template x-if="results.report_markdown">
-                <div>
-                  <div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:0.5rem;">
-                    <h2 style="font-size:1rem;margin:0;">Judge Report</h2>
-                    <div style="display:flex;gap:0.5rem;">
-                      <button class="ba-btn ba-btn-secondary" @click="copyReport()" x-text="reportCopied ? 'Copied!' : 'Copy Markdown'" style="font-size:0.8rem;"></button>
-                      <button class="ba-btn ba-btn-secondary" @click="window.print()" style="font-size:0.8rem;">Print</button>
-                    </div>
-                  </div>
-                  <div class="ba-card" style="line-height:1.7;" x-html="DOMPurify.sanitize(marked.parse(results.report_markdown))"></div>
-                </div>
-              </template>
+                  </template>
+                </tbody>
+              </table>
             </div>
           </template>
         </div>
 
       </section>
 
-      <!-- ── Live run view ───────────────────────── -->
-      <section x-show="route === 'runs/detail'" x-data="runView()"
+      <!-- ── Run detail (progress + results) ─────── -->
+      <section x-show="route === 'runs/detail'" x-data="runDetail()"
                x-init="$watch('params.id', id => { if (id && route === 'runs/detail') init(id); }); if (params.id && route === 'runs/detail') init(params.id);">
 
+        <!-- Header -->
         <div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:1.25rem;">
           <div style="display:flex;align-items:center;gap:0.75rem;">
-            <h1 style="margin:0;">Live Run</h1>
+            <span class="badge-muted" x-text="runId ? runId.slice(0,8) + '...' : ''"></span>
             <template x-if="run">
-              <span class="badge-muted" x-text="runId ? runId.slice(0,8) + '...' : ''"></span>
+              <span x-text="run.status"
+                :style="run.status === 'complete' ? 'color:var(--success);font-weight:600;font-size:0.88rem;' : run.status === 'error' ? 'color:var(--danger);font-weight:600;font-size:0.88rem;' : 'color:var(--gold);font-weight:600;font-size:0.88rem;'"></span>
             </template>
           </div>
-          <a :href="run && run.battle_id ? '#/battles/' + run.battle_id : '#/battles/new'"
-             class="text-muted" style="text-decoration:none;font-size:0.86rem;">← Back to Battle</a>
+          <div style="display:flex;gap:0.75rem;align-items:center;">
+            <button x-show="results" @click="downloadMarkdown()"
+              class="ba-btn ba-btn-secondary" style="font-size:0.82rem;color:var(--ba-accent,#d4a02a);border-color:rgba(212,160,42,0.3);">
+              Download Markdown
+            </button>
+            <a :href="run && run.battle_id ? '#/battles/' + run.battle_id : (results && results.battle_id ? '#/battles/' + results.battle_id : '#/battles/new')"
+               class="text-muted" style="text-decoration:none;font-size:0.86rem;">← Back to Battle</a>
+          </div>
         </div>
 
         <template x-if="error">
           <p class="text-danger" x-text="error"></p>
         </template>
-
         <template x-if="!run && !error">
-          <p class="text-muted">Loading run status...</p>
+          <p class="text-muted">Loading run...</p>
         </template>
 
-        <template x-if="run">
-          <div>
-            <div style="display:flex;align-items:center;gap:1rem;margin-bottom:1.5rem;">
-              <span class="text-muted" style="font-size:0.88rem;">Status:</span>
-              <span x-text="run.status"
-                :style="run.status === 'complete' ? 'color:var(--success);font-weight:600;' : run.status === 'error' ? 'color:var(--danger);font-weight:600;' : 'color:var(--gold);font-weight:600;'"></span>
-              <template x-if="run.status === 'complete'">
-                <a :href="'#/results/' + runId"
-                   style="background:var(--success);color:#fff;padding:5px 14px;border-radius:6px;font-size:0.84rem;font-weight:600;text-decoration:none;">
-                  View Results →
-                </a>
-              </template>
+        <!-- Progress section (shown while running; condenses to status header once terminal) -->
+        <template x-if="run && !isTerminal()">
+          <div style="margin-bottom:1.5rem;">
+            <div class="ba-runbar-wrap">
+              <div class="ba-runbar-label">
+                <span x-text="run.status === 'running' ? 'Running...' : 'Starting...'"></span>
+                <span x-text="runProgress() + '%'"></span>
+              </div>
+              <div class="ba-runbar">
+                <div class="ba-runbar-fill" :class="{ running: run.status === 'running' }"
+                     :style="'width:' + runProgress() + '%'"></div>
+              </div>
             </div>
-
             <template x-if="sources().length > 0 && fighters().length > 0">
               <div style="overflow-x:auto;">
                 <table class="data-table">
@@ -1594,181 +1436,177 @@
             </template>
           </div>
         </template>
-      </section>
 
-      <!-- ── Results view ────────────────────────── -->
-      <section x-show="route === 'results/detail'" x-data="resultsView()"
-               x-init="$watch('route', r => { if (r === 'results/detail' && params.id) load(params.id); }); if (route === 'results/detail' && params.id) load(params.id);">
-
-        <div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:1.25rem;">
-          <div style="display:flex;align-items:center;gap:0.75rem;">
-            <h1 style="margin:0;">Results</h1>
-            <span class="badge-muted" x-text="runId ? runId.slice(0,8) + '...' : ''"></span>
-          </div>
-          <div style="display:flex;gap:0.75rem;align-items:center;">
-            <button @click="downloadMarkdown()" x-show="results"
-              class="ba-btn ba-btn-secondary" style="color:var(--ba-accent,#d4a02a);border-color:rgba(212,160,42,0.3);">
-              Download Markdown
-            </button>
-            <a :href="results && results.battle_id ? '#/battles/' + results.battle_id : '#/battles/new'"
-               class="text-muted" style="text-decoration:none;font-size:0.86rem;">← Back to Battle</a>
-          </div>
-        </div>
-
-        <template x-if="loading">
-          <p class="text-muted">Loading results...</p>
-        </template>
-        <template x-if="error">
-          <div style="color:var(--ba-danger,#c00);font-size:0.88rem;" x-text="error"></div>
-        </template>
-
-        <template x-if="results">
+        <!-- Results section -->
+        <template x-if="run && isTerminal()">
           <div>
-            <!-- Fighter Summary Leaderboard -->
-            <h2 style="font-size:1rem;margin:0 0 0.75rem;">Fighter Summary</h2>
-            <div class="ba-section" style="overflow-x:auto;margin-bottom:2rem;">
-              <table class="ba-table">
-                <thead>
-                  <tr>
-                    <th>#</th>
-                    <th>Fighter</th>
-                    <th style="text-align:right;">Avg Score</th>
-                    <th style="text-align:right;">Total Cost</th>
-                    <th style="text-align:right;">Token Cost</th>
-                    <th style="text-align:right;">Credit Cost</th>
-                    <th style="text-align:right;">Time</th>
-                    <th style="text-align:right;">Success</th>
-                    <th style="text-align:right;">Failed</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  <template x-for="(f, idx) in fighterSummary()" :key="f.fighter_name">
-                    <tr>
-                      <td>
-                        <span class="ba-rank-badge" :class="'rank-' + (idx+1)" x-text="idx+1"></span>
-                      </td>
-                      <td style="font-weight:600;" x-text="f.fighter_name"></td>
-                      <td style="text-align:right;">
-                        <span :style="f.avg_score !== null ? scoreColor(f.avg_score) : ''"
-                              x-text="f.avg_score !== null ? f.avg_score.toFixed(2) : '—'"></span>
-                      </td>
-                      <td style="text-align:right;font-family:var(--ba-font-mono,monospace);font-size:0.83rem;"
-                          x-text="f.pricing_unknown ? 'unknown' : '$' + f.total_cost.toFixed(4)"></td>
-                      <td style="text-align:right;font-family:var(--ba-font-mono,monospace);font-size:0.83rem;color:var(--ba-text-mid,#6b7280);"
-                          x-text="f.token_cost > 0 ? '$' + f.token_cost.toFixed(4) : '—'"></td>
-                      <td style="text-align:right;font-family:var(--ba-font-mono,monospace);font-size:0.83rem;color:var(--ba-accent,#d4a02a);"
-                          x-text="f.credit_cost > 0 ? '$' + f.credit_cost.toFixed(4) : '—'"></td>
-                      <td style="text-align:right;font-family:var(--ba-font-mono,monospace);font-size:0.83rem;"
-                          x-text="f.total_latency_ms > 0 ? (f.total_latency_ms / 1000).toFixed(1) + 's' : '—'"></td>
-                      <td style="text-align:right;" x-text="f.success_count"></td>
-                      <td style="text-align:right;color:var(--danger,#c00);" x-text="f.failed_count"></td>
-                    </tr>
-                  </template>
-                </tbody>
-              </table>
-            </div>
+            <!-- Loading / waiting -->
+            <template x-if="resultsLoading">
+              <p class="text-muted">Loading results...</p>
+            </template>
+            <template x-if="resultsError">
+              <div style="color:var(--ba-danger,#c00);font-size:0.88rem;" x-text="resultsError"></div>
+            </template>
+            <template x-if="!resultsLoading && !resultsError && !results && run.status !== 'complete'">
+              <div class="placeholder" style="height:120px;">
+                <p class="text-muted" style="margin:0;font-size:0.9rem;" x-text="'Run ' + run.status + ' — no results available.'"></p>
+              </div>
+            </template>
 
-            <!-- Per-Source Breakdown -->
-            <h2 style="font-size:1rem;margin:0 0 0.75rem;">Per-Source Breakdown</h2>
-            <template x-for="source in sourceGroups()" :key="source.label">
-              <div class="ba-card" style="padding:0;overflow:hidden;margin-bottom:1rem;">
-                <div style="padding:9px 14px;font-weight:600;font-size:0.88rem;border-bottom:1px solid var(--ba-border,#e5e5e5);background:var(--ba-bg-paper,#faf9f6);">
-                  <span x-text="source.label"></span>
+            <template x-if="results">
+              <div>
+                <!-- Fighter Summary Leaderboard -->
+                <h2 style="font-size:1rem;margin:0 0 0.75rem;">Fighter Summary</h2>
+                <div class="ba-section" style="overflow-x:auto;margin-bottom:2rem;">
+                  <table class="ba-table">
+                    <thead>
+                      <tr>
+                        <th>#</th>
+                        <th>Fighter</th>
+                        <th style="text-align:right;">Avg Score</th>
+                        <th style="text-align:right;">Total Cost</th>
+                        <th style="text-align:right;">Token Cost</th>
+                        <th style="text-align:right;">Credit Cost</th>
+                        <th style="text-align:right;">Time</th>
+                        <th style="text-align:right;">Success</th>
+                        <th style="text-align:right;">Failed</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      <template x-for="(f, idx) in fighterSummary()" :key="f.fighter_name">
+                        <tr>
+                          <td><span class="ba-rank-badge" :class="'rank-' + (idx+1)" x-text="idx+1"></span></td>
+                          <td style="font-weight:600;" x-text="f.fighter_name"></td>
+                          <td style="text-align:right;">
+                            <span :style="f.avg_score !== null ? scoreColor(f.avg_score) : ''"
+                                  x-text="f.avg_score !== null ? f.avg_score.toFixed(2) : '—'"></span>
+                          </td>
+                          <td style="text-align:right;font-family:var(--ba-font-mono,monospace);font-size:0.83rem;"
+                              x-text="f.pricing_unknown ? 'unknown' : '$' + f.total_cost.toFixed(4)"></td>
+                          <td style="text-align:right;font-family:var(--ba-font-mono,monospace);font-size:0.83rem;color:var(--ba-text-mid,#6b7280);"
+                              x-text="f.token_cost > 0 ? '$' + f.token_cost.toFixed(4) : '—'"></td>
+                          <td style="text-align:right;font-family:var(--ba-font-mono,monospace);font-size:0.83rem;color:var(--ba-accent,#d4a02a);"
+                              x-text="f.credit_cost > 0 ? '$' + f.credit_cost.toFixed(4) : '—'"></td>
+                          <td style="text-align:right;font-family:var(--ba-font-mono,monospace);font-size:0.83rem;"
+                              x-text="f.total_latency_ms > 0 ? (f.total_latency_ms / 1000).toFixed(1) + 's' : '—'"></td>
+                          <td style="text-align:right;" x-text="f.success_count"></td>
+                          <td style="text-align:right;color:var(--danger,#c00);" x-text="f.failed_count"></td>
+                        </tr>
+                      </template>
+                    </tbody>
+                  </table>
                 </div>
-                <div :style="'display:grid;grid-template-columns:repeat(' + source.fighters.length + ', 1fr);gap:0;'">
-                  <template x-for="(fighter, fi) in source.fighters" :key="fighter.fighter_name">
-                    <div :style="fi > 0 ? 'border-left:1px solid var(--ba-border,#e5e5e5);' : ''">
-                      <div style="padding:8px 14px;border-bottom:1px solid var(--ba-border,#e5e5e5);display:flex;align-items:center;justify-content:space-between;">
-                        <span style="font-weight:600;font-size:0.84rem;" x-text="fighter.fighter_name"></span>
-                        <span :style="'font-size:0.8rem;font-weight:700;padding:2px 8px;border-radius:4px;' + scoreColor(fighter.score)"
-                              x-text="fighter.score !== null && fighter.score !== undefined ? fighter.score.toFixed(1) : 'N/A'"></span>
-                      </div>
-                      <div style="padding:10px 14px;">
-                        <template x-if="fighter.reasoning">
-                          <div style="font-size:0.78rem;color:var(--ba-text-mid,#6b7280);font-style:italic;margin-bottom:6px;line-height:1.4;"
-                               x-text="fighter.reasoning"></div>
-                        </template>
-                        <div @click="toggleExpand(source.label + '::' + fighter.fighter_name)"
-                             style="cursor:pointer;display:flex;align-items:center;gap:6px;font-size:0.8rem;color:var(--ba-accent,#d4a02a);margin-bottom:6px;user-select:none;">
-                          <span x-text="expanded[source.label + '::' + fighter.fighter_name] ? '▼ Hide output' : '▶ Show output'"></span>
-                        </div>
-                        <template x-if="expanded[source.label + '::' + fighter.fighter_name]">
-                          <pre style="background:var(--ba-bg-paper,#faf9f6);border:1px solid var(--ba-border,#e5e5e5);border-radius:4px;padding:10px;font-size:0.78rem;white-space:pre-wrap;word-break:break-word;margin:0;max-height:300px;overflow-y:auto;"
-                               x-text="fighter.final_output || '(no output)'"></pre>
-                        </template>
-                        <div style="font-size:0.76rem;color:var(--ba-text-mid,#6b7280);margin-top:6px;">
-                          <span x-text="fighter.step_count + ' step(s)'"></span>
-                          <template x-if="fighter.total_latency_ms > 0">
-                            <span>&nbsp;·&nbsp;<span style="font-family:var(--ba-font-mono,monospace);" x-text="formatDuration(fighter.total_latency_ms)"></span></span>
-                          </template>
-                          &nbsp;·&nbsp;
-                          <span style="font-family:var(--ba-font-mono,monospace);"
-                                x-text="fighter.total_cost_usd === null && (fighter.total_input_tokens || fighter.total_output_tokens) ? 'unknown pricing' : '$' + (fighter.total_cost_usd || 0).toFixed(4) + ' total'"></span>
-                          <template x-if="fighter.total_input_tokens || fighter.total_output_tokens">
-                            <span>&nbsp;·&nbsp;<span x-text="(fighter.total_input_tokens || 0) + ' in / ' + (fighter.total_output_tokens || 0) + ' out tokens'"></span></span>
-                          </template>
-                          <template x-if="(!fighter.total_input_tokens && !fighter.total_output_tokens) && fighter.total_cost_usd">
-                            <span>&nbsp;·&nbsp;<span style="color:var(--ba-accent,#d4a02a);">credit-based</span></span>
-                          </template>
-                        </div>
-                        <!-- Per-step breakdown (only when multiple steps have latency data) -->
-                        <template x-if="fighter.step_results && fighter.step_results.length > 1">
-                          <div style="margin-top:6px;">
-                            <div @click="toggleSteps(source.label + '::' + fighter.fighter_name)"
-                                 style="cursor:pointer;font-size:0.76rem;color:var(--ba-accent,#d4a02a);user-select:none;margin-bottom:4px;">
-                              <span x-text="stepsExpanded[source.label + '::' + fighter.fighter_name] ? '▼ Hide step timing' : '▶ Show step timing'"></span>
+
+                <!-- Per-Source Breakdown -->
+                <h2 style="font-size:1rem;margin:0 0 0.75rem;">Per-Source Breakdown</h2>
+                <template x-for="source in sourceGroups()" :key="source.label">
+                  <div class="ba-card" style="padding:0;overflow:hidden;margin-bottom:1rem;">
+                    <div style="padding:9px 14px;font-weight:600;font-size:0.88rem;border-bottom:1px solid var(--ba-border,#e5e5e5);background:var(--ba-bg-paper,#faf9f6);">
+                      <span x-text="source.label"></span>
+                    </div>
+                    <div :style="'display:grid;grid-template-columns:repeat(' + source.fighters.length + ', 1fr);gap:0;'">
+                      <template x-for="(fighter, fi) in source.fighters" :key="fighter.fighter_name">
+                        <div :style="fi > 0 ? 'border-left:1px solid var(--ba-border,#e5e5e5);' : ''">
+                          <div style="padding:8px 14px;border-bottom:1px solid var(--ba-border,#e5e5e5);display:flex;align-items:center;justify-content:space-between;">
+                            <span style="font-weight:600;font-size:0.84rem;" x-text="fighter.fighter_name"></span>
+                            <span :style="'font-size:0.8rem;font-weight:700;padding:2px 8px;border-radius:4px;' + scoreColor(fighter.score)"
+                                  x-text="fighter.score !== null && fighter.score !== undefined ? fighter.score.toFixed(1) : 'N/A'"></span>
+                          </div>
+                          <div style="padding:10px 14px;">
+                            <template x-if="fighter.reasoning">
+                              <div style="font-size:0.78rem;color:var(--ba-text-mid,#6b7280);font-style:italic;margin-bottom:6px;line-height:1.4;" x-text="fighter.reasoning"></div>
+                            </template>
+                            <div @click="toggleExpand(source.label + '::' + fighter.fighter_name)"
+                                 style="cursor:pointer;display:flex;align-items:center;gap:6px;font-size:0.8rem;color:var(--ba-accent,#d4a02a);margin-bottom:6px;user-select:none;">
+                              <span x-text="expanded[source.label + '::' + fighter.fighter_name] ? '▼ Hide output' : '▶ Show output'"></span>
                             </div>
-                            <template x-if="stepsExpanded[source.label + '::' + fighter.fighter_name]">
-                              <table style="width:100%;border-collapse:collapse;font-size:0.74rem;font-family:var(--ba-font-mono,monospace);">
-                                <thead>
-                                  <tr style="color:var(--ba-text-mid,#6b7280);">
-                                    <th style="text-align:left;padding:2px 6px;border-bottom:1px solid var(--ba-border,#e5e5e5);">#</th>
-                                    <th style="text-align:left;padding:2px 6px;border-bottom:1px solid var(--ba-border,#e5e5e5);">Step</th>
-                                    <th style="text-align:right;padding:2px 6px;border-bottom:1px solid var(--ba-border,#e5e5e5);">Duration</th>
-                                    <th style="text-align:right;padding:2px 6px;border-bottom:1px solid var(--ba-border,#e5e5e5);">In/Out tokens</th>
-                                    <th style="text-align:right;padding:2px 6px;border-bottom:1px solid var(--ba-border,#e5e5e5);">Cost</th>
-                                  </tr>
-                                </thead>
-                                <tbody>
-                                  <template x-for="(step, si) in fighter.step_results" :key="si">
-                                    <tr>
-                                      <td style="padding:2px 6px;color:var(--ba-text-mid,#6b7280);" x-text="step.step_index + 1"></td>
-                                      <td style="padding:2px 6px;" x-text="step.step_label"></td>
-                                      <td style="text-align:right;padding:2px 6px;" x-text="formatDuration(step.latency_ms)"></td>
-                                      <td style="text-align:right;padding:2px 6px;color:var(--ba-text-mid,#6b7280);"
-                                          x-text="(step.input_tokens || step.output_tokens) ? (step.input_tokens || 0) + ' / ' + (step.output_tokens || 0) : '—'"></td>
-                                      <td style="text-align:right;padding:2px 6px;"
-                                          x-text="step.cost_usd !== null && step.cost_usd !== undefined ? '$' + step.cost_usd.toFixed(4) : '—'"></td>
-                                    </tr>
-                                  </template>
-                                </tbody>
-                              </table>
+                            <template x-if="expanded[source.label + '::' + fighter.fighter_name]">
+                              <pre style="background:var(--ba-bg-paper,#faf9f6);border:1px solid var(--ba-border,#e5e5e5);border-radius:4px;padding:10px;font-size:0.78rem;white-space:pre-wrap;word-break:break-word;margin:0;max-height:300px;overflow-y:auto;"
+                                   x-text="fighter.final_output || '(no output)'"></pre>
+                            </template>
+                            <div style="font-size:0.76rem;color:var(--ba-text-mid,#6b7280);margin-top:6px;">
+                              <span x-text="fighter.step_count + ' step(s)'"></span>
+                              <template x-if="fighter.total_latency_ms > 0">
+                                <span>&nbsp;·&nbsp;<span style="font-family:var(--ba-font-mono,monospace);" x-text="formatDuration(fighter.total_latency_ms)"></span></span>
+                              </template>
+                              &nbsp;·&nbsp;
+                              <span style="font-family:var(--ba-font-mono,monospace);"
+                                    x-text="fighter.total_cost_usd === null && (fighter.total_input_tokens || fighter.total_output_tokens) ? 'unknown pricing' : '$' + (fighter.total_cost_usd || 0).toFixed(4) + ' total'"></span>
+                              <template x-if="fighter.total_input_tokens || fighter.total_output_tokens">
+                                <span>&nbsp;·&nbsp;<span x-text="(fighter.total_input_tokens || 0) + ' in / ' + (fighter.total_output_tokens || 0) + ' out tokens'"></span></span>
+                              </template>
+                              <template x-if="(!fighter.total_input_tokens && !fighter.total_output_tokens) && fighter.total_cost_usd">
+                                <span>&nbsp;·&nbsp;<span style="color:var(--ba-accent,#d4a02a);">credit-based</span></span>
+                              </template>
+                            </div>
+                            <!-- Per-step breakdown (only when multiple steps have latency data) -->
+                            <template x-if="fighter.step_results && fighter.step_results.length > 1">
+                              <div style="margin-top:6px;">
+                                <div @click="toggleSteps(source.label + '::' + fighter.fighter_name)"
+                                     style="cursor:pointer;font-size:0.76rem;color:var(--ba-accent,#d4a02a);user-select:none;margin-bottom:4px;">
+                                  <span x-text="stepsExpanded[source.label + '::' + fighter.fighter_name] ? '▼ Hide step timing' : '▶ Show step timing'"></span>
+                                </div>
+                                <template x-if="stepsExpanded[source.label + '::' + fighter.fighter_name]">
+                                  <table style="width:100%;border-collapse:collapse;font-size:0.74rem;font-family:var(--ba-font-mono,monospace);">
+                                    <thead>
+                                      <tr style="color:var(--ba-text-mid,#6b7280);">
+                                        <th style="text-align:left;padding:2px 6px;border-bottom:1px solid var(--ba-border,#e5e5e5);">#</th>
+                                        <th style="text-align:left;padding:2px 6px;border-bottom:1px solid var(--ba-border,#e5e5e5);">Step</th>
+                                        <th style="text-align:right;padding:2px 6px;border-bottom:1px solid var(--ba-border,#e5e5e5);">Duration</th>
+                                        <th style="text-align:right;padding:2px 6px;border-bottom:1px solid var(--ba-border,#e5e5e5);">In/Out tokens</th>
+                                        <th style="text-align:right;padding:2px 6px;border-bottom:1px solid var(--ba-border,#e5e5e5);">Cost</th>
+                                      </tr>
+                                    </thead>
+                                    <tbody>
+                                      <template x-for="(step, si) in fighter.step_results" :key="si">
+                                        <tr>
+                                          <td style="padding:2px 6px;color:var(--ba-text-mid,#6b7280);" x-text="step.step_index + 1"></td>
+                                          <td style="padding:2px 6px;" x-text="step.step_label"></td>
+                                          <td style="text-align:right;padding:2px 6px;" x-text="formatDuration(step.latency_ms)"></td>
+                                          <td style="text-align:right;padding:2px 6px;color:var(--ba-text-mid,#6b7280);"
+                                              x-text="(step.input_tokens || step.output_tokens) ? (step.input_tokens || 0) + ' / ' + (step.output_tokens || 0) : '—'"></td>
+                                          <td style="text-align:right;padding:2px 6px;"
+                                              x-text="step.cost_usd !== null && step.cost_usd !== undefined ? '$' + step.cost_usd.toFixed(4) : '—'"></td>
+                                        </tr>
+                                      </template>
+                                    </tbody>
+                                  </table>
+                                </template>
+                              </div>
                             </template>
                           </div>
-                        </template>
+                        </div>
+                      </template>
+                    </div>
+                  </div>
+                </template>
+
+                <!-- Judge Report -->
+                <template x-if="results.report_markdown">
+                  <div>
+                    <div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:0.5rem;">
+                      <h2 style="font-size:1rem;margin:0;">Judge Report</h2>
+                      <div style="display:flex;gap:0.5rem;">
+                        <button class="ba-btn ba-btn-secondary" @click="copyReportMarkdown()"
+                                x-text="reportCopied ? 'Copied!' : 'Copy Markdown'" style="font-size:0.8rem;"></button>
+                        <button class="ba-btn ba-btn-secondary" @click="window.print()" style="font-size:0.8rem;">Print</button>
                       </div>
                     </div>
-                  </template>
-                </div>
-              </div>
-            </template>
-
-            <!-- Judge Report -->
-            <template x-if="results.report_markdown">
-              <div>
-                <div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:0.5rem;">
-                  <h2 style="font-size:1rem;margin:0;">Judge Report</h2>
-                  <div style="display:flex;gap:0.5rem;">
-                    <button class="ba-btn ba-btn-secondary" @click="copyReportMarkdown()"
-                            x-text="reportCopied ? 'Copied!' : 'Copy Markdown'" style="font-size:0.8rem;"></button>
-                    <button class="ba-btn ba-btn-secondary" @click="window.print()" style="font-size:0.8rem;">Print</button>
+                    <div class="ba-card" style="line-height:1.7;" x-html="renderMarkdown(results.report_markdown)"></div>
                   </div>
-                </div>
-                <div class="ba-card" style="line-height:1.7;" x-html="renderMarkdown(results.report_markdown)"></div>
+                </template>
               </div>
             </template>
           </div>
         </template>
+
+        <!-- Waiting for completion placeholder (terminal but results loading) -->
+        <template x-if="run && !isTerminal() && !results">
+          <div class="placeholder" style="height:100px;margin-top:1rem;">
+            <p class="text-muted" style="margin:0;font-size:0.88rem;">Waiting for completion...</p>
+          </div>
+        </template>
+
       </section>
 
 
@@ -1795,7 +1633,6 @@
   <script src="/js/fighter-list.js"></script>
   <script src="/js/run-view.js"></script>
   <script src="/js/battle-results-tab.js"></script>
-  <script src="/js/results-view.js"></script>
   <script src="/js/app.js"></script>
 
   <script src="/js/providers-modal.js"></script>

--- a/t01_llm_battle/static/js/app.js
+++ b/t01_llm_battle/static/js/app.js
@@ -63,7 +63,9 @@ function app() {
       } else if (parts[0] === 'runs' && parts[1]) {
         this.route = 'runs/detail'; this.params = { id: parts[1] };
       } else if (parts[0] === 'results' && parts[1]) {
-        this.route = 'results/detail'; this.params = { id: parts[1] };
+        // Redirect old #/results/{id} bookmarks to #/runs/{id}
+        window.location.hash = '/runs/' + parts[1];
+        return;
       } else {
         this.resolveBattlesHash();
         return;

--- a/t01_llm_battle/static/js/battle-detail.js
+++ b/t01_llm_battle/static/js/battle-detail.js
@@ -3,7 +3,6 @@ function battleDetail() {
   return {
     sources: [], uploading: false, error: null,
     running: false, fighterCount: 0, runError: null, currentBattleId: null,
-    currentRunId: null, currentRun: null, runPolling: null,
     battleName: '', nameInput: '', nameSaving: false,
     showTextForm: false, textItems: [{ content: '', label: '' }], addingText: false,
     // Judge state
@@ -130,67 +129,8 @@ function battleDetail() {
         });
         if (!resp.ok) throw new Error(await resp.text());
         const data = await resp.json();
-        this.currentRunId = data.run_id;
-        this.currentRun = null;
-        this.stopRunPolling();
-        this.startRunPolling();
-        window.dispatchEvent(new CustomEvent('set-active-tab', { detail: 'run' }));
+        window.location.hash = '#/runs/' + data.run_id;
       } catch(e) { this.runError = e.message; this.running = false; }
-    },
-
-    startRunPolling() {
-      this.fetchRunStatus();
-      this.runPolling = setInterval(() => this.fetchRunStatus(), 2000);
-    },
-    stopRunPolling() {
-      if (this.runPolling) { clearInterval(this.runPolling); this.runPolling = null; }
-    },
-    async fetchRunStatus() {
-      if (!this.currentRunId) return;
-      try {
-        const resp = await fetch('/runs/' + this.currentRunId + '/status');
-        if (!resp.ok) throw new Error(await resp.text());
-        this.currentRun = await resp.json();
-        if (this.currentRun.status === 'complete' || this.currentRun.status === 'error' || this.currentRun.status === 'cancelled') {
-          this.stopRunPolling();
-          this.running = false;
-        }
-      } catch(e) { this.stopRunPolling(); this.running = false; }
-    },
-    async cancelRun() {
-      if (!this.currentRunId) return;
-      try {
-        const resp = await fetch('/runs/' + this.currentRunId + '/cancel', { method: 'POST' });
-        if (!resp.ok) throw new Error(await resp.text());
-        this.currentRun = await resp.json();
-        this.stopRunPolling();
-        this.running = false;
-      } catch(e) { /* ignore cancel errors */ }
-    },
-    runProgress() {
-      if (!this.currentRun || !this.currentRun.fighter_results) return 0;
-      const total = this.currentRun.fighter_results.length;
-      if (!total) return 0;
-      const done = this.currentRun.fighter_results.filter(fr => fr.status === 'complete' || fr.status === 'error').length;
-      return Math.round((done / total) * 100);
-    },
-    runSources() {
-      if (!this.currentRun || !this.currentRun.fighter_results) return [];
-      const seen = new Set();
-      return this.currentRun.fighter_results.filter(fr => {
-        if (seen.has(fr.source_id)) return false; seen.add(fr.source_id); return true;
-      }).map(fr => ({ source_id: fr.source_id, source_label: fr.source_label || fr.source_id }));
-    },
-    runFighters() {
-      if (!this.currentRun || !this.currentRun.fighter_results) return [];
-      const seen = new Set();
-      return this.currentRun.fighter_results.filter(fr => {
-        if (seen.has(fr.fighter_id)) return false; seen.add(fr.fighter_id); return true;
-      }).map(fr => ({ fighter_id: fr.fighter_id, fighter_name: fr.fighter_name || fr.fighter_id }));
-    },
-    getRunCell(fighter_id, source_id) {
-      if (!this.currentRun || !this.currentRun.fighter_results) return null;
-      return this.currentRun.fighter_results.find(fr => fr.fighter_id === fighter_id && fr.source_id === source_id) || null;
     },
 
     async upload(event, battleId) {

--- a/t01_llm_battle/static/js/battle-results-tab.js
+++ b/t01_llm_battle/static/js/battle-results-tab.js
@@ -1,96 +1,39 @@
-// ── Battle Results Tab (inline within battle detail) ─────
-function battleResultsTab() {
+// ── Runs Tab (battle detail) ──────────────────────────────
+function runsTab() {
   return {
-    tabLoading: false, tabError: null, results: null,
-    tabExpanded: {}, reportCopied: false,
+    loading: false, error: null, runs: [],
 
     async load(battleId) {
       if (!battleId) return;
-      this.tabLoading = true; this.tabError = null; this.results = null;
+      this.loading = true; this.error = null; this.runs = [];
       try {
-        // Fetch runs for this battle, get the latest complete one
         const resp = await fetch('/battles/' + battleId + '/runs');
         if (!resp.ok) throw new Error(await resp.text());
         const data = await resp.json();
-        const runs = Array.isArray(data) ? data : (data.runs || []);
-        const complete = runs.filter(r => r.status === 'complete');
-        if (!complete.length) { this.tabLoading = false; return; }
-        const latestRunId = complete[0].id; // sorted DESC
-        const rResp = await fetch('/runs/' + latestRunId + '/results');
-        if (!rResp.ok) throw new Error(await rResp.text());
-        this.results = await rResp.json();
-      } catch(e) { this.tabError = e.message; }
-      finally { this.tabLoading = false; }
+        this.runs = Array.isArray(data) ? data : (data.runs || []);
+      } catch(e) { this.error = e.message; }
+      finally { this.loading = false; }
     },
 
-    toggleExpand(key) { this.tabExpanded[key] = !this.tabExpanded[key]; },
-
-    fighterSummary() {
-      if (!this.results || !this.results.summary) return [];
-      const map = {};
-      for (const item of this.results.summary) {
-        const name = item.fighter_name;
-        if (!map[name]) map[name] = { fighter_name: name, scores: [], total_cost: 0, token_cost: 0, credit_cost: 0, total_latency_ms: 0, success_count: 0, failed_count: 0, pricing_unknown: false };
-        if (item.score !== null && item.score !== undefined) map[name].scores.push(item.score);
-        if (item.total_cost_usd === null && (item.total_input_tokens || item.total_output_tokens)) map[name].pricing_unknown = true;
-        map[name].total_cost += item.total_cost_usd || 0;
-        map[name].token_cost += item.token_cost || 0;
-        map[name].credit_cost += item.credit_cost || 0;
-        map[name].total_latency_ms += item.total_latency_ms || 0;
-        if (item.status === 'complete') map[name].success_count++;
-        else if (item.status === 'error') map[name].failed_count++;
-      }
-      return Object.values(map).map(f => ({
-        ...f, avg_score: f.scores.length ? f.scores.reduce((a, b) => a + b, 0) / f.scores.length : null,
-      })).sort((a, b) => (b.avg_score ?? -Infinity) - (a.avg_score ?? -Infinity));
+    formatDuration(startedAt, finishedAt) {
+      if (!startedAt || !finishedAt) return '—';
+      const ms = new Date(finishedAt) - new Date(startedAt);
+      if (isNaN(ms) || ms < 0) return '—';
+      return ms < 1000 ? ms + 'ms' : (ms / 1000).toFixed(1) + 's';
     },
 
-    sourceGroups() {
-      if (!this.results || !this.results.summary) return [];
-      const order = []; const map = {};
-      for (const item of this.results.summary) {
-        const label = item.source_label || item.source_id || 'Unknown';
-        if (!map[label]) { map[label] = { label, fighters: [] }; order.push(label); }
-        map[label].fighters.push(item);
-      }
-      return order.map(l => map[l]);
+    formatStarted(startedAt) {
+      if (!startedAt) return '—';
+      try {
+        return new Date(startedAt).toLocaleString(undefined, { month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit' });
+      } catch(_) { return startedAt; }
     },
 
-    scoreColor(score) {
-      if (score === null || score === undefined) return 'color:var(--ba-text-mid,#6b7280);';
-      if (score >= 8) return 'color:var(--success,#16a34a);';
-      if (score >= 5) return 'color:#e67e22;';
-      return 'color:var(--danger,#c00);';
-    },
-
-    copyReport() {
-      if (!this.results || !this.results.report_markdown) return;
-      navigator.clipboard.writeText(this.results.report_markdown).then(() => {
-        this.reportCopied = true;
-        setTimeout(() => { this.reportCopied = false; }, 2000);
-      });
-    },
-
-    downloadMarkdown() {
-      if (!this.results) return;
-      const summary = this.fighterSummary();
-      const lines = ['# LLM Battle Results', '', '**Run ID:** ' + (this.results.run_id || '')];
-      lines.push('', '## Fighter Summary', '', '| # | Fighter | Avg Score | Cost | Time | S/F |', '|---|---------|-----------|------|------|-----|');
-      summary.forEach((f, i) => lines.push('| ' + (i+1) + ' | ' + f.fighter_name + ' | ' + (f.avg_score !== null ? f.avg_score.toFixed(2) : '—') + ' | ' + (f.pricing_unknown ? 'unknown' : '$' + f.total_cost.toFixed(4)) + ' | ' + (f.total_latency_ms > 0 ? (f.total_latency_ms/1000).toFixed(1)+'s' : '—') + ' | ' + f.success_count + '/' + f.failed_count + ' |'));
-      lines.push('', '## Per-Source Breakdown', '');
-      for (const source of this.sourceGroups()) {
-        lines.push('### ' + source.label, '');
-        for (const fighter of source.fighters) {
-          lines.push('**' + fighter.fighter_name + '** — Score: ' + (fighter.score !== null && fighter.score !== undefined ? fighter.score.toFixed(1) : 'N/A'));
-          if (fighter.reasoning) lines.push('', '_' + fighter.reasoning + '_');
-          lines.push('', '```', fighter.final_output || '(no output)', '```', '');
-        }
-      }
-      if (this.results.report_markdown) lines.push('## Judge Report', '', this.results.report_markdown, '');
-      const blob = new Blob([lines.join('\n')], { type: 'text/markdown' });
-      const url = URL.createObjectURL(blob);
-      const a = document.createElement('a'); a.href = url; a.download = 'battle-results.md'; a.click();
-      URL.revokeObjectURL(url);
+    statusColor(status) {
+      if (status === 'complete') return 'color:var(--success,#16a34a);';
+      if (status === 'error') return 'color:var(--danger,#c00);';
+      if (status === 'running' || status === 'pending') return 'color:var(--gold,#d4a02a);';
+      return 'color:var(--ba-text-mid,#6b7280);';
     }
   };
 }

--- a/t01_llm_battle/static/js/run-view.js
+++ b/t01_llm_battle/static/js/run-view.js
@@ -1,24 +1,29 @@
-// ── Run view ─────────────────────────────────────────────
-function runView() {
+// ── Run detail (progress + results) ──────────────────────
+function runDetail() {
   return {
     runId: null, run: null, polling: null, error: null,
+    results: null, resultsLoading: false, resultsError: null,
+    expanded: {}, stepsExpanded: {},
 
     init(runId) {
       if (this.polling) { clearInterval(this.polling); this.polling = null; }
       this.runId = runId; this.run = null; this.error = null;
+      this.results = null; this.resultsLoading = false; this.resultsError = null;
+      this.expanded = {}; this.stepsExpanded = {};
       this.startPolling();
     },
 
+    // ── Progress polling ────────────────────────────────
     async fetchStatus() {
       if (!this.runId) return;
       try {
         const resp = await fetch('/runs/' + this.runId + '/status');
         if (!resp.ok) throw new Error(await resp.text());
         this.run = await resp.json();
-        if (this.run.status === 'complete' || this.run.status === 'error') {
+        if (this.run.status === 'complete' || this.run.status === 'error' || this.run.status === 'cancelled') {
           this.stopPolling();
-          if (this.run.status === 'complete') {
-            setTimeout(() => { location.hash = '#/results/' + this.runId; }, 500);
+          if (this.run.status === 'complete' && !this.results) {
+            this.loadResults();
           }
         }
       } catch(e) { this.error = e.message; this.stopPolling(); }
@@ -27,6 +32,9 @@ function runView() {
     startPolling() { this.fetchStatus(); this.polling = setInterval(() => this.fetchStatus(), 2000); },
     stopPolling() { if (this.polling) { clearInterval(this.polling); this.polling = null; } },
 
+    isTerminal() { return this.run && (this.run.status === 'complete' || this.run.status === 'error' || this.run.status === 'cancelled'); },
+
+    // ── Progress helpers ────────────────────────────────
     sources() {
       if (!this.run || !this.run.fighter_results) return [];
       const seen = new Set();
@@ -46,6 +54,115 @@ function runView() {
     getCellResult(fighter_id, source_id) {
       if (!this.run || !this.run.fighter_results) return null;
       return this.run.fighter_results.find(fr => fr.fighter_id === fighter_id && fr.source_id === source_id) || null;
+    },
+
+    runProgress() {
+      if (!this.run || !this.run.fighter_results) return 0;
+      const total = this.run.fighter_results.length;
+      if (!total) return 0;
+      const done = this.run.fighter_results.filter(fr => fr.status === 'complete' || fr.status === 'error').length;
+      return Math.round((done / total) * 100);
+    },
+
+    // ── Results loading ─────────────────────────────────
+    async loadResults() {
+      this.resultsLoading = true; this.resultsError = null;
+      try {
+        const resp = await fetch('/runs/' + this.runId + '/results');
+        if (!resp.ok) throw new Error(await resp.text());
+        this.results = await resp.json();
+      } catch(e) { this.resultsError = e.message; }
+      finally { this.resultsLoading = false; }
+    },
+
+    // ── Results helpers ─────────────────────────────────
+    toggleExpand(key) { this.expanded[key] = !this.expanded[key]; },
+    toggleSteps(key) { this.stepsExpanded[key] = !this.stepsExpanded[key]; },
+
+    formatDuration(ms) {
+      if (ms === null || ms === undefined) return '—';
+      if (ms < 1000) return ms + 'ms';
+      return (ms / 1000).toFixed(1) + 's';
+    },
+
+    fighterSummary() {
+      if (!this.results || !this.results.summary) return [];
+      const map = {};
+      for (const item of this.results.summary) {
+        const name = item.fighter_name;
+        if (!map[name]) map[name] = { fighter_name: name, scores: [], total_cost: 0, token_cost: 0, credit_cost: 0, total_latency_ms: 0, success_count: 0, failed_count: 0, pricing_unknown: false };
+        if (item.score !== null && item.score !== undefined) map[name].scores.push(item.score);
+        if (item.total_cost_usd === null && (item.total_input_tokens || item.total_output_tokens)) map[name].pricing_unknown = true;
+        map[name].total_cost += item.total_cost_usd || 0;
+        if (item.total_input_tokens || item.total_output_tokens) map[name].token_cost += item.total_cost_usd || 0;
+        else if (item.total_cost_usd) map[name].credit_cost += item.total_cost_usd || 0;
+        map[name].total_latency_ms += item.total_latency_ms || 0;
+        if (item.status === 'complete') map[name].success_count += 1;
+        else if (item.status === 'error') map[name].failed_count += 1;
+      }
+      return Object.values(map).map(f => ({
+        ...f, avg_score: f.scores.length ? f.scores.reduce((a, b) => a + b, 0) / f.scores.length : null,
+      })).sort((a, b) => (b.avg_score ?? -Infinity) - (a.avg_score ?? -Infinity));
+    },
+
+    sourceGroups() {
+      if (!this.results || !this.results.summary) return [];
+      const order = []; const map = {};
+      for (const item of this.results.summary) {
+        const label = item.source_label || item.source_id || 'Unknown';
+        if (!map[label]) { map[label] = { label, fighters: [] }; order.push(label); }
+        map[label].fighters.push(item);
+      }
+      return order.map(l => map[l]);
+    },
+
+    scoreColor(score) {
+      if (score === null || score === undefined) return 'color:var(--mid);';
+      if (score >= 8) return 'color:var(--success);';
+      if (score >= 5) return 'color:#e67e22;';
+      return 'color:var(--danger);';
+    },
+
+    renderMarkdown(text) {
+      if (typeof marked !== 'undefined') {
+        const raw = marked.parse ? marked.parse(text) : marked(text);
+        return typeof DOMPurify !== 'undefined' ? DOMPurify.sanitize(raw) : raw;
+      }
+      return text.replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;');
+    },
+
+    downloadMarkdown() {
+      if (!this.results) return;
+      const summary = this.fighterSummary();
+      const lines = ['# LLM Battle Results', '', '**Run ID:** ' + (this.results.run_id || this.runId)];
+      if (this.results.battle_id) lines.push('**Battle ID:** ' + this.results.battle_id);
+      lines.push('', '## Fighter Summary', '', '| Fighter | Avg Score | Total Cost USD | Token Cost | Credit Cost | Time | Success | Failed |', '|---------|-----------|---------------|-----------|-------------|------|---------|--------|');
+      for (const f of summary) lines.push('| ' + f.fighter_name + ' | ' + (f.avg_score !== null ? f.avg_score.toFixed(2) : '—') + ' | ' + (f.pricing_unknown ? 'unknown' : '$' + f.total_cost.toFixed(4)) + ' | ' + (f.token_cost > 0 ? '$' + f.token_cost.toFixed(4) : '—') + ' | ' + (f.credit_cost > 0 ? '$' + f.credit_cost.toFixed(4) : '—') + ' | ' + (f.total_latency_ms > 0 ? (f.total_latency_ms / 1000).toFixed(1) + 's' : '—') + ' | ' + f.success_count + ' | ' + f.failed_count + ' |');
+      lines.push('', '## Per-Source Breakdown', '');
+      for (const source of this.sourceGroups()) {
+        lines.push('### ' + source.label, '');
+        for (const fighter of source.fighters) {
+          const reasoningLine = fighter.reasoning ? '_' + fighter.reasoning + '_' : '';
+          lines.push('**' + fighter.fighter_name + '** — Score: ' + (fighter.score !== null && fighter.score !== undefined ? fighter.score.toFixed(1) : 'N/A'));
+          if (reasoningLine) lines.push('', reasoningLine);
+          lines.push('', '```', fighter.final_output || '(no output)', '```', '');
+        }
+      }
+      if (this.results.report_markdown) lines.push('## Judge Report', '', this.results.report_markdown, '');
+      const blob = new Blob([lines.join('\n')], { type: 'text/markdown' });
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url; a.download = 'battle-results-' + (this.runId || 'export') + '.md'; a.click();
+      URL.revokeObjectURL(url);
+    },
+
+    reportCopied: false,
+    copyReportMarkdown() {
+      if (!this.results || !this.results.report_markdown) return;
+      navigator.clipboard.writeText(this.results.report_markdown).then(() => {
+        this.reportCopied = true;
+        setTimeout(() => { this.reportCopied = false; }, 2000);
+      });
     }
   };
 }


### PR DESCRIPTION
Closes #351

Major UI restructuring: renames Results tab to Runs, merges live progress polling with results display into single run detail page.

### Changes

**Component Refactoring:**
- battle-results-tab.js → runsTab() displays list of all runs with click navigation
- results-view.js + run-view.js merged into single runDetail() component

**Functionality:**
- Run detail page combines Progress (live polling) + Results (once complete) in single view
- Backward compatibility: old #/results/{id} bookmarks redirect to #/runs/{id}
- Tab bar: renamed Results → Runs, removed separate Run tab

**UI Updates:**
- Battle detail now has 2 tabs: Setup | Runs
- Runs tab shows table of all runs per battle
- Click any run row to view Run detail page with embedded progress and results

Tests: 119 tests pass.