### PR TITLE
fix: POST /runs returns status='pending' matching DB row

### DIFF
--- a/t01_llm_battle/routers/runs.py
+++ b/t01_llm_battle/routers/runs.py
@@ -77,7 +77,7 @@ async def create_run(body: CreateRunRequest):
     # Kick off background execution
     start_run_background(run_id)
 
-    return {"run_id": run_id, "status": "running"}
+    return {"run_id": run_id, "status": "pending"}
 
 
 @router.get("/{run_id}/status")


### PR DESCRIPTION
Closes #359

## Summary

Fixes race condition where POST /runs returns `{"status": "running"}` while the DB row is still `'pending'`.

**Before:** Immediate polling could see 'pending' in DB, conflicting with response body 'running'.

**Fix:** Return status='pending' in POST response, matching actual DB state. Frontend should poll /runs/{id}/status to observe transition to 'running'.

Affects FR-10 Run Execution, FR-11 Live Run View.