### PR TITLE
test: add unit tests for serper, tavily, firecrawl providers (FR-6, FR-18)

### DIFF
--- a/tests/test_firecrawl_provider.py
+++ b/tests/test_firecrawl_provider.py
@@ -1,0 +1,132 @@
+"""Unit tests for FirecrawlProvider adapter (FR-6, FR-18)."""
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from t01_llm_battle.providers.firecrawl import FirecrawlProvider, _format_firecrawl_results
+from t01_llm_battle.providers.base import ProviderRequest
+
+
+def _make_request(model: str = "scrape", prompt: str = "https://example.com") -> ProviderRequest:
+    return ProviderRequest(
+        model=model,
+        system_prompt=None,
+        user_prompt=prompt,
+        api_key="test-key",
+    )
+
+
+# ---------------------------------------------------------------------------
+# _format_firecrawl_results
+# ---------------------------------------------------------------------------
+
+def test_format_scrape_with_title_and_markdown():
+    data = {"data": {"metadata": {"title": "Page Title"}, "markdown": "# Hello"}}
+    out = _format_firecrawl_results(data, "scrape")
+    assert "Page Title" in out
+    assert "# Hello" in out
+
+
+def test_format_scrape_no_title():
+    data = {"data": {"markdown": "Content only"}}
+    out = _format_firecrawl_results(data, "scrape")
+    assert "Content only" in out
+
+
+def test_format_crawl_multiple_pages():
+    data = {
+        "data": [
+            {"metadata": {"title": "Page A"}, "markdown": "A content"},
+            {"metadata": {"title": "Page B"}, "markdown": "B content"},
+        ]
+    }
+    out = _format_firecrawl_results(data, "crawl")
+    assert "2 page" in out
+    assert "Page A" in out
+    assert "Page B" in out
+
+
+def test_format_crawl_empty_pages():
+    data = {"data": []}
+    out = _format_firecrawl_results(data, "crawl")
+    assert "0 page" in out
+
+
+# ---------------------------------------------------------------------------
+# FirecrawlProvider.models()
+# ---------------------------------------------------------------------------
+
+def test_models_returns_functions():
+    provider = FirecrawlProvider()
+    assert provider.models() == ["scrape", "crawl"]
+
+
+# ---------------------------------------------------------------------------
+# FirecrawlProvider.run() — pricing (FR-18)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_run_scrape_credits_and_cost():
+    mock_response = MagicMock()
+    mock_response.raise_for_status = MagicMock()
+    mock_response.json.return_value = {"data": {"markdown": "text", "metadata": {}}}
+
+    with patch("httpx.AsyncClient") as mock_client_cls:
+        mock_client = AsyncMock()
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+        mock_client.post = AsyncMock(return_value=mock_response)
+        mock_client_cls.return_value = mock_client
+
+        provider = FirecrawlProvider()
+        result = await provider.run(_make_request("scrape"))
+
+    assert result.credits_used == 1.0
+    assert result.cost_usd == pytest.approx(0.001)
+    assert result.provider == "firecrawl"
+    assert result.model == "scrape"
+    assert result.input_tokens is None
+    assert result.output_tokens is None
+
+
+@pytest.mark.asyncio
+async def test_run_crawl_uses_crawl_endpoint():
+    mock_response = MagicMock()
+    mock_response.raise_for_status = MagicMock()
+    mock_response.json.return_value = {"data": []}
+
+    with patch("httpx.AsyncClient") as mock_client_cls:
+        mock_client = AsyncMock()
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+        mock_client.post = AsyncMock(return_value=mock_response)
+        mock_client_cls.return_value = mock_client
+
+        provider = FirecrawlProvider()
+        result = await provider.run(_make_request("crawl"))
+
+    call_url = mock_client.post.call_args[0][0]
+    assert "crawl" in call_url
+    assert result.model == "crawl"
+
+
+@pytest.mark.asyncio
+async def test_run_sends_bearer_auth():
+    mock_response = MagicMock()
+    mock_response.raise_for_status = MagicMock()
+    mock_response.json.return_value = {"data": {"markdown": "", "metadata": {}}}
+
+    with patch("httpx.AsyncClient") as mock_client_cls:
+        mock_client = AsyncMock()
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+        mock_client.post = AsyncMock(return_value=mock_response)
+        mock_client_cls.return_value = mock_client
+
+        provider = FirecrawlProvider()
+        await provider.run(_make_request("scrape"))
+
+    headers = mock_client.post.call_args[1]["headers"]
+    assert headers["Authorization"] == "Bearer test-key"

--- a/tests/test_serper_provider.py
+++ b/tests/test_serper_provider.py
@@ -1,0 +1,101 @@
+"""Unit tests for SerperProvider adapter (FR-6, FR-18)."""
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from t01_llm_battle.providers.serper import SerperProvider, _format_serper_results
+from t01_llm_battle.providers.base import ProviderRequest
+
+
+def _make_request(model: str = "search", prompt: str = "test query") -> ProviderRequest:
+    return ProviderRequest(
+        model=model,
+        system_prompt=None,
+        user_prompt=prompt,
+        api_key="test-key",
+    )
+
+
+# ---------------------------------------------------------------------------
+# _format_serper_results
+# ---------------------------------------------------------------------------
+
+def test_format_search_results():
+    data = {"organic": [{"title": "Result 1", "snippet": "Snippet 1", "link": "https://a.com"}]}
+    out = _format_serper_results(data, "search")
+    assert "Result 1" in out
+    assert "Snippet 1" in out
+    assert "https://a.com" in out
+
+
+def test_format_news_results():
+    data = {"news": [{"title": "News 1", "snippet": "Blurb", "link": "https://news.com"}]}
+    out = _format_serper_results(data, "news")
+    assert "News 1" in out
+    assert "https://news.com" in out
+
+
+def test_format_empty_falls_back_to_json():
+    data = {"unknownKey": "value"}
+    out = _format_serper_results(data, "search")
+    assert "unknownKey" in out
+
+
+# ---------------------------------------------------------------------------
+# SerperProvider.models()
+# ---------------------------------------------------------------------------
+
+def test_models_returns_functions():
+    provider = SerperProvider()
+    assert provider.models() == ["search", "news"]
+
+
+# ---------------------------------------------------------------------------
+# SerperProvider.run() — pricing (FR-18)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_run_credits_and_cost():
+    mock_response = MagicMock()
+    mock_response.raise_for_status = MagicMock()
+    mock_response.json.return_value = {"organic": [{"title": "T", "snippet": "S", "link": "L"}]}
+
+    with patch("httpx.AsyncClient") as mock_client_cls:
+        mock_client = AsyncMock()
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+        mock_client.post = AsyncMock(return_value=mock_response)
+        mock_client_cls.return_value = mock_client
+
+        provider = SerperProvider()
+        result = await provider.run(_make_request("search"))
+
+    assert result.credits_used == 1.0
+    assert result.cost_usd == pytest.approx(0.001)
+    assert result.provider == "serper"
+    assert result.model == "search"
+    assert result.input_tokens is None
+    assert result.output_tokens is None
+
+
+@pytest.mark.asyncio
+async def test_run_news_function_uses_news_endpoint():
+    mock_response = MagicMock()
+    mock_response.raise_for_status = MagicMock()
+    mock_response.json.return_value = {"news": []}
+
+    with patch("httpx.AsyncClient") as mock_client_cls:
+        mock_client = AsyncMock()
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+        mock_client.post = AsyncMock(return_value=mock_response)
+        mock_client_cls.return_value = mock_client
+
+        provider = SerperProvider()
+        result = await provider.run(_make_request("news"))
+
+    call_args = mock_client.post.call_args
+    assert "news" in call_args[0][0]
+    assert result.model == "news"

--- a/tests/test_tavily_provider.py
+++ b/tests/test_tavily_provider.py
@@ -1,0 +1,102 @@
+"""Unit tests for TavilyProvider adapter (FR-6, FR-18)."""
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from t01_llm_battle.providers.tavily import TavilyProvider, _format_tavily_results
+from t01_llm_battle.providers.base import ProviderRequest
+
+
+def _make_request(prompt: str = "test query") -> ProviderRequest:
+    return ProviderRequest(
+        model="search",
+        system_prompt=None,
+        user_prompt=prompt,
+        api_key="test-key",
+    )
+
+
+# ---------------------------------------------------------------------------
+# _format_tavily_results
+# ---------------------------------------------------------------------------
+
+def test_format_with_answer_and_results():
+    data = {
+        "answer": "42",
+        "results": [{"title": "Source", "content": "Details", "url": "https://src.com"}],
+    }
+    out = _format_tavily_results(data)
+    assert "42" in out
+    assert "Source" in out
+    assert "https://src.com" in out
+
+
+def test_format_no_answer():
+    data = {"results": [{"title": "T", "content": "C", "url": "https://u.com"}]}
+    out = _format_tavily_results(data)
+    assert "Answer" not in out
+    assert "T" in out
+
+
+def test_format_empty_results():
+    out = _format_tavily_results({})
+    assert out == ""
+
+
+# ---------------------------------------------------------------------------
+# TavilyProvider.models()
+# ---------------------------------------------------------------------------
+
+def test_models_returns_functions():
+    provider = TavilyProvider()
+    assert provider.models() == ["search"]
+
+
+# ---------------------------------------------------------------------------
+# TavilyProvider.run() — pricing (FR-18)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_run_credits_and_cost():
+    mock_response = MagicMock()
+    mock_response.raise_for_status = MagicMock()
+    mock_response.json.return_value = {"answer": "yes", "results": []}
+
+    with patch("httpx.AsyncClient") as mock_client_cls:
+        mock_client = AsyncMock()
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+        mock_client.post = AsyncMock(return_value=mock_response)
+        mock_client_cls.return_value = mock_client
+
+        provider = TavilyProvider()
+        result = await provider.run(_make_request())
+
+    assert result.credits_used == 1.0
+    assert result.cost_usd == pytest.approx(0.002)
+    assert result.provider == "tavily"
+    assert result.model == "search"
+    assert result.input_tokens is None
+    assert result.output_tokens is None
+
+
+@pytest.mark.asyncio
+async def test_run_sends_api_key_in_body():
+    mock_response = MagicMock()
+    mock_response.raise_for_status = MagicMock()
+    mock_response.json.return_value = {"results": []}
+
+    with patch("httpx.AsyncClient") as mock_client_cls:
+        mock_client = AsyncMock()
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+        mock_client.post = AsyncMock(return_value=mock_response)
+        mock_client_cls.return_value = mock_client
+
+        provider = TavilyProvider()
+        await provider.run(_make_request())
+
+    call_json = mock_client.post.call_args[1]["json"]
+    assert call_json["api_key"] == "test-key"


### PR DESCRIPTION
Closes #358

## Summary

Comprehensive test coverage for all 3 tool providers shipped in v0.1:

### test_serper_provider.py (6 tests)
- Format search/news results
- models() returns functions
- Pricing: credits_per_call=1.0, cost_usd=0.001

### test_tavily_provider.py (6 tests)
- Format results with/without answer
- models() returns functions
- Pricing: credits_per_call=1.0, cost_usd=0.002
- API key in body validation

### test_firecrawl_provider.py (8 tests)
- Format scrape/crawl results
- models() returns functions
- Pricing: credits_per_call=1.0, cost_usd=0.001
- Bearer auth header validation

20 new tests, all passing. Verifies FR-6 providers and FR-18 pricing math.