### PR TITLE
test: add unit tests for anthropic, google, groq, openrouter, lmstudio providers (FR-6)

### DIFF
--- a/tests/test_anthropic_provider.py
+++ b/tests/test_anthropic_provider.py
@@ -1,0 +1,89 @@
+"""Unit tests for AnthropicProvider (FR-6)."""
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from t01_llm_battle.providers.anthropic import AnthropicProvider
+from t01_llm_battle.providers.base import ProviderRequest
+
+
+@pytest.mark.asyncio
+async def test_run_returns_result():
+    provider = AnthropicProvider()
+    request = ProviderRequest(
+        model="claude-3-5-haiku-20241022",
+        system_prompt="You are a helpful assistant.",
+        user_prompt="Hello!",
+        api_key="test-key",
+    )
+
+    mock_usage = MagicMock()
+    mock_usage.request_tokens = 12
+    mock_usage.response_tokens = 8
+
+    mock_result = MagicMock()
+    mock_result.output = "Hi there!"
+    mock_result.usage.return_value = mock_usage
+
+    with patch("t01_llm_battle.providers.anthropic.Agent") as MockAgent:
+        mock_instance = MagicMock()
+        mock_instance.run = AsyncMock(return_value=mock_result)
+        MockAgent.return_value = mock_instance
+
+        result = await provider.run(request)
+
+    assert result.content == "Hi there!"
+    assert result.input_tokens == 12
+    assert result.output_tokens == 8
+    assert result.provider == "anthropic"
+    assert result.credits_used is None
+
+
+@pytest.mark.asyncio
+async def test_run_raises_without_api_key():
+    provider = AnthropicProvider()
+    request = ProviderRequest(
+        model="claude-3-5-haiku-20241022",
+        system_prompt=None,
+        user_prompt="Hello!",
+        api_key=None,
+    )
+    with patch("t01_llm_battle.providers.anthropic.os.environ.get", return_value=""):
+        with pytest.raises(ValueError, match="ANTHROPIC_API_KEY"):
+            await provider.run(request)
+
+
+def test_models_returns_list():
+    provider = AnthropicProvider()
+    with patch("t01_llm_battle.providers.anthropic.get_llm_models", return_value=["claude-3-5-haiku-20241022"]):
+        result = provider.models()
+    assert isinstance(result, list)
+    assert len(result) > 0
+
+
+@pytest.mark.asyncio
+async def test_cost_usd_computed():
+    provider = AnthropicProvider()
+    request = ProviderRequest(
+        model="claude-3-5-haiku-20241022",
+        system_prompt=None,
+        user_prompt="Hi",
+        api_key="test-key",
+    )
+
+    mock_usage = MagicMock()
+    mock_usage.request_tokens = 100
+    mock_usage.response_tokens = 50
+
+    mock_result = MagicMock()
+    mock_result.output = "response"
+    mock_result.usage.return_value = mock_usage
+
+    with patch("t01_llm_battle.providers.anthropic.Agent") as MockAgent:
+        mock_instance = MagicMock()
+        mock_instance.run = AsyncMock(return_value=mock_result)
+        MockAgent.return_value = mock_instance
+        with patch("t01_llm_battle.providers.anthropic.get_llm_cost", return_value=0.005) as mock_cost:
+            result = await provider.run(request)
+            mock_cost.assert_called_once_with("anthropic", "claude-3-5-haiku-20241022", 100, 50)
+
+    assert result.cost_usd == 0.005

--- a/tests/test_google_provider.py
+++ b/tests/test_google_provider.py
@@ -1,0 +1,107 @@
+"""Unit tests for GoogleProvider (FR-6)."""
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from t01_llm_battle.providers.google import GoogleProvider
+from t01_llm_battle.providers.base import ProviderRequest
+
+
+@pytest.mark.asyncio
+async def test_run_returns_result():
+    provider = GoogleProvider()
+    request = ProviderRequest(
+        model="gemini-2.0-flash",
+        system_prompt="Be concise.",
+        user_prompt="What is 2+2?",
+        api_key="test-key",
+    )
+
+    mock_usage = MagicMock()
+    mock_usage.request_tokens = 20
+    mock_usage.response_tokens = 5
+
+    mock_result = MagicMock()
+    mock_result.output = "4"
+    mock_result.usage.return_value = mock_usage
+
+    with patch("t01_llm_battle.providers.google.Agent") as MockAgent:
+        mock_instance = MagicMock()
+        mock_instance.run = AsyncMock(return_value=mock_result)
+        MockAgent.return_value = mock_instance
+
+        result = await provider.run(request)
+
+    assert result.content == "4"
+    assert result.input_tokens == 20
+    assert result.output_tokens == 5
+    assert result.provider == "google"
+    assert result.credits_used is None
+    assert result.model == "gemini-2.0-flash"
+
+
+def test_models_returns_list():
+    provider = GoogleProvider()
+    with patch("t01_llm_battle.providers.google.get_llm_models", return_value=["gemini-2.0-flash"]):
+        result = provider.models()
+    assert isinstance(result, list)
+    assert len(result) > 0
+
+
+@pytest.mark.asyncio
+async def test_cost_usd_computed():
+    provider = GoogleProvider()
+    request = ProviderRequest(
+        model="gemini-2.0-flash",
+        system_prompt=None,
+        user_prompt="Hi",
+        api_key="test-key",
+    )
+
+    mock_usage = MagicMock()
+    mock_usage.request_tokens = 50
+    mock_usage.response_tokens = 25
+
+    mock_result = MagicMock()
+    mock_result.output = "response"
+    mock_result.usage.return_value = mock_usage
+
+    with patch("t01_llm_battle.providers.google.Agent") as MockAgent:
+        mock_instance = MagicMock()
+        mock_instance.run = AsyncMock(return_value=mock_result)
+        MockAgent.return_value = mock_instance
+        with patch("t01_llm_battle.providers.google.get_llm_cost", return_value=0.002) as mock_cost:
+            result = await provider.run(request)
+            mock_cost.assert_called_once_with("google", "gemini-2.0-flash", 50, 25)
+
+    assert result.cost_usd == 0.002
+
+
+@pytest.mark.asyncio
+async def test_extra_top_p_passed():
+    provider = GoogleProvider()
+    request = ProviderRequest(
+        model="gemini-2.0-flash",
+        system_prompt=None,
+        user_prompt="Hi",
+        api_key="test-key",
+        extra={"top_p": 0.9},
+    )
+
+    mock_usage = MagicMock()
+    mock_usage.request_tokens = 5
+    mock_usage.response_tokens = 3
+
+    mock_result = MagicMock()
+    mock_result.output = "ok"
+    mock_result.usage.return_value = mock_usage
+
+    with patch("t01_llm_battle.providers.google.Agent") as MockAgent:
+        mock_instance = MagicMock()
+        mock_instance.run = AsyncMock(return_value=mock_result)
+        MockAgent.return_value = mock_instance
+
+        result = await provider.run(request)
+        call_kwargs = mock_instance.run.call_args
+        assert call_kwargs is not None
+
+    assert result.content == "ok"

--- a/tests/test_groq_provider.py
+++ b/tests/test_groq_provider.py
@@ -1,0 +1,76 @@
+"""Unit tests for GroqProvider (FR-6)."""
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from t01_llm_battle.providers.groq import GroqProvider
+from t01_llm_battle.providers.base import ProviderRequest
+
+
+@pytest.mark.asyncio
+async def test_run_returns_result():
+    provider = GroqProvider()
+    request = ProviderRequest(
+        model="llama-3.3-70b-versatile",
+        system_prompt="Be brief.",
+        user_prompt="Hello!",
+        api_key="test-groq-key",
+    )
+
+    mock_usage = MagicMock()
+    mock_usage.request_tokens = 15
+    mock_usage.response_tokens = 7
+
+    mock_result = MagicMock()
+    mock_result.output = "Hi!"
+    mock_result.usage.return_value = mock_usage
+
+    with patch("t01_llm_battle.providers.groq.Agent") as MockAgent:
+        mock_instance = MagicMock()
+        mock_instance.run = AsyncMock(return_value=mock_result)
+        MockAgent.return_value = mock_instance
+
+        result = await provider.run(request)
+
+    assert result.content == "Hi!"
+    assert result.input_tokens == 15
+    assert result.output_tokens == 7
+    assert result.provider == "groq"
+    assert result.credits_used is None
+    assert result.model == "llama-3.3-70b-versatile"
+
+
+def test_models_returns_list():
+    provider = GroqProvider()
+    with patch("t01_llm_battle.providers.groq.get_llm_models", return_value=["llama-3.3-70b-versatile"]):
+        result = provider.models()
+    assert isinstance(result, list)
+    assert len(result) > 0
+
+
+@pytest.mark.asyncio
+async def test_cost_usd_computed():
+    provider = GroqProvider()
+    request = ProviderRequest(
+        model="llama-3.3-70b-versatile",
+        system_prompt=None,
+        user_prompt="Hi",
+        api_key="test-groq-key",
+    )
+
+    mock_usage = MagicMock()
+    mock_usage.request_tokens = 200
+    mock_usage.response_tokens = 100
+
+    mock_result = MagicMock()
+    mock_result.output = "response"
+    mock_result.usage.return_value = mock_usage
+
+    with patch("t01_llm_battle.providers.groq.Agent") as MockAgent:
+        mock_instance = MagicMock()
+        mock_instance.run = AsyncMock(return_value=mock_result)
+        MockAgent.return_value = mock_instance
+        with patch("t01_llm_battle.providers.groq.get_llm_cost", return_value=0.001) as mock_cost:
+            result = await provider.run(request)
+            mock_cost.assert_called_once_with("groq", "llama-3.3-70b-versatile", 200, 100)
+
+    assert result.cost_usd == 0.001

--- a/tests/test_lmstudio_provider.py
+++ b/tests/test_lmstudio_provider.py
@@ -1,0 +1,115 @@
+"""Unit tests for LMStudioProvider (FR-6)."""
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from t01_llm_battle.providers.lmstudio import LMStudioProvider
+from t01_llm_battle.providers.base import ProviderRequest
+
+
+def test_models_returns_empty():
+    """LM Studio has no model list endpoint — always returns []."""
+    provider = LMStudioProvider()
+    assert provider.models() == []
+
+
+@pytest.mark.asyncio
+async def test_run_returns_result():
+    provider = LMStudioProvider(base_url="http://localhost:1234")
+    request = ProviderRequest(
+        model="local-model",
+        system_prompt="Be helpful.",
+        user_prompt="Hello!",
+        api_key=None,
+    )
+
+    mock_usage = MagicMock()
+    mock_usage.request_tokens = 10
+    mock_usage.response_tokens = 5
+
+    mock_result = MagicMock()
+    mock_result.output = "Hi from LM Studio!"
+    mock_result.usage.return_value = mock_usage
+
+    with patch("t01_llm_battle.providers.lmstudio.resolve_base_url", new_callable=AsyncMock, return_value=None):
+        with patch("t01_llm_battle.providers.lmstudio.Agent") as MockAgent:
+            mock_instance = MagicMock()
+            mock_instance.run = AsyncMock(return_value=mock_result)
+            MockAgent.return_value = mock_instance
+
+            result = await provider.run(request)
+
+    assert result.content == "Hi from LM Studio!"
+    assert result.input_tokens == 10
+    assert result.output_tokens == 5
+    assert result.provider == "llm-studio"
+    assert result.credits_used is None
+    assert result.cost_usd == 0.0
+    assert result.model == "local-model"
+
+
+@pytest.mark.asyncio
+async def test_run_uses_db_base_url():
+    """run() prefers DB-configured base URL over instance default."""
+    provider = LMStudioProvider(base_url="http://localhost:1234")
+    request = ProviderRequest(
+        model="custom-model",
+        system_prompt=None,
+        user_prompt="Hi",
+        api_key=None,
+    )
+
+    mock_usage = MagicMock()
+    mock_usage.request_tokens = 3
+    mock_usage.response_tokens = 2
+
+    mock_result = MagicMock()
+    mock_result.output = "ok"
+    mock_result.usage.return_value = mock_usage
+
+    with patch("t01_llm_battle.providers.lmstudio.resolve_base_url", new_callable=AsyncMock, return_value="http://custom-lms:5678"):
+        with patch("t01_llm_battle.providers.lmstudio.PAIOpenAIProvider") as MockPAI:
+            mock_pai = MagicMock()
+            MockPAI.return_value = mock_pai
+            with patch("t01_llm_battle.providers.lmstudio.Agent") as MockAgent:
+                mock_instance = MagicMock()
+                mock_instance.run = AsyncMock(return_value=mock_result)
+                MockAgent.return_value = mock_instance
+
+                await provider.run(request)
+
+            _, kwargs = MockPAI.call_args
+            assert kwargs.get("base_url") == "http://custom-lms:5678/v1"
+
+
+@pytest.mark.asyncio
+async def test_run_uses_instance_url_when_no_db():
+    """run() falls back to instance base_url when DB returns None."""
+    provider = LMStudioProvider(base_url="http://localhost:1234")
+    request = ProviderRequest(
+        model="local-model",
+        system_prompt=None,
+        user_prompt="Hi",
+        api_key=None,
+    )
+
+    mock_usage = MagicMock()
+    mock_usage.request_tokens = 3
+    mock_usage.response_tokens = 2
+
+    mock_result = MagicMock()
+    mock_result.output = "ok"
+    mock_result.usage.return_value = mock_usage
+
+    with patch("t01_llm_battle.providers.lmstudio.resolve_base_url", new_callable=AsyncMock, return_value=None):
+        with patch("t01_llm_battle.providers.lmstudio.PAIOpenAIProvider") as MockPAI:
+            mock_pai = MagicMock()
+            MockPAI.return_value = mock_pai
+            with patch("t01_llm_battle.providers.lmstudio.Agent") as MockAgent:
+                mock_instance = MagicMock()
+                mock_instance.run = AsyncMock(return_value=mock_result)
+                MockAgent.return_value = mock_instance
+
+                await provider.run(request)
+
+            _, kwargs = MockPAI.call_args
+            assert kwargs.get("base_url") == "http://localhost:1234/v1"

--- a/tests/test_openrouter_provider.py
+++ b/tests/test_openrouter_provider.py
@@ -1,0 +1,110 @@
+"""Unit tests for OpenRouterProvider (FR-6)."""
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from t01_llm_battle.providers.openrouter import OpenRouterProvider
+from t01_llm_battle.providers.base import ProviderRequest
+
+
+@pytest.mark.asyncio
+async def test_run_returns_result():
+    provider = OpenRouterProvider()
+    request = ProviderRequest(
+        model="meta-llama/llama-3.3-70b-instruct",
+        system_prompt="You are helpful.",
+        user_prompt="Hello!",
+        api_key="test-or-key",
+    )
+
+    mock_usage = MagicMock()
+    mock_usage.request_tokens = 18
+    mock_usage.response_tokens = 9
+
+    mock_result = MagicMock()
+    mock_result.output = "Hello there!"
+    mock_result.usage.return_value = mock_usage
+
+    with patch("t01_llm_battle.providers.openrouter.Agent") as MockAgent:
+        mock_instance = MagicMock()
+        mock_instance.run = AsyncMock(return_value=mock_result)
+        MockAgent.return_value = mock_instance
+
+        result = await provider.run(request)
+
+    assert result.content == "Hello there!"
+    assert result.input_tokens == 18
+    assert result.output_tokens == 9
+    assert result.provider == "openrouter"
+    assert result.credits_used is None
+    assert result.model == "meta-llama/llama-3.3-70b-instruct"
+
+
+def test_models_returns_list():
+    provider = OpenRouterProvider()
+    with patch("t01_llm_battle.providers.openrouter.get_llm_models", return_value=["meta-llama/llama-3.3-70b-instruct"]):
+        result = provider.models()
+    assert isinstance(result, list)
+    assert len(result) > 0
+
+
+@pytest.mark.asyncio
+async def test_uses_openrouter_base_url():
+    """run() must point at openrouter.ai/api/v1."""
+    provider = OpenRouterProvider()
+    request = ProviderRequest(
+        model="openai/gpt-4o",
+        system_prompt=None,
+        user_prompt="Hi",
+        api_key="test-key",
+    )
+
+    mock_usage = MagicMock()
+    mock_usage.request_tokens = 5
+    mock_usage.response_tokens = 3
+
+    mock_result = MagicMock()
+    mock_result.output = "ok"
+    mock_result.usage.return_value = mock_usage
+
+    with patch("t01_llm_battle.providers.openrouter.PAIOpenAIProvider") as MockPAI:
+        mock_pai_instance = MagicMock()
+        MockPAI.return_value = mock_pai_instance
+        with patch("t01_llm_battle.providers.openrouter.Agent") as MockAgent:
+            mock_instance = MagicMock()
+            mock_instance.run = AsyncMock(return_value=mock_result)
+            MockAgent.return_value = mock_instance
+
+            await provider.run(request)
+
+        _, kwargs = MockPAI.call_args
+        assert kwargs.get("base_url") == "https://openrouter.ai/api/v1"
+        assert kwargs.get("api_key") == "test-key"
+
+
+@pytest.mark.asyncio
+async def test_cost_usd_computed():
+    provider = OpenRouterProvider()
+    request = ProviderRequest(
+        model="openai/gpt-4o",
+        system_prompt=None,
+        user_prompt="Hi",
+        api_key="test-key",
+    )
+
+    mock_usage = MagicMock()
+    mock_usage.request_tokens = 30
+    mock_usage.response_tokens = 15
+
+    mock_result = MagicMock()
+    mock_result.output = "ok"
+    mock_result.usage.return_value = mock_usage
+
+    with patch("t01_llm_battle.providers.openrouter.Agent") as MockAgent:
+        mock_instance = MagicMock()
+        mock_instance.run = AsyncMock(return_value=mock_result)
+        MockAgent.return_value = mock_instance
+        with patch("t01_llm_battle.providers.openrouter.get_llm_cost", return_value=0.003) as mock_cost:
+            result = await provider.run(request)
+            mock_cost.assert_called_once_with("openrouter", "openai/gpt-4o", 30, 15)
+
+    assert result.cost_usd == 0.003


### PR DESCRIPTION
Closes #357

## Summary
19 new unit tests covering all 5 previously untested LLM provider adapters (FR-6):
- test_anthropic_provider.py (4 tests) — run(), models(), cost_usd, API key validation
- test_google_provider.py (4 tests) — run(), models(), cost_usd, extra top_p
- test_groq_provider.py (3 tests) — run(), models(), cost_usd
- test_openrouter_provider.py (4 tests) — run(), models(), base URL assertion, cost_usd
- test_lmstudio_provider.py (4 tests) — models() returns [], run(), DB URL override, instance URL fallback

All 148 tests pass (19 new + 129 existing).