### PR TITLE
fix: validate provider_config is valid JSON object on create/update (FR-7)

### DIFF
--- a/t01_llm_battle/routers/fighters.py
+++ b/t01_llm_battle/routers/fighters.py
@@ -18,8 +18,10 @@ import uuid
 from datetime import datetime, timezone
 from typing import Any
 
+import json
+
 from fastapi import APIRouter, HTTPException
-from pydantic import BaseModel
+from pydantic import BaseModel, field_validator
 
 from ..db import get_db, DB_PATH
 from ..providers.registry import list_providers, get_provider
@@ -65,6 +67,17 @@ class StepCreate(BaseModel):
     provider: str
     model_id: str
     provider_config: str = "{}"
+
+    @field_validator("provider_config")
+    @classmethod
+    def validate_provider_config_is_json(cls, v: str) -> str:
+        try:
+            parsed = json.loads(v)
+        except (json.JSONDecodeError, ValueError) as exc:
+            raise ValueError(f"provider_config must be valid JSON: {exc}") from exc
+        if not isinstance(parsed, dict):
+            raise ValueError("provider_config must be a JSON object, not an array or scalar")
+        return v
 
 
 class StepOut(BaseModel):


### PR DESCRIPTION
Closes #356

## Summary
Adds a Pydantic `field_validator` on `StepCreate.provider_config` that:
1. Calls `json.loads()` — rejects malformed JSON with 422
2. Asserts result is a `dict` — rejects arrays and scalars with 422

Malformed values no longer silently pass through to SQLite and corrupt step config at run time.

All 129 tests pass.