### PR TITLE
chore: simplify delete_battle using ON DELETE CASCADE

### DIFF
--- a/t01_llm_battle/routers/battles.py
+++ b/t01_llm_battle/routers/battles.py
@@ -254,21 +254,5 @@ async def delete_battle(battle_id: str) -> None:
         if row is None:
             raise HTTPException(status_code=404, detail="Battle not found")
 
-        # Delete child records first (schema uses REFERENCES without ON DELETE CASCADE)
-        await db.execute(
-            "DELETE FROM step_result WHERE run_id IN (SELECT id FROM run WHERE battle_id = ?)",
-            (battle_id,),
-        )
-        await db.execute(
-            "DELETE FROM fighter_result WHERE run_id IN (SELECT id FROM run WHERE battle_id = ?)",
-            (battle_id,),
-        )
-        await db.execute("DELETE FROM run WHERE battle_id = ?", (battle_id,))
-        await db.execute(
-            "DELETE FROM fighter_step WHERE fighter_id IN (SELECT id FROM fighter WHERE battle_id = ?)",
-            (battle_id,),
-        )
-        await db.execute("DELETE FROM fighter WHERE battle_id = ?", (battle_id,))
-        await db.execute("DELETE FROM battle_source WHERE battle_id = ?", (battle_id,))
         await db.execute("DELETE FROM battle WHERE id = ?", (battle_id,))
         await db.commit()


### PR DESCRIPTION
Closes #377

Removes 7 manual child DELETE statements and stale comment from `delete_battle`. Since PR #370 added `ON DELETE CASCADE` to all FK constraints and `PRAGMA foreign_keys = ON` is set per-connection, a single `DELETE FROM battle WHERE id = ?` now cascades to all children automatically.

## Changes
- `t01_llm_battle/routers/battles.py`: remove 7 explicit child DELETEs and stale comment

## Testing
- 170 tests pass