### PR TITLE
feat: add tests for GET /runs/{run_id}/results endpoint (FR-14)

### DIFF
--- a/tests/test_runs_router.py
+++ b/tests/test_runs_router.py
@@ -274,3 +274,253 @@ async def test_cancel_run_already_complete(client, db_path):
 
     resp = await client.post(f"/runs/{run_id}/cancel")
     assert resp.status_code == 400
+
+
+# ---------------------------------------------------------------------------
+# GET /runs/{run_id}/results
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_get_run_results_not_found(client):
+    """GET /runs/<nonexistent>/results should return 404."""
+    resp = await client.get(f"/runs/{uuid.uuid4()}/results")
+    assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_get_run_results_leaderboard_aggregates(client, db_path):
+    """Returns fighter leaderboard aggregates (avg score, cost, latency) for a complete run."""
+    now = datetime.now(timezone.utc).isoformat()
+    battle_id = str(uuid.uuid4())
+    run_id = str(uuid.uuid4())
+    fighter_id = str(uuid.uuid4())
+    source_id = str(uuid.uuid4())
+    step_id = str(uuid.uuid4())
+    fr_id = str(uuid.uuid4())
+    sr_id = str(uuid.uuid4())
+
+    async with get_db(db_path) as db:
+        await db.execute(
+            "INSERT INTO battle (id, name, judge_provider, judge_model, judge_rubric, created_at) VALUES (?, ?, ?, ?, ?, ?)",
+            (battle_id, "Results Battle", "openai", "gpt-4o", "", now),
+        )
+        await db.execute(
+            "INSERT INTO battle_source (id, battle_id, label, content, position) VALUES (?, ?, ?, ?, ?)",
+            (source_id, battle_id, "src1", "question text", 1),
+        )
+        await db.execute(
+            "INSERT INTO fighter (id, battle_id, name, is_manual, position, created_at) VALUES (?, ?, ?, ?, ?, ?)",
+            (fighter_id, battle_id, "Fighter A", 0, 1, now),
+        )
+        await db.execute(
+            "INSERT INTO fighter_step (id, fighter_id, position, system_prompt, provider, model_id, provider_config, created_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+            (step_id, fighter_id, 0, None, "openai", "gpt-4o", "{}", now),
+        )
+        await db.execute(
+            "INSERT INTO run (id, battle_id, status, started_at) VALUES (?, ?, ?, ?)",
+            (run_id, battle_id, "complete", now),
+        )
+        await db.execute(
+            "INSERT INTO fighter_result (id, run_id, fighter_id, source_id, status, judge_score, judge_reasoning, total_cost_usd, total_latency_ms, total_input_tokens, total_output_tokens, created_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            (fr_id, run_id, fighter_id, source_id, "complete", 8.5, "good answer", 0.002, 1200, 50, 30, now),
+        )
+        await db.execute(
+            "INSERT INTO step_result (id, run_id, fighter_id, step_id, source_id, input_text, output_text, input_tokens, output_tokens, latency_ms, cost_usd, created_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            (sr_id, run_id, fighter_id, step_id, source_id, "q", "The answer", 50, 30, 1200, 0.002, now),
+        )
+        await db.commit()
+
+    resp = await client.get(f"/runs/{run_id}/results")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["run_id"] == run_id
+    assert data["status"] == "complete"
+    assert len(data["summary"]) == 1
+    entry = data["summary"][0]
+    assert entry["fighter_name"] == "Fighter A"
+    assert entry["source_label"] == "src1"
+    assert entry["score"] == pytest.approx(8.5)
+    assert entry["total_cost_usd"] == pytest.approx(0.002)
+    assert entry["total_latency_ms"] == 1200
+
+
+@pytest.mark.asyncio
+async def test_get_run_results_per_source_breakdown(client, db_path):
+    """Per-source breakdown: each source item lists the fighter output."""
+    now = datetime.now(timezone.utc).isoformat()
+    battle_id = str(uuid.uuid4())
+    run_id = str(uuid.uuid4())
+    fighter_id = str(uuid.uuid4())
+    source_id_a = str(uuid.uuid4())
+    source_id_b = str(uuid.uuid4())
+    step_id = str(uuid.uuid4())
+
+    async with get_db(db_path) as db:
+        await db.execute(
+            "INSERT INTO battle (id, name, judge_provider, judge_model, judge_rubric, created_at) VALUES (?, ?, ?, ?, ?, ?)",
+            (battle_id, "Multi-src Battle", None, None, None, now),
+        )
+        await db.execute(
+            "INSERT INTO battle_source (id, battle_id, label, content, position) VALUES (?, ?, ?, ?, ?)",
+            (source_id_a, battle_id, "srcA", "q1", 1),
+        )
+        await db.execute(
+            "INSERT INTO battle_source (id, battle_id, label, content, position) VALUES (?, ?, ?, ?, ?)",
+            (source_id_b, battle_id, "srcB", "q2", 2),
+        )
+        await db.execute(
+            "INSERT INTO fighter (id, battle_id, name, is_manual, position, created_at) VALUES (?, ?, ?, ?, ?, ?)",
+            (fighter_id, battle_id, "Fighter B", 0, 1, now),
+        )
+        await db.execute(
+            "INSERT INTO fighter_step (id, fighter_id, position, system_prompt, provider, model_id, provider_config, created_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+            (step_id, fighter_id, 0, None, "openai", "gpt-4o", "{}", now),
+        )
+        await db.execute(
+            "INSERT INTO run (id, battle_id, status, started_at) VALUES (?, ?, ?, ?)",
+            (run_id, battle_id, "complete", now),
+        )
+        for sid, label in [(source_id_a, "out-A"), (source_id_b, "out-B")]:
+            fr_id = str(uuid.uuid4())
+            sr_id = str(uuid.uuid4())
+            await db.execute(
+                "INSERT INTO fighter_result (id, run_id, fighter_id, source_id, status, created_at) VALUES (?, ?, ?, ?, ?, ?)",
+                (fr_id, run_id, fighter_id, sid, "complete", now),
+            )
+            await db.execute(
+                "INSERT INTO step_result (id, run_id, fighter_id, step_id, source_id, input_text, output_text, created_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+                (sr_id, run_id, fighter_id, step_id, sid, "q", label, now),
+            )
+        await db.commit()
+
+    resp = await client.get(f"/runs/{run_id}/results")
+    assert resp.status_code == 200
+    data = resp.json()
+    labels = {e["source_label"] for e in data["summary"]}
+    assert labels == {"srcA", "srcB"}
+
+
+@pytest.mark.asyncio
+async def test_get_run_results_report_markdown_included(client, db_path):
+    """report_markdown field is included when judge was configured."""
+    now = datetime.now(timezone.utc).isoformat()
+    battle_id = str(uuid.uuid4())
+    run_id = str(uuid.uuid4())
+
+    async with get_db(db_path) as db:
+        await db.execute(
+            "INSERT INTO battle (id, name, judge_provider, judge_model, judge_rubric, created_at) VALUES (?, ?, ?, ?, ?, ?)",
+            (battle_id, "Judge Battle", "openai", "gpt-4o", "score 1-10", now),
+        )
+        await db.execute(
+            "INSERT INTO run (id, battle_id, status, started_at, report_markdown) VALUES (?, ?, ?, ?, ?)",
+            (run_id, battle_id, "complete", now, "# Report\nFighter A wins."),
+        )
+        await db.commit()
+
+    resp = await client.get(f"/runs/{run_id}/results")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["report_markdown"] == "# Report\nFighter A wins."
+
+
+@pytest.mark.asyncio
+async def test_get_run_results_no_judge_scores_null(client, db_path):
+    """Endpoint works when no judge configured — scores are null in summary."""
+    now = datetime.now(timezone.utc).isoformat()
+    battle_id = str(uuid.uuid4())
+    run_id = str(uuid.uuid4())
+    fighter_id = str(uuid.uuid4())
+    source_id = str(uuid.uuid4())
+    fr_id = str(uuid.uuid4())
+
+    async with get_db(db_path) as db:
+        await db.execute(
+            "INSERT INTO battle (id, name, judge_provider, judge_model, judge_rubric, created_at) VALUES (?, ?, ?, ?, ?, ?)",
+            (battle_id, "No Judge Battle", None, None, None, now),
+        )
+        await db.execute(
+            "INSERT INTO battle_source (id, battle_id, label, content, position) VALUES (?, ?, ?, ?, ?)",
+            (source_id, battle_id, "src1", "q", 1),
+        )
+        await db.execute(
+            "INSERT INTO fighter (id, battle_id, name, is_manual, position, created_at) VALUES (?, ?, ?, ?, ?, ?)",
+            (fighter_id, battle_id, "Fighter C", 0, 1, now),
+        )
+        await db.execute(
+            "INSERT INTO run (id, battle_id, status, started_at) VALUES (?, ?, ?, ?)",
+            (run_id, battle_id, "complete", now),
+        )
+        await db.execute(
+            "INSERT INTO fighter_result (id, run_id, fighter_id, source_id, status, created_at) VALUES (?, ?, ?, ?, ?, ?)",
+            (fr_id, run_id, fighter_id, source_id, "complete", now),
+        )
+        await db.commit()
+
+    resp = await client.get(f"/runs/{run_id}/results")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["report_markdown"] is None
+    assert len(data["summary"]) == 1
+    assert data["summary"][0]["score"] is None
+
+
+@pytest.mark.asyncio
+async def test_get_run_results_step_drill_down(client, db_path):
+    """step_results list is populated per fighter per source."""
+    now = datetime.now(timezone.utc).isoformat()
+    battle_id = str(uuid.uuid4())
+    run_id = str(uuid.uuid4())
+    fighter_id = str(uuid.uuid4())
+    source_id = str(uuid.uuid4())
+    step_id_0 = str(uuid.uuid4())
+    step_id_1 = str(uuid.uuid4())
+    fr_id = str(uuid.uuid4())
+
+    async with get_db(db_path) as db:
+        await db.execute(
+            "INSERT INTO battle (id, name, judge_provider, judge_model, judge_rubric, created_at) VALUES (?, ?, ?, ?, ?, ?)",
+            (battle_id, "Step Battle", None, None, None, now),
+        )
+        await db.execute(
+            "INSERT INTO battle_source (id, battle_id, label, content, position) VALUES (?, ?, ?, ?, ?)",
+            (source_id, battle_id, "src1", "q", 1),
+        )
+        await db.execute(
+            "INSERT INTO fighter (id, battle_id, name, is_manual, position, created_at) VALUES (?, ?, ?, ?, ?, ?)",
+            (fighter_id, battle_id, "Fighter D", 0, 1, now),
+        )
+        await db.execute(
+            "INSERT INTO fighter_step (id, fighter_id, position, system_prompt, provider, model_id, provider_config, created_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+            (step_id_0, fighter_id, 0, None, "openai", "gpt-4o", "{}", now),
+        )
+        await db.execute(
+            "INSERT INTO fighter_step (id, fighter_id, position, system_prompt, provider, model_id, provider_config, created_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+            (step_id_1, fighter_id, 1, None, "openai", "gpt-4o", "{}", now),
+        )
+        await db.execute(
+            "INSERT INTO run (id, battle_id, status, started_at) VALUES (?, ?, ?, ?)",
+            (run_id, battle_id, "complete", now),
+        )
+        await db.execute(
+            "INSERT INTO fighter_result (id, run_id, fighter_id, source_id, status, created_at) VALUES (?, ?, ?, ?, ?, ?)",
+            (fr_id, run_id, fighter_id, source_id, "complete", now),
+        )
+        for step_id, pos, text in [(step_id_0, 0, "step1 out"), (step_id_1, 1, "step2 out")]:
+            sr_id = str(uuid.uuid4())
+            await db.execute(
+                "INSERT INTO step_result (id, run_id, fighter_id, step_id, source_id, input_text, output_text, latency_ms, input_tokens, output_tokens, cost_usd, created_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                (sr_id, run_id, fighter_id, step_id, source_id, "q", text, 100 * (pos + 1), 10, 5, 0.001, now),
+            )
+        await db.commit()
+
+    resp = await client.get(f"/runs/{run_id}/results")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert len(data["summary"]) == 1
+    step_results = data["summary"][0]["step_results"]
+    assert len(step_results) == 2
+    assert step_results[0]["step_index"] == 0
+    assert step_results[0]["output_text"] == "step1 out"
+    assert step_results[1]["step_index"] == 1
+    assert step_results[1]["output_text"] == "step2 out"


### PR DESCRIPTION
Closes #376

Adds 6 pytest tests covering all acceptance criteria for `GET /runs/{run_id}/results`:

- 404 when run not found
- Leaderboard aggregates: avg score, total cost, latency
- Per-source breakdown: multiple sources each list fighter outputs
- `report_markdown` field included when judge was configured
- No judge configured: scores are null
- Step drill-down: `step_results` list populated per fighter per source

## Testing
176 tests pass (170 existing + 6 new)