### PR TITLE
fix: wrap provider.run() in asyncio.wait_for to bound per-step execution

### DIFF
--- a/t01_llm_battle/engine.py
+++ b/t01_llm_battle/engine.py
@@ -4,10 +4,13 @@ from __future__ import annotations
 
 import asyncio
 import json
+import os
 import threading
 import time
 import uuid
 from datetime import datetime, timezone
+
+PER_STEP_TIMEOUT_S: float = float(os.environ.get("T01_STEP_TIMEOUT_S", "300"))
 
 from .db import DB_PATH, get_db, resolve_api_key
 from .judge import score_response, generate_report
@@ -114,7 +117,9 @@ async def _execute_pair(
                 request.api_key = api_key
             await rate_limiter.acquire(step["provider"])
             t0 = time.monotonic()
-            result: ProviderResult = await provider.run(request)
+            result: ProviderResult = await asyncio.wait_for(
+                provider.run(request), timeout=PER_STEP_TIMEOUT_S
+            )
             latency_ms = int((time.monotonic() - t0) * 1000)
 
             async with get_db(db_path) as db:
@@ -147,6 +152,24 @@ async def _execute_pair(
             step_input = result.content
             final_output = result.content
 
+        except asyncio.TimeoutError:
+            timeout_msg = f"step timeout (>{int(PER_STEP_TIMEOUT_S)}s)"
+            async with get_db(db_path) as db:
+                await db.execute(
+                    "INSERT INTO step_result "
+                    "(id, run_id, fighter_id, step_id, source_id, "
+                    "input_text, output_text, input_tokens, output_tokens, "
+                    "latency_ms, cost_usd, error, created_at) "
+                    "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                    (
+                        sr_id, run_id, fighter_id, step_id, source_id,
+                        step_input, None, None, None, None, None,
+                        timeout_msg, sr_now,
+                    ),
+                )
+                await db.commit()
+            had_error = True
+            break
         except Exception as exc:
             async with get_db(db_path) as db:
                 await db.execute(

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -413,3 +413,46 @@ async def test_cancel_propagates_to_inflight_steps(tmp_path):
         )
         row = await cursor.fetchone()
     assert row["status"] == "cancelled"
+
+
+@pytest.mark.asyncio
+async def test_step_timeout_marks_error_with_message(tmp_path):
+    """A hanging provider.run() is cancelled by asyncio.wait_for; step_result error = 'step timeout (>Xs)' (FR-10)."""
+    import asyncio as _asyncio
+    db_path = str(tmp_path / "test.db")
+    await init_db(db_path)
+
+    battle_id, source_id = await _seed_battle(db_path)
+    fighter_id = await _seed_fighter(db_path, battle_id)
+    await _seed_step(db_path, fighter_id, position=1)
+    run_id = await _seed_run(db_path, battle_id)
+
+    async def hang_forever(request):
+        await _asyncio.sleep(9999)
+
+    mock_provider = MagicMock()
+    mock_provider.run = hang_forever
+
+    with (
+        patch("t01_llm_battle.engine.get_provider", return_value=mock_provider),
+        patch("t01_llm_battle.engine.rate_limiter.acquire", new=AsyncMock()),
+        patch("t01_llm_battle.engine.score_response", new=AsyncMock(return_value=(None, ""))),
+        patch("t01_llm_battle.engine.generate_report", new=AsyncMock(return_value="")),
+        patch("t01_llm_battle.engine._resolve_api_key", new=AsyncMock(return_value=None)),
+        patch("t01_llm_battle.engine.PER_STEP_TIMEOUT_S", 0.05),
+    ):
+        await execute_run(run_id, db_path)
+
+    async with get_db(db_path) as db:
+        cursor = await db.execute(
+            "SELECT error FROM step_result WHERE run_id = ?", (run_id,)
+        )
+        step_row = await cursor.fetchone()
+        fr_cursor = await db.execute(
+            "SELECT status FROM fighter_result WHERE run_id = ?", (run_id,)
+        )
+        fr_row = await fr_cursor.fetchone()
+
+    assert step_row["error"] is not None
+    assert "timeout" in step_row["error"]
+    assert fr_row["status"] == "error"


### PR DESCRIPTION
Closes #373

Adds asyncio.wait_for around each provider.run() call in the engine step loop. Default timeout 300s, overridable via T01_STEP_TIMEOUT_S env var.

On timeout: records step timeout error in step_result.error, aborts the fighter pipeline.

## Changes
- t01_llm_battle/engine.py: add PER_STEP_TIMEOUT_S, wrap call in asyncio.wait_for, add explicit TimeoutError handler
- tests/test_engine.py: regression test test_step_timeout_marks_error_with_message

## Testing
172 tests pass