### PR TITLE
fix: catch only expected OperationalError in migration loop; re-raise others

### DIFF
--- a/t01_llm_battle/db.py
+++ b/t01_llm_battle/db.py
@@ -2,11 +2,23 @@
 
 from __future__ import annotations
 
+import logging
+import sqlite3
 from contextlib import asynccontextmanager
 from pathlib import Path
 from typing import AsyncGenerator
 
 import aiosqlite
+
+logger = logging.getLogger(__name__)
+
+# sqlite3 error substrings that indicate a migration was already applied.
+_ALREADY_APPLIED = (
+    "duplicate column name",
+    "already exists",
+    "table _",  # RENAME TO already ran; old table doesn't exist
+    "no such table: _",  # old table was already dropped
+)
 
 DB_PATH: Path = Path.home() / ".t01-llm-battle" / "battles.db"
 
@@ -235,8 +247,13 @@ async def init_db(db_path: str | Path = DB_PATH) -> None:
             try:
                 await db.execute(sql)
                 await db.commit()
-            except Exception:
-                pass  # migration already applied
+            except sqlite3.OperationalError as exc:
+                msg = str(exc).lower()
+                if any(pat in msg for pat in _ALREADY_APPLIED):
+                    logger.debug("migration already applied (skipped): %s", exc)
+                    await db.rollback()
+                else:
+                    raise
 
     await _migrate_plaintext_keys(db_path)
 

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -1,3 +1,6 @@
+import sqlite3
+from unittest.mock import patch, AsyncMock
+
 import pytest
 import aiosqlite
 from t01_llm_battle.db import init_db, get_db
@@ -83,3 +86,33 @@ async def test_foreign_keys_enforced(tmp_path):
         except aiosqlite.IntegrityError:
             raised = True
     assert raised, "Expected IntegrityError for FK violation — foreign_keys pragma may be OFF"
+
+
+@pytest.mark.asyncio
+async def test_init_db_migration_already_applied_is_swallowed(tmp_path):
+    """'duplicate column name' / 'already exists' OperationalError is silently skipped (FR-15)."""
+    import t01_llm_battle.db as db_module
+
+    db_path = str(tmp_path / "test.db")
+    # First call applies schema + migrations cleanly
+    await init_db(db_path)
+    # Second call: every migration hits 'already exists' — must not raise
+    await init_db(db_path)
+
+
+@pytest.mark.asyncio
+async def test_init_db_unexpected_migration_error_is_raised(tmp_path):
+    """Unexpected OperationalError (not 'already applied') propagates out of init_db (NFR Reliability)."""
+    import t01_llm_battle.db as db_module
+
+    db_path = str(tmp_path / "test.db")
+
+    # Inject a migration that triggers a real unexpected error
+    bad_sql = "SELECT * FROM nonexistent_table_xyz"
+    original = db_module._MIGRATIONS_SQL
+    try:
+        db_module._MIGRATIONS_SQL = [bad_sql]
+        with pytest.raises(sqlite3.OperationalError, match="nonexistent_table_xyz"):
+            await init_db(db_path)
+    finally:
+        db_module._MIGRATIONS_SQL = original


### PR DESCRIPTION
Closes #372

Replaces bare `except Exception: pass` with a targeted `sqlite3.OperationalError` catch that checks for known \"already applied\" substrings. Unexpected errors now propagate.

## Changes
- t01_llm_battle/db.py: add _ALREADY_APPLIED tuple, replace catch-all with targeted OperationalError + debug log
- tests/test_db.py: two regression tests

## Testing
173 tests pass