### PR TITLE
fix: enforce 10 MB size cap on raw-text source upload path

### DIFF
--- a/t01_llm_battle/routers/sources.py
+++ b/t01_llm_battle/routers/sources.py
@@ -116,6 +116,11 @@ async def upload_source(
                 created.append({"id": source_id, "label": filename})
 
         elif text is not None:
+            if len(text.encode("utf-8")) > MAX_UPLOAD_BYTES:
+                raise HTTPException(
+                    status_code=413,
+                    detail="Source text too large. Maximum is 10 MB.",
+                )
             item_label = label or f"Source {datetime.now(timezone.utc).isoformat()}"
             source_id = str(uuid.uuid4())
             async with get_db() as db2:

--- a/tests/test_routers_sources.py
+++ b/tests/test_routers_sources.py
@@ -163,3 +163,33 @@ async def test_delete_source_wrong_battle_returns_404(client, db_path):
 
     resp = await client.delete(f"/battles/{battle_b}/sources/{source_id}")
     assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_raw_text_upload_creates_source(client, db_path):
+    """POSTing a text form field creates one source item (FR-3)."""
+    battle_id = await _create_battle(db_path)
+
+    resp = await client.post(
+        f"/battles/{battle_id}/sources",
+        data={"text": "hello from raw text", "label": "my-text"},
+    )
+
+    assert resp.status_code == 201
+    data = resp.json()
+    assert data["label"] == "my-text"
+
+
+@pytest.mark.asyncio
+async def test_raw_text_upload_over_limit_returns_413(client, db_path):
+    """Text field larger than 10 MB is rejected with 413 (FR-3, NFR Reliability)."""
+    battle_id = await _create_battle(db_path)
+
+    oversized = "x" * (10 * 1024 * 1024 + 1)
+    resp = await client.post(
+        f"/battles/{battle_id}/sources",
+        data={"text": oversized},
+    )
+
+    assert resp.status_code == 413
+    assert "10 MB" in resp.json()["detail"]


### PR DESCRIPTION
Closes #371

The file upload branch had MAX_UPLOAD_BYTES (10 MB) enforcement; the text form-field branch had none. One-line fix adds the same guard to the text path.

## Changes
- t01_llm_battle/routers/sources.py: add size check before text INSERT
- tests/test_routers_sources.py: two regression tests (success + 413)

## Testing
173 tests pass