### PR TITLE
docs: add OSS marketing copy

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 A tiny local tool for comparing LLMs and multi-step pipelines on your real prompts by quality, cost, and latency.
 
+Public docs: [Manual](docs/manual.md) · [Showcases](docs/showcases.md)
+
 [![PyPI version](https://img.shields.io/pypi/v/t01-llm-battle)](https://pypi.org/project/t01-llm-battle/)
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue)](LICENSE)
 [![Python >=3.11](https://img.shields.io/badge/python-%3E%3D3.11-blue)](https://www.python.org/)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # t01-llm-battle
 
-**A tiny tool to help you pick the right approach for your AI project.**
+**Pick models with evidence, not vibes.**
+
+A tiny local tool for comparing LLMs and multi-step pipelines on your real prompts by quality, cost, and latency.
 
 [![PyPI version](https://img.shields.io/pypi/v/t01-llm-battle)](https://pypi.org/project/t01-llm-battle/)
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue)](LICENSE)

--- a/docs/manual.md
+++ b/docs/manual.md
@@ -1,0 +1,68 @@
+# t01-llm-battle manual
+
+`t01-llm-battle` is a local browser tool for comparing model and pipeline choices on your own inputs. It is for early project decisions: which model, prompt, or multi-step approach is good enough for the job?
+
+## 1. Install and start
+
+```bash
+pipx install t01-llm-battle
+t01-llm-battle serve
+```
+
+The command starts a local server and opens the browser. Your battles, keys, prompts, and results stay on your machine.
+
+## 2. Create a battle
+
+A battle is one comparison run. Give it a name that describes the decision you are trying to make, for example:
+
+- `Summarize support tickets`
+- `Extract invoice fields`
+- `Rewrite docs for beginners`
+
+Choose a judge model and edit the rubric so the score matches your task.
+
+## 3. Add sources
+
+Sources are the inputs every fighter will receive. Add them as:
+
+- `.txt` or `.md` files, one input per file
+- a `.csv` file, one input per row
+
+Use real examples when possible. The tool is most useful when the inputs look like the work you actually need to ship.
+
+## 4. Add fighters
+
+A fighter is one approach you want to compare. It can be:
+
+- a single model call
+- a prompt variation
+- a multi-step pipeline
+- a manual baseline entered by a human
+
+Examples:
+
+- `Haiku single-step`
+- `Sonnet single-step`
+- `Cheap model draft + strong model edit`
+- `Human baseline`
+
+## 5. Run and inspect results
+
+Start the run and inspect:
+
+- final answer quality
+- judge score and reasoning
+- token usage
+- estimated cost
+- latency
+- step-level outputs for pipeline fighters
+
+Do not treat the judge as an oracle. Use the reasoning and raw outputs to sanity-check the score.
+
+## 6. Export the decision
+
+Use the generated markdown report to record what you tried, which fighter won, and why. The report is meant for sharing in issues, pull requests, design docs, or team notes.
+
+## Privacy model
+
+`t01-llm-battle` is local-first. It does not host your battles or publish your results. Provider API calls happen only when you configure a provider and run a battle.

--- a/docs/showcases.md
+++ b/docs/showcases.md
@@ -1,0 +1,44 @@
+# t01-llm-battle showcases
+
+These examples show public, user-facing ways to use `t01-llm-battle`. They are not benchmark claims; they are starting points you can recreate with your own inputs and rubric.
+
+## 1. Pick the cheapest model that is good enough
+
+**Question:** Can a small model handle this feature, or do we need a premium model?
+
+**Setup:**
+
+- Sources: 20 representative user messages
+- Fighters: small model, mid-tier model, premium model
+- Rubric: correctness, tone, missing details, hallucinations
+
+**Decision:** Choose the cheapest fighter whose quality is acceptable on real examples.
+
+## 2. Compare single-step vs multi-step pipelines
+
+**Question:** Is a two-step pipeline worth the extra latency and cost?
+
+**Setup:**
+
+- Sources: messy input documents
+- Fighter A: one model call that extracts final JSON
+- Fighter B: first normalize the text, then extract final JSON
+- Rubric: schema validity, missed fields, incorrect fields
+
+**Decision:** Use the pipeline only if the quality gain is visible enough to justify the cost.
+
+## 3. Keep a human baseline in the loop
+
+**Question:** How far is the model from a careful human answer?
+
+**Setup:**
+
+- Sources: a small set of difficult cases
+- Fighters: one or more model approaches plus a manual fighter
+- Rubric: task-specific quality criteria
+
+**Decision:** Use the human baseline to calibrate expectations, not to claim universal model superiority.
+
+## 4. Share a decision report
+
+After the run, copy the markdown summary into a design note or pull request. The useful artifact is not just the winning model; it is the record of inputs, rubric, tradeoffs, and why the choice was made.


### PR DESCRIPTION
## Summary
- Refines the public README positioning copy.
- Adds public end-user docs: manual and showcases.
- Keeps internal marketing calendar, launch-plan, and messaging-resource files out of the public branch.

## Scope
Public README/manual/showcase content only.

## Test Plan
- Documentation-only change.
- Verified changed files are public-facing docs only.